### PR TITLE
fix(models): make pro tier include dynamically merged cloud models

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -201,7 +201,7 @@ const ALL_MODEL_KEYS = Object.keys(MODELS);
 const FREE_TIER_MODELS = ['gpt-4o-mini', 'gemini-2.5-flash'];
 
 export const MODEL_TIER_ACCESS = {
-  pro: ALL_MODEL_KEYS,
+  get pro() { return Object.keys(MODELS); },
   free: FREE_TIER_MODELS,
   unknown: FREE_TIER_MODELS,
   expired: [],


### PR DESCRIPTION
## Problem

`MODEL_TIER_ACCESS.pro` currently references `ALL_MODEL_KEYS`, a snapshot of `Object.keys(MODELS)` taken at module load time. When `mergeCloudModels()` adds new models to the `MODELS` dict after startup (e.g. the five `claude-opus-4-7-*` entries from `GetCascadeModelConfigs`), they never appear in `pro`'s frozen array.

Downstream this bites:

- `auth.js:getAvailableModelsForAccount()` filters `getTierModels(tier)`, so cloud-added models are missing from every account's `availableModels`.
- `handlers/chat.js` preflight returns **403 `model_not_entitled`** for every request targeting a cloud-added model, even on pro accounts that legitimately have access.

## Repro

On a fresh pro account after `mergeCloudModels` has run:

```bash
# Catalog sees the models (listModels enumerates live MODELS each call)
curl -sS http://localhost:3003/v1/models | jq '.data[].id' | grep opus-4-7
# → claude-opus-4-7-low, -medium, -high, -xhigh, -none

# Account's availableModels does NOT (goes through getTierModels → ALL_MODEL_KEYS snapshot)
curl -sS http://localhost:3003/auth/accounts \
  | jq '.accounts[0].availableModels | map(select(contains("opus-4-7")))'
# → []   ← the mismatch

# And chat preflight 403s every request
curl -sS http://localhost:3003/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"claude-opus-4-7-high","messages":[{"role":"user","content":"hi"}]}'
# → {"error":{"message":"模型 claude-opus-4-7-high 在当前账号池中不可用（未订阅或已被封禁）","type":"model_not_entitled"}}
```

## Fix

Replace the frozen-array reference with a getter so every access re-enumerates the live `MODELS` dictionary:

```diff
   export const MODEL_TIER_ACCESS = {
-    pro: ALL_MODEL_KEYS,
+    get pro() { return Object.keys(MODELS); },
     free: FREE_TIER_MODELS,
     unknown: FREE_TIER_MODELS,
     expired: [],
   };
```

One-line minimal diff. `ALL_MODEL_KEYS` is left declared (now unused) to keep the patch as small as possible for review; feel free to drop the dead variable in a follow-up cleanup if desired.

## Verified

Applied on my instance — `claude-opus-4-7-high` and the other four `opus-4-7-*` entries now route correctly. Every future `mergeCloudModels` addition will flow through without further code changes.

Thanks for the excellent project!
