### PR TITLE
fix(auth): don't demote Pro/Trial tier to 'free' after each chat call

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -739,7 +739,14 @@ export function updateCapability(apiKey, modelKey, ok, reason = '') {
   if (ok && (account.tier === 'free' || account.tier === 'unknown')) {
     registerDiscoveredFreeModel(modelKey);
   }
-  account.tier = inferTier(account.capabilities);
+  // Only infer tier when we have no authoritative source. GetUserStatus
+  // (userStatusLastFetched) and manual override (tierManual) are both
+  // authoritative; inferTier only looks at canary model capabilities and
+  // would otherwise demote a Pro/Trial account back to 'free' as soon as
+  // a non-premium model (e.g. gemini-2.5-flash, gpt-4o-mini) succeeds.
+  if (!account.tierManual && !account.userStatusLastFetched) {
+    account.tier = inferTier(account.capabilities);
+  }
   saveAccounts();
 }
 


### PR DESCRIPTION
## Problem

After any successful `/v1/chat/completions` call, the dashboard shows the
account tier as **FREE** even for Pro / 14-day Trial accounts (e.g. screenshot
where `planName` is `Trial` but the tier badge renders `FREE`).

## Root cause

[handlers/chat.js](cci:7://file:///Users/jaxyu/NodeProjects/auto-cc-poll/_WindsurfAPI_tmp/src/handlers/chat.js:0:0-0:0) calls [updateCapability(apiKey, modelKey, true, 'success')](cci:1://file:///Users/jaxyu/NodeProjects/auto-cc-poll/_wfpr/src/auth.js:721:0-750:1)
after every successful request. [updateCapability](cci:1://file:///Users/jaxyu/NodeProjects/auto-cc-poll/_wfpr/src/auth.js:721:0-750:1) then runs
[inferTier(account.capabilities)](cci:1://file:///Users/jaxyu/NodeProjects/auto-cc-poll/_wfpr/src/auth.js:752:0-763:1) **unconditionally** and writes the result
back to `account.tier`.

[inferTier](cci:1://file:///Users/jaxyu/NodeProjects/auto-cc-poll/_wfpr/src/auth.js:752:0-763:1) only recognises `claude-opus-4.6` / `claude-sonnet-4.6` as Pro
evidence. If a Pro or Trial account calls a non-premium model such as
`gemini-2.5-flash` or `gpt-4o-mini`, [inferTier](cci:1://file:///Users/jaxyu/NodeProjects/auto-cc-poll/_wfpr/src/auth.js:752:0-763:1) sees `ok=true` on that model
and returns `'free'`, overwriting the authoritative tier that
`GetUserStatus` / [refreshCredits](cci:1://file:///Users/jaxyu/NodeProjects/auto-cc-poll/_wfpr/src/auth.js:669:0-709:1) had set.

[probeAccount](cci:1://file:///Users/jaxyu/NodeProjects/auto-cc-poll/_wfpr/src/auth.js:854:0-980:1) already works around this with a manual
`account.tier = status.tierName` restore at the end (see the existing
comment: _"updateCapability rewrites tier via inferTier, so restore it
afterwards"_), but the chat handler path has no such restore, so every real
API call silently demotes the tier.

## Fix

Skip the [inferTier](cci:1://file:///Users/jaxyu/NodeProjects/auto-cc-poll/_wfpr/src/auth.js:752:0-763:1) fallback in [updateCapability](cci:1://file:///Users/jaxyu/NodeProjects/auto-cc-poll/_wfpr/src/auth.js:721:0-750:1) when an authoritative
tier source is present:

- `userStatusLastFetched > 0` — `GetUserStatus` has returned a real tier
- `tierManual === true` — user has manually pinned the tier in the dashboard

The fallback still runs for brand-new accounts that have never been probed,
so tier inference for those accounts is unchanged.

## Test

1. Add a Trial account, run the 15-min refresh / probe → tier shows `pro`.
2. Send a chat request to `gemini-2.5-flash` (any non-premium model).
3. Before: tier flips to `free` in `accounts.json` and in the dashboard.
   After: tier remains `pro`.