### PR TITLE
修复 Dashboard 登录取号：支持 Auth1 登录流并新增批量导入

### DIFF
--- a/src/dashboard/api.js
+++ b/src/dashboard/api.js
@@ -50,6 +50,44 @@ function checkAuth(req) {
   return true;  // No password and no API key = open access
 }
 
+async function processWindsurfLogin({ email, password, loginProxy, autoAdd }) {
+  if (!email || !password) {
+    const err = new Error('email 和 password 为必填');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  // Use provided proxy, or global proxy
+  const proxy = loginProxy?.host ? loginProxy : getProxyConfig().global;
+  const result = await windsurfLogin(email, password, proxy);
+
+  // Auto-add to account pool if requested
+  let account = null;
+  if (autoAdd !== false) {
+    account = addAccountByKey(result.apiKey, result.name || email);
+    // Persist refresh token via the setter so it survives restart and
+    // the background Firebase-renewal loop can find it.
+    if (result.refreshToken) {
+      setAccountTokens(account.id, { refreshToken: result.refreshToken, idToken: result.idToken });
+    }
+    // Persist the per-account proxy we used for login so chat requests
+    // also egress through the same IP, then warm up a matching LS.
+    if (loginProxy?.host) setAccountProxy(account.id, loginProxy);
+    ensureLsForAccount(account.id)
+      .then(() => probeAccount(account.id))
+      .catch(e => log.warn(`Auto-probe failed: ${e.message}`));
+  }
+
+  return {
+    success: true,
+    apiKey: result.apiKey,
+    name: result.name,
+    email: result.email,
+    apiServerUrl: result.apiServerUrl,
+    account: account ? { id: account.id, email: account.email, status: account.status } : null,
+  };
+}
+
 /**
  * Handle all /dashboard/api/* requests.
  */
@@ -456,41 +494,49 @@ export async function handleDashboardApi(method, subpath, body, req, res) {
   // ─── Windsurf Login ────────────────────────────────────
   if (subpath === '/windsurf-login' && method === 'POST') {
     try {
-      const { email, password, proxy: loginProxy, autoAdd } = body;
-      if (!email || !password) return json(res, 400, { error: 'email 和 password 為必填' });
+      const { email, password, proxy: loginProxy, autoAdd } = body || {};
+      return json(res, 200, await processWindsurfLogin({ email, password, loginProxy, autoAdd }));
+    } catch (err) {
+      return json(res, err.statusCode || 400, { error: err.message, isAuthFail: !!err.isAuthFail, firebaseCode: err.firebaseCode });
+    }
+  }
 
-      // Use provided proxy, or global proxy
-      const proxy = loginProxy?.host ? loginProxy : getProxyConfig().global;
-
-      const result = await windsurfLogin(email, password, proxy);
-
-      // Auto-add to account pool if requested
-      let account = null;
-      if (autoAdd !== false) {
-        account = addAccountByKey(result.apiKey, result.name || email);
-        // Persist refresh token via the setter so it survives restart and
-        // the background Firebase-renewal loop can find it.
-        if (result.refreshToken) {
-          setAccountTokens(account.id, { refreshToken: result.refreshToken, idToken: result.idToken });
-        }
-        // Persist the per-account proxy we used for login so chat requests
-        // also egress through the same IP, then warm up a matching LS.
-        if (loginProxy?.host) setAccountProxy(account.id, loginProxy);
-        ensureLsForAccount(account.id)
-          .then(() => probeAccount(account.id))
-          .catch(e => log.warn(`Auto-probe failed: ${e.message}`));
+  if (subpath === '/windsurf-login/batch' && method === 'POST') {
+    try {
+      const { accounts, proxy: loginProxy, autoAdd } = body || {};
+      if (!Array.isArray(accounts) || !accounts.length) {
+        return json(res, 400, { error: 'accounts 为必填数组' });
       }
 
+      const results = [];
+      for (const acct of accounts) {
+        const email = String(acct?.email || '').trim();
+        const password = String(acct?.password || '').trim();
+        try {
+          const result = await processWindsurfLogin({ email, password, loginProxy, autoAdd });
+          results.push(result);
+        } catch (err) {
+          results.push({
+            success: false,
+            email,
+            error: err.message,
+            isAuthFail: !!err.isAuthFail,
+            firebaseCode: err.firebaseCode,
+          });
+        }
+      }
+
+      const successCount = results.filter(r => r.success).length;
+      const failCount = results.length - successCount;
       return json(res, 200, {
         success: true,
-        apiKey: result.apiKey,
-        name: result.name,
-        email: result.email,
-        apiServerUrl: result.apiServerUrl,
-        account: account ? { id: account.id, email: account.email, status: account.status } : null,
+        total: results.length,
+        successCount,
+        failCount,
+        results,
       });
     } catch (err) {
-      return json(res, 400, { error: err.message, isAuthFail: !!err.isAuthFail, firebaseCode: err.firebaseCode });
+      return json(res, 400, { error: err.message });
     }
   }
 

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -1048,7 +1048,7 @@ window._firebaseOAuth = async function(provider) {
       <div class="section-header">
         <div>
           <div class="section-title">邮箱密码登录</div>
-          <div class="section-desc">仅限邮箱+密码注册的账号 第三方登录请用上面的按钮</div>
+          <div class="section-desc">仅限邮箱+密码注册的账号 第三方登录请用上面的按钮；支持单个登录或按“邮箱 密码”格式批量导入</div>
         </div>
       </div>
       <div class="section-body">
@@ -1062,7 +1062,6 @@ window._firebaseOAuth = async function(provider) {
             <input id="wl-password" class="input" type="password" placeholder="••••••••" autocomplete="off" onkeydown="if(event.key==='Enter')App.windsurfLogin()">
           </div>
         </div>
-        </div>
         <div class="field-row-actions">
           <button class="btn btn-primary" onclick="App.windsurfLogin()" id="wl-btn">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>
@@ -1073,6 +1072,26 @@ window._firebaseOAuth = async function(provider) {
             <span class="box"></span>
             <span>登录成功自动加入账号池</span>
           </label>
+        </div>
+        <div style="margin-top:16px;padding-top:16px;border-top:1px dashed var(--border)">
+          <label class="field-label">批量导入</label>
+          <textarea
+            id="wl-batch-input"
+            class="textarea"
+            rows="6"
+            placeholder="buulzqkz0iee@2116666.xyz  zy$&X5f5CT8k&#10;ejjdthoqi34l@2116666.xyz  zy$&X5f5CT8k&#10;lij3th36mtki@2116666.xyz  zy$&X5f5CT8k"
+          ></textarea>
+          <div class="field-hint">每行一个账号，格式：邮箱 + 空格/Tab + 密码。会自动忽略空行。</div>
+          <div class="field-row-actions">
+            <button class="btn btn-outline" onclick="App.pasteWindsurfBatch()">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/></svg>
+              读取剪贴板
+            </button>
+            <button class="btn btn-primary" onclick="App.windsurfLoginBatch()" id="wl-batch-btn">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M3 5h18"/><path d="M3 12h18"/><path d="M3 19h18"/></svg>
+              批量导入并登录
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -2003,11 +2022,8 @@ const App = {
       status.textContent = `登录成功 ${r.email || label} 已加入账号池`;
       this.toast(`${label} 登录成功`, 'success');
       this.loadAccounts();
-      const entry = { time: new Date().toISOString(), email: r.email || label, proxy: '直连', status: 'ok', method: label };
-      this.loginHistory.unshift(entry);
-      if (this.loginHistory.length > 50) this.loginHistory.length = 50;
-      localStorage.setItem('wl_history', JSON.stringify(this.loginHistory));
-      this.renderLoginHistory();
+      const entry = { time: new Date().toISOString(), email: r.email || label, proxy: '直连', status: 'success', method: label };
+      this.pushLoginHistory(entry);
     } catch (err) {
       status.style.color = '#ef4444';
       status.textContent = `${label} 登录失败: ${err.message}`;
@@ -2017,71 +2033,173 @@ const App = {
     }
   },
 
-  async windsurfLogin() {
-    const email = document.getElementById('wl-email').value.trim();
-    const password = document.getElementById('wl-password').value.trim();
-    if (!email || !password) return this.toast('请输入邮箱和密码', 'error');
-
+  getWindsurfLoginProxy() {
     const proxyHost = document.getElementById('wl-proxy-host').value.trim();
-    const proxy = proxyHost ? {
+    return proxyHost ? {
       type: document.getElementById('wl-proxy-type').value,
       host: proxyHost,
       port: parseInt(document.getElementById('wl-proxy-port').value) || 8080,
       username: document.getElementById('wl-proxy-user').value,
       password: document.getElementById('wl-proxy-pass').value,
     } : null;
+  },
+
+  getWindsurfProxyLabel(proxy) {
+    return proxy ? `${proxy.type}://${proxy.host}:${proxy.port}` : '全局';
+  },
+
+  pushLoginHistory(entry) {
+    this.pushLoginHistoryEntries([entry]);
+  },
+
+  pushLoginHistoryEntries(entries) {
+    for (let i = entries.length - 1; i >= 0; i--) this.loginHistory.unshift(entries[i]);
+    if (this.loginHistory.length > 50) this.loginHistory.length = 50;
+    localStorage.setItem('wl_history', JSON.stringify(this.loginHistory));
+    this.renderLoginHistory();
+  },
+
+  showWindsurfLoginResult(html) {
+    const rd = document.getElementById('wl-result');
+    rd.classList.remove('hidden');
+    rd.innerHTML = html;
+  },
+
+  getWindsurfLoginFailActions(r) {
+    if (!r.isAuthFail) return '';
+    return `
+      <div style="margin-top:12px;padding:12px;background:var(--surface-2);border-radius:var(--radius);border-left:3px solid var(--accent)">
+        <div style="font-weight:600;margin-bottom:8px">换个方式试试</div>
+        <div style="display:flex;gap:8px;flex-wrap:wrap">
+          <button class="btn btn-sm" style="background:#4285F4;color:#fff" onclick="App.oauthLogin('google')">Google 登录</button>
+          <button class="btn btn-sm" style="background:#24292e;color:#fff" onclick="App.oauthLogin('github')">GitHub 登录</button>
+          <a class="btn btn-sm btn-outline" href="https://windsurf.com/show-auth-token" target="_blank">复制 Auth Token</a>
+          <button class="btn btn-sm btn-ghost" onclick="document.querySelector('[data-panel=accounts]').click();setTimeout(()=>document.getElementById('acc-key')?.focus(),100)">去账号管理粘贴 Token</button>
+        </div>
+      </div>`;
+  },
+
+  renderSingleWindsurfLoginResult(r, autoAdd) {
+    if (r.success) {
+      this.showWindsurfLoginResult(`
+        <div class="section-header">
+          <div>
+            <div class="section-title" style="color:var(--success)">✓ 登录成功</div>
+            <div class="section-desc">API Key 已生成${autoAdd ? '并加入账号池' : ''}</div>
+          </div>
+        </div>
+        <div class="section-body">
+          <table style="background:transparent">
+            <tr><td style="color:var(--text-muted);width:120px">邮箱</td><td>${this.esc(r.email)}</td></tr>
+            <tr><td style="color:var(--text-muted)">姓名</td><td>${this.esc(r.name || '-')}</td></tr>
+            <tr><td style="color:var(--text-muted)">API Key</td><td><code class="break-all">${this.esc(r.apiKey)}</code></td></tr>
+            ${r.account ? `<tr><td style="color:var(--text-muted)">账号 ID</td><td><code>${r.account.id}</code> <span class="badge active">${r.account.status}</span></td></tr>` : ''}
+          </table>
+        </div>`);
+      return;
+    }
+    this.showWindsurfLoginResult(`
+      <div class="section-header">
+        <div>
+          <div class="section-title" style="color:var(--error)">✗ 登录失败</div>
+        </div>
+      </div>
+      <div class="section-body"><p class="text-sm">${this.esc(r.error || '未知错误')}</p>${this.getWindsurfLoginFailActions(r)}</div>`);
+  },
+
+  renderBatchWindsurfLoginResult(results, autoAdd) {
+    const successCount = results.filter(r => r.success).length;
+    const failCount = results.length - successCount;
+    this.showWindsurfLoginResult(`
+        <div class="section-header">
+        <div>
+          <div class="section-title" style="color:${failCount ? 'var(--warning, #f59e0b)' : 'var(--success)'}">批量导入完成</div>
+          <div class="section-desc">共 ${results.length} 个账号，成功 ${successCount} 个，失败 ${failCount} 个${autoAdd ? '；成功项已自动加入账号池' : ''}</div>
+        </div>
+      </div>
+      <div class="section-body tight">
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>邮箱</th><th>状态</th><th>说明</th></tr></thead>
+            <tbody>
+              ${results.map(r => `
+                <tr>
+                  <td>${this.esc(r.email || '-')}</td>
+                  <td><span class="badge ${r.success ? 'active' : 'error'}">${r.success ? '成功' : '失败'}</span></td>
+                  <td class="text-sm">${r.success
+                    ? `<span class="break-all"><code>${this.esc(r.apiKey ? r.apiKey.slice(0, 16) + '...' : '-')}</code>${r.account ? ` · 账号 ${this.esc(r.account.id)}` : ''}</span>`
+                    : `<span style="color:var(--error)">${this.esc(r.error || '未知错误')}</span>`}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        </div>
+      </div>`);
+  },
+
+  parseWindsurfBatchInput(text) {
+    const entries = [];
+    const errors = [];
+    String(text || '').replace(/\r\n?/g, '\n').split('\n').forEach((raw, idx) => {
+      const line = raw.trim();
+      if (!line) return;
+      const m = line.match(/^(\S+)\s+(.+)$/);
+      if (!m) {
+        errors.push(`第 ${idx + 1} 行格式错误`);
+        return;
+      }
+      const email = m[1].trim();
+      const password = m[2].trim();
+      if (!email.includes('@') || !password) {
+        errors.push(`第 ${idx + 1} 行格式错误`);
+        return;
+      }
+      entries.push({ email, password });
+    });
+    return { entries, errors };
+  },
+
+  async pasteWindsurfBatch() {
+    const el = document.getElementById('wl-batch-input');
+    if (!navigator.clipboard || !window.isSecureContext) {
+      el?.focus();
+      return this.toast('当前环境不支持自动读取剪贴板，请手动粘贴', 'info');
+    }
+    try {
+      const text = await navigator.clipboard.readText();
+      if (!text) return this.toast('剪贴板为空', 'info');
+      el.value = text;
+      this.toast('已读取剪贴板', 'success');
+    } catch (err) {
+      this.toast('读取剪贴板失败: ' + err.message, 'error');
+    }
+  },
+
+  async windsurfLogin() {
+    const email = document.getElementById('wl-email').value.trim();
+    const password = document.getElementById('wl-password').value.trim();
+    if (!email || !password) return this.toast('请输入邮箱和密码', 'error');
+
+    const proxy = this.getWindsurfLoginProxy();
     const autoAdd = document.getElementById('wl-auto-add').checked;
 
     const btn = document.getElementById('wl-btn');
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner"></span> 登录中...';
 
-    const entry = { time: new Date().toISOString(), email, proxy: proxy ? `${proxy.type}://${proxy.host}:${proxy.port}` : '全局', status: 'pending' };
+    const entry = { time: new Date().toISOString(), email, proxy: this.getWindsurfProxyLabel(proxy), status: 'pending' };
 
     try {
       const r = await this.api('POST', '/windsurf-login', { email, password, proxy, autoAdd });
       if (r.success) {
         entry.status = 'success';
         entry.apiKey = r.apiKey?.slice(0, 16) + '...';
-        const rd = document.getElementById('wl-result');
-        rd.classList.remove('hidden');
-        rd.innerHTML = `
-          <div class="section-header">
-            <div>
-              <div class="section-title" style="color:var(--success)">✓ 登录成功</div>
-              <div class="section-desc">API Key 已生成${autoAdd ? '并加入账号池' : ''}</div>
-            </div>
-          </div>
-          <div class="section-body">
-            <table style="background:transparent">
-              <tr><td style="color:var(--text-muted);width:120px">邮箱</td><td>${this.esc(r.email)}</td></tr>
-              <tr><td style="color:var(--text-muted)">姓名</td><td>${this.esc(r.name || '-')}</td></tr>
-              <tr><td style="color:var(--text-muted)">API Key</td><td><code class="break-all">${this.esc(r.apiKey)}</code></td></tr>
-              ${r.account ? `<tr><td style="color:var(--text-muted)">账号 ID</td><td><code>${r.account.id}</code> <span class="badge active">${r.account.status}</span></td></tr>` : ''}
-            </table>
-          </div>`;
-        this.toast('登录成功，账号已加入');
+        this.renderSingleWindsurfLoginResult(r, autoAdd);
+        this.toast(autoAdd ? '登录成功，账号已加入' : '登录成功', 'success');
+        this.loadAccounts();
       } else {
         entry.status = 'error: ' + (r.error || 'unknown');
-        const rd = document.getElementById('wl-result');
-        rd.classList.remove('hidden');
-        const actionBlock = r.isAuthFail ? `
-          <div style="margin-top:12px;padding:12px;background:var(--surface-2);border-radius:var(--radius);border-left:3px solid var(--accent)">
-            <div style="font-weight:600;margin-bottom:8px">换个方式试试</div>
-            <div style="display:flex;gap:8px;flex-wrap:wrap">
-              <button class="btn btn-sm" style="background:#4285F4;color:#fff" onclick="App.oauthLogin('google')">Google 登录</button>
-              <button class="btn btn-sm" style="background:#24292e;color:#fff" onclick="App.oauthLogin('github')">GitHub 登录</button>
-              <a class="btn btn-sm btn-outline" href="https://windsurf.com/show-auth-token" target="_blank">复制 Auth Token</a>
-              <button class="btn btn-sm btn-ghost" onclick="document.querySelector('[data-panel=accounts]').click();setTimeout(()=>document.getElementById('acc-key')?.focus(),100)">去账号管理粘贴 Token</button>
-            </div>
-          </div>` : '';
-        rd.innerHTML = `
-          <div class="section-header">
-            <div>
-              <div class="section-title" style="color:var(--error)">✗ 登录失败</div>
-            </div>
-          </div>
-          <div class="section-body"><p class="text-sm">${this.esc(r.error || '未知错误')}</p>${actionBlock}</div>`;
+        this.renderSingleWindsurfLoginResult(r, autoAdd);
         this.toast(r.error || '登录失败', 'error');
       }
     } catch (err) {
@@ -2089,12 +2207,65 @@ const App = {
       this.toast(err.message, 'error');
     }
 
-    this.loginHistory.unshift(entry);
-    if (this.loginHistory.length > 50) this.loginHistory.length = 50;
-    localStorage.setItem('wl_history', JSON.stringify(this.loginHistory));
-    this.renderLoginHistory();
+    this.pushLoginHistory(entry);
     btn.disabled = false;
     btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/><polyline points="10 17 15 12 10 7"/><line x1="15" y1="12" x2="3" y2="12"/></svg> 登录';
+  },
+
+  async windsurfLoginBatch() {
+    const input = document.getElementById('wl-batch-input').value;
+    const { entries, errors } = this.parseWindsurfBatchInput(input);
+    if (!entries.length) return this.toast('请先粘贴批量账号', 'error');
+    if (errors.length) return this.toast(errors.slice(0, 3).join('；'), 'error');
+
+    const proxy = this.getWindsurfLoginProxy();
+    const autoAdd = document.getElementById('wl-auto-add').checked;
+    const btn = document.getElementById('wl-batch-btn');
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner"></span> 导入中...';
+    this.showWindsurfLoginResult(`
+      <div class="section-header">
+        <div>
+          <div class="section-title">批量导入中...</div>
+          <div class="section-desc">共 ${entries.length} 个账号，请稍候</div>
+        </div>
+      </div>`);
+
+    try {
+      const r = await this.api('POST', '/windsurf-login/batch', { accounts: entries, proxy, autoAdd });
+      if (!r.success || !Array.isArray(r.results)) {
+        this.showWindsurfLoginResult(`
+          <div class="section-header">
+            <div><div class="section-title" style="color:var(--error)">✗ 批量导入失败</div></div>
+          </div>
+          <div class="section-body"><p class="text-sm">${this.esc(r.error || '未知错误')}</p></div>`);
+        return this.toast(r.error || '批量导入失败', 'error');
+      }
+
+      this.renderBatchWindsurfLoginResult(r.results, autoAdd);
+      this.pushLoginHistoryEntries(r.results.map(item => ({
+          time: new Date().toISOString(),
+          email: item.email,
+          proxy: this.getWindsurfProxyLabel(proxy),
+          status: item.success ? 'success' : `error: ${item.error || 'unknown'}`,
+          apiKey: item.success && item.apiKey ? item.apiKey.slice(0, 16) + '...' : undefined,
+        })));
+      this.toast(`批量导入完成：成功 ${r.successCount || 0} / 失败 ${r.failCount || 0}`, (r.failCount || 0) ? 'info' : 'success');
+      if ((r.successCount || 0) > 0) {
+        this.loadAccounts();
+        document.getElementById('wl-batch-input').value = '';
+      }
+    } catch (err) {
+      this.showWindsurfLoginResult(`
+        <div class="section-header">
+          <div><div class="section-title" style="color:var(--error)">✗ 批量导入失败</div></div>
+        </div>
+        <div class="section-body"><p class="text-sm">${this.esc(err.message)}</p></div>`);
+      this.toast(err.message, 'error');
+    } finally {
+      btn.disabled = false;
+      btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M3 5h18"/><path d="M3 12h18"/><path d="M3 19h18"/></svg> 批量导入并登录';
+    }
   },
 
   renderLoginHistory() {

--- a/src/dashboard/windsurf-login.js
+++ b/src/dashboard/windsurf-login.js
@@ -1,5 +1,5 @@
 /**
- * Windsurf direct login — Firebase auth + Codeium registration.
+ * Windsurf direct login — Auth1/Firebase auth + Codeium registration.
  * Supports proxy tunneling and fingerprint randomization.
  */
 
@@ -11,6 +11,11 @@ const FIREBASE_API_KEY = 'AIzaSyDsOl-1XpT5err0Tcnx8FFod1H8gVGIycY';
 const FIREBASE_AUTH_URL = `https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${FIREBASE_API_KEY}`;
 const FIREBASE_REFRESH_URL = `https://securetoken.googleapis.com/v1/token?key=${FIREBASE_API_KEY}`;
 const CODEIUM_REGISTER_URL = 'https://api.codeium.com/register_user/';
+const AUTH1_CONNECTIONS_URL = 'https://windsurf.com/_devin-auth/connections';
+const AUTH1_PASSWORD_LOGIN_URL = 'https://windsurf.com/_devin-auth/password/login';
+const WINDSURF_SEAT_SERVICE_BASE = 'https://server.self-serve.windsurf.com/exa.seat_management_pb.SeatManagementService';
+const WINDSURF_POST_AUTH_URL = `${WINDSURF_SEAT_SERVICE_BASE}/WindsurfPostAuth`;
+const WINDSURF_ONE_TIME_TOKEN_URL = `${WINDSURF_SEAT_SERVICE_BASE}/GetOneTimeAuthToken`;
 
 // ─── Fingerprint randomization ────────────────────────────
 
@@ -61,6 +66,15 @@ function generateFingerprint() {
     'Sec-Fetch-Site': 'cross-site',
     'Origin': 'https://windsurf.com',
     'Referer': 'https://windsurf.com/',
+  };
+}
+
+function buildJsonHeaders(fingerprint, body, extra = {}) {
+  return {
+    ...fingerprint,
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+    ...extra,
   };
 }
 
@@ -147,8 +161,137 @@ function httpsRequest(url, opts, postData, proxy) {
 
 // ─── Login flow ───────────────────────────────────────────
 
+function createFriendlyAuthError(prefix, detail, fallback = '登录失败') {
+  const oauthHint = '若你用 Google/GitHub 注册的 Windsurf 账号 此处密码登录不适用 请用页面顶部的 Google / GitHub 登录按钮 或访问 https://windsurf.com/show-auth-token 复制 Auth Token 后在「账号管理」页手动添加';
+  const normalized = String(detail || '').trim();
+  const friendly = {
+    'EMAIL_NOT_FOUND': `该邮箱未注册邮箱密码登录方式（${oauthHint}）`,
+    'INVALID_PASSWORD': `密码错误（${oauthHint}）`,
+    'INVALID_LOGIN_CREDENTIALS': `邮箱或密码错误（${oauthHint}）`,
+    'Invalid email or password': `邮箱或密码错误（${oauthHint}）`,
+    'No password set. Please log in with Google or GitHub.': `该账号未设置密码登录方式（${oauthHint}）`,
+    'No password set': `该账号未设置密码登录方式（${oauthHint}）`,
+    'USER_DISABLED': '账号已被停用',
+    'TOO_MANY_ATTEMPTS_TRY_LATER': '尝试太多次 请稍后再试',
+    'INVALID_EMAIL': '邮箱格式错误',
+  }[normalized] || normalized || fallback;
+  const err = new Error(`${prefix}: ${friendly}`);
+  err.isAuthFail = [
+    'EMAIL_NOT_FOUND',
+    'INVALID_PASSWORD',
+    'INVALID_LOGIN_CREDENTIALS',
+    'Invalid email or password',
+    'No password set. Please log in with Google or GitHub.',
+    'No password set',
+  ].includes(normalized);
+  err.firebaseCode = normalized || undefined;
+  return err;
+}
+
+async function fetchAuth1Connections(email, fingerprint, proxy) {
+  const body = JSON.stringify({ product: 'windsurf', email });
+  const headers = buildJsonHeaders(fingerprint, body);
+  const res = await httpsRequest(AUTH1_CONNECTIONS_URL, { method: 'POST', headers }, body, proxy);
+  return res.data || {};
+}
+
+async function registerWithCodeium(token, fingerprint, proxy) {
+  const regBody = JSON.stringify({ firebase_id_token: token });
+  const regHeaders = buildJsonHeaders(fingerprint, regBody);
+  const regRes = await httpsRequest(CODEIUM_REGISTER_URL, { method: 'POST', headers: regHeaders }, regBody, proxy);
+
+  if (regRes.status >= 400 || !regRes.data.api_key) {
+    throw new Error(`Codeium 註冊失敗: ${JSON.stringify(regRes.data).slice(0, 200)}`);
+  }
+
+  return regRes.data;
+}
+
+async function windsurfLoginViaAuth1(email, password, fingerprint, proxy) {
+  const loginBody = JSON.stringify({ email, password });
+  const loginHeaders = buildJsonHeaders(fingerprint, loginBody);
+  const loginRes = await httpsRequest(AUTH1_PASSWORD_LOGIN_URL, { method: 'POST', headers: loginHeaders }, loginBody, proxy);
+
+  if (loginRes.status >= 400 || loginRes.data?.detail) {
+    throw createFriendlyAuthError('Windsurf Auth1 登入失败', loginRes.data?.detail, '登录失败');
+  }
+
+  const auth1Token = loginRes.data?.token;
+  if (!auth1Token) {
+    throw new Error(`Windsurf Auth1 回应缺少 token: ${JSON.stringify(loginRes.data).slice(0, 200)}`);
+  }
+
+  log.info(`Auth1 login OK: ${email}`);
+
+  const bridgeBody = JSON.stringify({ auth1Token, orgId: '' });
+  const bridgeHeaders = buildJsonHeaders(fingerprint, bridgeBody, { 'Connect-Protocol-Version': '1' });
+  const bridgeRes = await httpsRequest(WINDSURF_POST_AUTH_URL, { method: 'POST', headers: bridgeHeaders }, bridgeBody, proxy);
+
+  if (bridgeRes.status >= 400 || !bridgeRes.data?.sessionToken) {
+    throw new Error(`Windsurf PostAuth 失败: ${JSON.stringify(bridgeRes.data).slice(0, 200)}`);
+  }
+
+  const sessionToken = bridgeRes.data.sessionToken;
+  log.info(`Windsurf PostAuth OK: ${email} account=${bridgeRes.data.accountId || 'unknown'}`);
+
+  const ottBody = JSON.stringify({ authToken: sessionToken });
+  const ottHeaders = buildJsonHeaders(fingerprint, ottBody, { 'Connect-Protocol-Version': '1' });
+  const ottRes = await httpsRequest(WINDSURF_ONE_TIME_TOKEN_URL, { method: 'POST', headers: ottHeaders }, ottBody, proxy);
+
+  if (ottRes.status >= 400 || !ottRes.data?.authToken) {
+    throw new Error(`获取一次性 Auth Token 失败: ${JSON.stringify(ottRes.data).slice(0, 200)}`);
+  }
+
+  const reg = await registerWithCodeium(ottRes.data.authToken, fingerprint, proxy);
+  log.info(`Codeium register via Auth1 OK: ${email} → key=${reg.api_key.slice(0, 20)}...`);
+
+  return {
+    apiKey: reg.api_key,
+    name: reg.name || email,
+    email,
+    apiServerUrl: reg.api_server_url || '',
+    sessionToken,
+    auth1Token,
+  };
+}
+
+async function windsurfLoginViaFirebase(email, password, fingerprint, proxy) {
+  const firebaseBody = JSON.stringify({
+    email,
+    password,
+    returnSecureToken: true,
+  });
+
+  const fbHeaders = buildJsonHeaders(fingerprint, firebaseBody);
+  const fbRes = await httpsRequest(FIREBASE_AUTH_URL, { method: 'POST', headers: fbHeaders }, firebaseBody, proxy);
+
+  if (fbRes.data.error) {
+    const msg = fbRes.data.error.message || 'Unknown Firebase error';
+    throw createFriendlyAuthError('Firebase 登入失败', msg, msg);
+  }
+
+  const idToken = fbRes.data.idToken;
+  if (!idToken) throw new Error('Firebase 回應缺少 idToken');
+
+  log.info(`Firebase login OK: ${email}, UID=${fbRes.data.localId}`);
+
+  const reg = await registerWithCodeium(idToken, fingerprint, proxy);
+  log.info(`Codeium register OK: ${email} → key=${reg.api_key.slice(0, 20)}...`);
+
+  return {
+    apiKey: reg.api_key,
+    name: reg.name || email,
+    email,
+    idToken,
+    refreshToken: fbRes.data.refreshToken || '',
+    apiServerUrl: reg.api_server_url || '',
+  };
+}
+
 /**
- * Full Windsurf login: Firebase auth → Codeium register → API key.
+ * Full Windsurf login:
+ *  - Auth1 password login → bridge session → one-time auth token → Codeium register
+ *  - or legacy Firebase auth → Codeium register
  * @param {string} email
  * @param {string} password
  * @param {object} [proxy] - { host, port, username, password }
@@ -158,67 +301,33 @@ export async function windsurfLogin(email, password, proxy = null) {
   const fingerprint = generateFingerprint();
   log.info(`Windsurf login: ${email} fp=${fingerprint['User-Agent'].slice(0, 40)}... proxy=${proxy?.host || 'none'}`);
 
-  // Step 1: Firebase sign in
-  const firebaseBody = JSON.stringify({
-    email,
-    password,
-    returnSecureToken: true,
-  });
-
-  const fbHeaders = {
-    ...fingerprint,
-    'Content-Type': 'application/json',
-    'Content-Length': Buffer.byteLength(firebaseBody),
-  };
-
-  const fbRes = await httpsRequest(FIREBASE_AUTH_URL, { method: 'POST', headers: fbHeaders }, firebaseBody, proxy);
-
-  if (fbRes.data.error) {
-    const msg = fbRes.data.error.message || 'Unknown Firebase error';
-    const oauthHint = '若你用 Google/GitHub 注册的 Windsurf 账号 此处密码登录不适用 请用页面顶部的 Google / GitHub 登录按钮 或访问 https://windsurf.com/show-auth-token 复制 Auth Token 后在「账号管理」页手动添加';
-    const friendly = {
-      'EMAIL_NOT_FOUND': `该邮箱未注册邮箱密码登录方式（${oauthHint}）`,
-      'INVALID_PASSWORD': `密码错误（${oauthHint}）`,
-      'INVALID_LOGIN_CREDENTIALS': `邮箱或密码错误（${oauthHint}）`,
-      'USER_DISABLED': '账号已被停用',
-      'TOO_MANY_ATTEMPTS_TRY_LATER': '尝试太多次 请稍后再试',
-      'INVALID_EMAIL': '邮箱格式错误',
-    }[msg] || msg;
-    const err = new Error(`Firebase 登入失败: ${friendly}`);
-    err.firebaseCode = msg;
-    err.isAuthFail = ['EMAIL_NOT_FOUND', 'INVALID_PASSWORD', 'INVALID_LOGIN_CREDENTIALS'].includes(msg);
-    throw err;
+  let auth1Connections = null;
+  try {
+    auth1Connections = await fetchAuth1Connections(email, fingerprint, proxy);
+  } catch (err) {
+    log.warn(`Auth1 connections probe failed for ${email}: ${err.message}`);
   }
 
-  const idToken = fbRes.data.idToken;
-  if (!idToken) throw new Error('Firebase 回應缺少 idToken');
-
-  log.info(`Firebase login OK: ${email}, UID=${fbRes.data.localId}`);
-
-  // Step 2: Register with Codeium to get API key
-  const regBody = JSON.stringify({ firebase_id_token: idToken });
-  const regHeaders = {
-    ...fingerprint,
-    'Content-Type': 'application/json',
-    'Content-Length': Buffer.byteLength(regBody),
-  };
-
-  const regRes = await httpsRequest(CODEIUM_REGISTER_URL, { method: 'POST', headers: regHeaders }, regBody, proxy);
-
-  if (regRes.status >= 400 || !regRes.data.api_key) {
-    throw new Error(`Codeium 註冊失敗: ${JSON.stringify(regRes.data).slice(0, 200)}`);
+  const auth1Method = auth1Connections?.auth_method?.method;
+  if (auth1Method === 'auth1') {
+    if (auth1Connections?.auth_method?.has_password === false) {
+      throw createFriendlyAuthError('Windsurf Auth1 登入失败', 'No password set. Please log in with Google or GitHub.');
+    }
+    return await windsurfLoginViaAuth1(email, password, fingerprint, proxy);
   }
 
-  log.info(`Codeium register OK: ${email} → key=${regRes.data.api_key.slice(0, 12)}...`);
+  try {
+    return await windsurfLoginViaFirebase(email, password, fingerprint, proxy);
+  } catch (firebaseErr) {
+    if (!firebaseErr?.isAuthFail) throw firebaseErr;
 
-  return {
-    apiKey: regRes.data.api_key,
-    name: regRes.data.name || email,
-    email,
-    idToken,
-    refreshToken: fbRes.data.refreshToken || '',
-    apiServerUrl: regRes.data.api_server_url || '',
-  };
+    try {
+      return await windsurfLoginViaAuth1(email, password, fingerprint, proxy);
+    } catch (auth1Err) {
+      if (auth1Err?.isAuthFail) throw firebaseErr;
+      throw auth1Err;
+    }
+  }
 }
 
 /**
@@ -270,21 +379,10 @@ export async function refreshFirebaseToken(refreshToken, proxy = null) {
  */
 export async function reRegisterWithCodeium(idToken, proxy = null) {
   const fingerprint = generateFingerprint();
-  const regBody = JSON.stringify({ firebase_id_token: idToken });
-  const regHeaders = {
-    ...fingerprint,
-    'Content-Type': 'application/json',
-    'Content-Length': Buffer.byteLength(regBody),
-  };
-
-  const regRes = await httpsRequest(CODEIUM_REGISTER_URL, { method: 'POST', headers: regHeaders }, regBody, proxy);
-
-  if (regRes.status >= 400 || !regRes.data.api_key) {
-    throw new Error(`Codeium re-registration failed: ${JSON.stringify(regRes.data).slice(0, 200)}`);
-  }
+  const regRes = await registerWithCodeium(idToken, fingerprint, proxy);
 
   return {
-    apiKey: regRes.data.api_key,
-    name: regRes.data.name || '',
+    apiKey: regRes.api_key,
+    name: regRes.name || '',
   };
 }


### PR DESCRIPTION
## 变更说明
- 为 Dashboard 的 Windsurf 邮箱密码登录页新增批量导入能力，支持按“邮箱 空格/Tab 密码”格式一次粘贴多组账号
- 新增 `/dashboard/api/windsurf-login/batch` 接口，并抽取公共登录处理逻辑，统一单个登录与批量登录流程
- 修复 Windsurf 官网可登录但 Dashboard 登录失败的问题：补上官网当前实际使用的 Auth1 邮箱密码登录链路
- 保留旧 Firebase 邮箱密码登录作为兼容兜底逻辑

## 具体改动
### 前端
- 在“登录取号”页面新增批量导入输入框、读取剪贴板按钮、批量导入并登录按钮
- 新增批量账号解析、批量结果展示、批量历史记录写入逻辑
- 统一单个登录与批量登录的结果展示和代理配置复用

### 后端
- 新增批量登录接口：`POST /dashboard/api/windsurf-login/batch`
- 抽取 `processWindsurfLogin(...)`，供单账号登录与批量登录共用
- 在 `windsurf-login.js` 中新增 Auth1 登录流程：
  1. 探测 `/_devin-auth/connections`
  2. 调用 `/_devin-auth/password/login`
  3. 调用 `WindsurfPostAuth`
  4. 调用 `GetOneTimeAuthToken`
  5. 最终注册为可用 API Key
- 对非 Auth1 账号继续走原有 Firebase 登录流程

## 验证
- `node --check src/dashboard/windsurf-login.js`
- `node --check src/dashboard/api.js`
- 本地实测 `POST /dashboard/api/windsurf-login` 可成功登录官网可用的邮箱密码账号
- 本地实测 `POST /dashboard/api/windsurf-login/batch` 返回成功结果
