### PR TITLE
fix: disable Cascade reuse for tool-emulated Claude Code turns

### DIFF
--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -86,6 +86,10 @@ const CASCADE_REUSE_STRICT_RETRY_MS = (() => {
   return Number.isFinite(n) && n > 0 ? n : 60_000;
 })();
 
+export function shouldUseCascadeReuse({ useCascade, emulateTools }) {
+  return !!useCascade && !emulateTools;
+}
+
 function strictReuseRetryMs(availability) {
   return Math.max(1000, availability?.retryAfterMs || CASCADE_REUSE_STRICT_RETRY_MS);
 }
@@ -382,7 +386,7 @@ export async function handleChatCompletions(body) {
   // instead of replaying the whole history.
   //
   // Conversation reuse lets Cascade keep server-side context across turns.
-  const reuseEnabled = useCascade && isExperimentalEnabled('cascadeConversationReuse');
+  const reuseEnabled = shouldUseCascadeReuse({ useCascade, emulateTools }) && isExperimentalEnabled('cascadeConversationReuse');
   const fpBefore = reuseEnabled ? fingerprintBefore(messages, modelKey) : null;
   let reuseEntry = reuseEnabled ? poolCheckout(fpBefore) : null;
   let checkedOutReuseEntry = reuseEntry;
@@ -793,7 +797,7 @@ function streamResponse(id, created, model, modelKey, messages, cascadeMessages,
       // Cascade conversation pool (experimental, stream path) — bypassed in
       // tool-emulation mode because the fingerprint can't collapse turns
       // whose bodies carry <tool_call>/<tool_result> markup.
-      const reuseEnabled = useCascade && isExperimentalEnabled('cascadeConversationReuse');
+      const reuseEnabled = shouldUseCascadeReuse({ useCascade, emulateTools }) && isExperimentalEnabled('cascadeConversationReuse');
       const fpBefore = reuseEnabled ? fingerprintBefore(messages, modelKey) : null;
       let reuseEntry = reuseEnabled ? poolCheckout(fpBefore) : null;
       let checkedOutReuseEntry = reuseEntry;

--- a/test/chat-reuse.test.js
+++ b/test/chat-reuse.test.js
@@ -1,0 +1,17 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldUseCascadeReuse } from '../src/handlers/chat.js';
+
+describe('shouldUseCascadeReuse', () => {
+  it('allows reuse for normal Cascade chat turns', () => {
+    assert.equal(shouldUseCascadeReuse({ useCascade: true, emulateTools: false }), true);
+  });
+
+  it('disables reuse for tool-emulated Claude Code turns', () => {
+    assert.equal(shouldUseCascadeReuse({ useCascade: true, emulateTools: true }), false);
+  });
+
+  it('disables reuse outside Cascade', () => {
+    assert.equal(shouldUseCascadeReuse({ useCascade: false, emulateTools: false }), false);
+  });
+});


### PR DESCRIPTION
## Summary\n- Disable Cascade conversation reuse for tool-emulated requests, including Claude Code tool_use/tool_result turns.\n- Keep Cascade reuse enabled for normal non-tool chat turns.\n- Add focused tests for reuse eligibility.\n\n## Test Plan\n- npm test