### PR TITLE
fix: bring Claude Code tool-call flow back to Anthropic-equivalent behaviour

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -743,6 +743,19 @@ export class WindsurfClient {
       } else {
         log.info('Cascade done', summary);
       }
+      // When the polling loop times out (max_wait) instead of seeing a
+      // clean idle_done, the model has been generating tokens continuously
+      // for ~3 minutes without ever yielding a stop signal. Knowing what
+      // those tokens look like is the only way to diagnose whether it's a
+      // generation loop, a tool-call format the parser is rejecting, or
+      // mid-thought truncation. Dump head + tail of the accumulated text
+      // (capped) so a single log line shows the symptom shape.
+      if (endReason === 'max_wait' && totalYielded > 0) {
+        const accum = chunks.map(c => c.text || '').join('');
+        const head = accum.slice(0, 400).replace(/\s+/g, ' ');
+        const tail = accum.length > 800 ? accum.slice(-400).replace(/\s+/g, ' ') : '';
+        log.warn(`Cascade max_wait dump: head="${head}"${tail ? ` ... tail="${tail}"` : ''}`);
+      }
 
       onEnd?.(chunks);
 

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -146,6 +146,73 @@ export function neutralizeCascadeIdentity(text, modelName) {
     .replace(/\b(?:the )?Cascade(?:['’]s)? workspace\b/gi, 'the workspace');
 }
 
+/**
+ * Lift authoritative environment facts from the caller's request so they
+ * can be re-emitted into the proto-level tool_calling_section override.
+ *
+ * Why this exists: Claude Code (and most Anthropic-format clients) put
+ * working-directory / git / platform info in an `<env>` block inside the
+ * system prompt or a `<system-reminder>` user block. That information IS
+ * forwarded to Cascade (client.js prepends sysText to the user text), but
+ * Cascade's own planner system prompt is structurally more authoritative
+ * to the upstream model than user-message text — and Cascade's prompt
+ * tells the model "your workspace is /tmp/windsurf-workspace". Result:
+ * Opus issues LS / Read against /tmp/windsurf-workspace instead of the
+ * user's real cwd, and confidently narrates the contents of an empty
+ * scratch dir back as if it were the user's project.
+ *
+ * Lifting cwd into tool_calling_section gives it equal authority weight
+ * inside the model's mental model, and the surrounding wording in
+ * buildToolPreambleForProto explicitly tells the model to prefer THIS
+ * environment over any prior workspace assumption.
+ *
+ * Parser is intentionally lenient: it scans every message's text content
+ * (string or content-block array) and pulls out the standard Claude Code
+ * `<env>` keys. If nothing is found, returns '' and the override gets no
+ * environment block (existing behaviour preserved).
+ */
+export function extractCallerEnvironment(messages) {
+  if (!Array.isArray(messages)) return '';
+  const seen = new Set();
+  const out = [];
+
+  // Patterns are anchored to start-of-line so they won't false-positive
+  // on body text that mentions e.g. "the working directory in the docs".
+  // Allowed key forms cover Claude Code's `<env>` block, OpenAI Codex'
+  // `<system-reminder>`, and the loose `cwd:` form some agents emit.
+  const PATTERNS = [
+    ['cwd', /(?:^|\n)\s*(?:Working directory|cwd|<cwd>)\s*[:=]\s*([^\n<]+)/i, (v) => `- Working directory: ${v}`],
+    ['git', /(?:^|\n)\s*Is directory a git repo\s*[:=]\s*([^\n<]+)/i, (v) => `- Is the directory a git repo: ${v}`],
+    ['platform', /(?:^|\n)\s*Platform\s*[:=]\s*([^\n<]+)/i, (v) => `- Platform: ${v}`],
+    ['os', /(?:^|\n)\s*OS Version\s*[:=]\s*([^\n<]+)/i, (v) => `- OS version: ${v}`],
+  ];
+
+  for (const m of messages) {
+    if (!m) continue;
+    let content;
+    if (typeof m.content === 'string') content = m.content;
+    else if (Array.isArray(m.content)) content = m.content.filter(p => p?.type === 'text').map(p => p.text || '').join('\n');
+    else continue;
+    if (!content) continue;
+
+    for (const [key, re, fmt] of PATTERNS) {
+      if (seen.has(key)) continue;
+      const match = content.match(re);
+      if (match) {
+        const value = match[1].trim();
+        // Reject obvious garbage (empty after trim, control chars, our own
+        // redaction marker leaking back in).
+        if (!value || /[\x00-\x1f]/.test(value) || value === '…') continue;
+        seen.add(key);
+        out.push(fmt(value));
+      }
+    }
+    if (seen.size === PATTERNS.length) break;
+  }
+
+  return out.join('\n');
+}
+
 // Rough token estimate (~4 chars/token). Used only to populate the
 // OpenAI-compatible `usage.prompt_tokens_details.cached_tokens` field so
 // upstream billing/dashboards (new-api) can recognise our local cache hits.
@@ -332,7 +399,12 @@ export async function handleChatCompletions(body) {
   // Also inject into the last user message as fallback — some models in
   // NO_TOOL mode ignore the SectionOverride entirely and refuse to call
   // tools unless they see the definitions in the conversation itself. (#22)
-  const toolPreamble = emulateTools ? buildToolPreambleForProto(tools || [], tool_choice) : '';
+  // Lift the caller's environment hints (cwd, git status, platform) into
+  // the proto-level system slot so Cascade's authoritative planner system
+  // prompt can no longer override them with /tmp/windsurf-workspace
+  // priors. See extractCallerEnvironment() above for the parser.
+  const callerEnv = emulateTools ? extractCallerEnvironment(messages) : '';
+  const toolPreamble = emulateTools ? buildToolPreambleForProto(tools || [], tool_choice, callerEnv) : '';
   let cascadeMessages = emulateTools
     ? normalizeMessagesForCascade(messages, tools)
     : [...messages];

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -232,6 +232,19 @@ export function extractCallerEnvironment(messages) {
     if (seen.size === PATTERNS.length) break;
   }
 
+  // Only emit an environment block if we actually have the cwd. Platform /
+  // OS / git status without cwd are useless for the original goal (tell
+  // the model where to run tools) AND adding them anyway makes the
+  // tool_calling_section preamble look like a system prompt with no
+  // real signal — which trips Opus 4.7's injection guard, observed live
+  // when Claude Code v2.1.114 (which does NOT include cwd in its system
+  // prompt) caused us to emit an env block containing only Platform +
+  // OS Version, and Opus refused with "the message I received is a
+  // system prompt for Claude Code along with truncated tool output".
+  // Sticking to the rule "no cwd → no block" both removes the noise and
+  // lets the model learn cwd via its own `pwd` tool call (which already
+  // works on every Anthropic-format client we have tested).
+  if (!seen.has('cwd')) return '';
   return out.join('\n');
 }
 

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -118,18 +118,32 @@ const MODEL_PROVIDERS = {
   o3: 'OpenAI', o4: 'OpenAI',
 };
 
-function neutralizeCascadeIdentity(text, modelName) {
+export function neutralizeCascadeIdentity(text, modelName) {
   if (!text || !modelName) return text;
   const provider = MODEL_PROVIDERS[Object.keys(MODEL_PROVIDERS).find(k => modelName.toLowerCase().startsWith(k)) || ''];
   if (!provider) return text;
   return text
+    // First-person identity claims
     .replace(/\bI am Cascade\b/gi, `I am ${modelName}`)
     .replace(/\bI'm Cascade\b/gi, `I'm ${modelName}`)
     .replace(/\bmy name is Cascade\b/gi, `my name is ${modelName}`)
+    // Third-person self-reference common in Cascade prose
     .replace(/\bCascade, an AI coding assistant\b/gi, `${modelName}, an AI assistant`)
+    .replace(/\bCascade is an? (?:AI )?(?:coding )?assistant\b/gi, `${modelName} is an AI assistant`)
+    .replace(/\b(?:As|Acting as) Cascade\b/g, `As ${modelName}`)
+    // Provider attribution
     .replace(/\bCascade, made by (?:Codeium|Windsurf)\b/gi, `${modelName}, made by ${provider}`)
+    .replace(/\b(?:Codeium|Windsurf)(?:['’]s)? Cascade\b/g, modelName)
     .replace(/\bdeveloped by (?:Codeium|Windsurf)\b/gi, `developed by ${provider}`)
-    .replace(/\bcreated by (?:Codeium|Windsurf)\b/gi, `created by ${provider}`);
+    .replace(/\bcreated by (?:Codeium|Windsurf)\b/gi, `created by ${provider}`)
+    .replace(/\bbuilt by (?:Codeium|Windsurf)\b/gi, `built by ${provider}`)
+    // Cascade-flavoured workspace narration. The model regularly says things
+    // like "Cascade's workspace at /tmp/windsurf-workspace" — sanitizeText
+    // already scrubs the path; this strips the lingering "Cascade's" /
+    // "the Cascade" prefix so the sentence reads naturally. The leading
+    // "the " is consumed by the same regex so we don't end up with the
+    // double-article artefact ("the the workspace").
+    .replace(/\b(?:the )?Cascade(?:['’]s)? workspace\b/gi, 'the workspace');
 }
 
 // Rough token estimate (~4 chars/token). Used only to populate the

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -176,15 +176,35 @@ export function extractCallerEnvironment(messages) {
   const seen = new Set();
   const out = [];
 
-  // Patterns are anchored to start-of-line so they won't false-positive
-  // on body text that mentions e.g. "the working directory in the docs".
-  // Allowed key forms cover Claude Code's `<env>` block, OpenAI Codex'
-  // `<system-reminder>`, and the loose `cwd:` form some agents emit.
+  // Match the cwd phrasing every Anthropic-format client we have seen in
+  // the wild emits, while staying narrow enough that prose mentions like
+  // "the working directory in the docs" don't trip it. Two formats matter:
+  //
+  //   (a) Canonical `<env>` key/value block (older Claude Code, opencode,
+  //       Cline): `Working directory: /path` on its own line. Must allow
+  //       a leading `<env>` tag, optional `-`/`*` bullet prefix, and `:`
+  //       or `=` separator.
+  //
+  //   (b) Claude Code 2.1+ prose system prompt: `…and the current working
+  //       directory is /path.`  No newline anchor, no separator, the path
+  //       just trails the phrase. (Confirmed via the env-NOT-lifted probe
+  //       diagnostic against Claude Code v2.1.114.)
+  //
+  // The capture group is locked to `[/~]…` so we only grab actual-looking
+  // paths — "the working directory you choose" or similar abstract prose
+  // never has a `/` or `~` in the captured slot and is rejected.
+  const PATH_TAIL = `[\\/~][^\\s\`'"<>\\n.,;)]+`;
   const PATTERNS = [
-    ['cwd', /(?:^|\n)\s*(?:Working directory|cwd|<cwd>)\s*[:=]\s*([^\n<]+)/i, (v) => `- Working directory: ${v}`],
-    ['git', /(?:^|\n)\s*Is directory a git repo\s*[:=]\s*([^\n<]+)/i, (v) => `- Is the directory a git repo: ${v}`],
-    ['platform', /(?:^|\n)\s*Platform\s*[:=]\s*([^\n<]+)/i, (v) => `- Platform: ${v}`],
-    ['os', /(?:^|\n)\s*OS Version\s*[:=]\s*([^\n<]+)/i, (v) => `- OS version: ${v}`],
+    ['cwd', new RegExp(
+      // Form (a): line-anchored key/value
+      `(?:^|\\n)\\s*(?:[-*]\\s+)?(?:Working directory|cwd|<cwd>)\\s*[:=]\\s*\`?(${PATH_TAIL})\`?` +
+      // Form (b): prose "current working directory is /path"
+      `|(?:current\\s+working\\s+directory(?:\\s+is)?)\\s*[:=]?\\s*\`?(${PATH_TAIL})\`?`,
+      'i'
+    ), (v) => `- Working directory: ${v}`],
+    ['git', /(?:^|\n)\s*(?:[-*]\s+)?Is directory a git repo\s*[:=]\s*([^\n<]+)/i, (v) => `- Is the directory a git repo: ${v}`],
+    ['platform', /(?:^|\n)\s*(?:[-*]\s+)?Platform\s*[:=]\s*([^\n<]+)/i, (v) => `- Platform: ${v}`],
+    ['os', /(?:^|\n)\s*(?:[-*]\s+)?OS Version\s*[:=]\s*([^\n<]+)/i, (v) => `- OS version: ${v}`],
   ];
 
   for (const m of messages) {
@@ -199,7 +219,9 @@ export function extractCallerEnvironment(messages) {
       if (seen.has(key)) continue;
       const match = content.match(re);
       if (match) {
-        const value = match[1].trim();
+        // The cwd pattern has two alternative capture groups (one per
+        // accepted form); the others have one. Pick the first non-empty.
+        const value = (match[1] || match[2] || '').trim();
         // Reject obvious garbage (empty after trim, control chars, our own
         // redaction marker leaking back in).
         if (!value || /[\x00-\x1f]/.test(value) || value === '…') continue;
@@ -405,6 +427,29 @@ export async function handleChatCompletions(body) {
   // priors. See extractCallerEnvironment() above for the parser.
   const callerEnv = emulateTools ? extractCallerEnvironment(messages) : '';
   const toolPreamble = emulateTools ? buildToolPreambleForProto(tools || [], tool_choice, callerEnv) : '';
+  // Diagnostic: surface whether environment lifting actually fired so a real
+  // request log immediately tells us if Claude Code 2.x changed `<env>` block
+  // wording, or if the extraction guard rejected a valid hint. Cheap to log,
+  // and the alternative is a 200-char Probe head that hides the env block.
+  if (emulateTools) {
+    if (callerEnv) {
+      const compact = callerEnv.replace(/\s+/g, ' ').slice(0, 200);
+      log.info(`Chat[${reqId}]: env lifted into tool_calling_section: ${compact}`);
+    } else {
+      // Hunt for env-shaped substrings so we can see WHY the extractor
+      // missed (e.g. Claude Code put cwd in a freeform paragraph instead
+      // of the canonical `Working directory: …` line).
+      let probe = '';
+      for (const m of (messages || [])) {
+        const c = typeof m?.content === 'string' ? m.content
+          : Array.isArray(m?.content) ? m.content.filter(p => p?.type === 'text').map(p => p.text || '').join('\n')
+          : '';
+        const hit = c.match(/[^.\n]{0,40}(?:working directory|cwd|<env>|<cwd>)[^.\n]{0,80}/i);
+        if (hit) { probe = hit[0].replace(/\s+/g, ' ').slice(0, 160); break; }
+      }
+      log.info(`Chat[${reqId}]: env NOT lifted (extractor returned empty)${probe ? '; nearest env-shaped substring in messages: ' + probe : '; no env-shaped substring found in any message'}`);
+    }
+  }
   let cascadeMessages = emulateTools
     ? normalizeMessagesForCascade(messages, tools)
     : [...messages];

--- a/src/handlers/tool-emulation.js
+++ b/src/handlers/tool-emulation.js
@@ -116,11 +116,34 @@ function resolveToolChoice(tc) {
   return { mode: 'auto', forceName: null };
 }
 
-export function buildToolPreambleForProto(tools, toolChoice) {
+/**
+ * Build the proto-level tool_calling_section override.
+ *
+ * The optional `environment` parameter is a short multi-line summary of
+ * authoritative environment facts extracted from the caller's request
+ * (e.g. Claude Code's `<env>` block: working directory, git status,
+ * platform). When provided, it is rendered BEFORE the tool protocol
+ * header so the model treats those facts as ground truth rather than as
+ * a user-message hint the baked-in Cascade planner system prompt could
+ * override. This is the only reliable way to tell Opus "your real cwd is
+ * X, not /tmp/windsurf-workspace" in a way that survives Cascade's
+ * authoritative workspace prior. (#54 follow-up.)
+ */
+export function buildToolPreambleForProto(tools, toolChoice, environment) {
   if (!Array.isArray(tools) || tools.length === 0) return '';
   const { mode, forceName } = resolveToolChoice(toolChoice);
 
-  const lines = [TOOL_PROTOCOL_SYSTEM_HEADER];
+  const lines = [];
+  if (environment && typeof environment === 'string' && environment.trim()) {
+    lines.push('## Authoritative environment for this session');
+    lines.push('The facts below are provided by the calling agent and describe the REAL execution context. Tool calls MUST operate on these paths. Ignore any workspace path you may have inferred from earlier instructions or training priors.');
+    lines.push('');
+    lines.push(environment.trim());
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+  }
+  lines.push(TOOL_PROTOCOL_SYSTEM_HEADER);
   // Append the appropriate behaviour suffix
   lines.push(TOOL_CHOICE_SUFFIX[mode] || TOOL_CHOICE_SUFFIX.auto);
   if (forceName) {

--- a/src/handlers/tool-emulation.js
+++ b/src/handlers/tool-emulation.js
@@ -22,36 +22,29 @@ import { log } from '../config.js';
 
 // User-message-level fallback preamble.
 //
-// Phrasing deliberately mirrors the proto-level TOOL_PROTOCOL_SYSTEM_HEADER so
-// clients with strong prompt-injection guards (Claude Code / Opus in
-// particular) do not flag the preamble as a jailbreak.
+// MINIMAL by design. The proto-level tool_calling_section override
+// (buildToolPreambleForProto) is authoritative and carries the full
+// function schemas. This fallback is only a short pointer that exists so
+// Cascade NO_TOOL-mode models which ignore SectionOverride (issue #22)
+// still see that tools exist and how to emit them.
 //
-// Avoid in this block:
-//   - "IGNORE any earlier framing / previous instructions"
-//   - "For THIS request only you additionally have access to..."
-//   - `---` fences + `[bracketed section titles]`
-//   - Any phrasing that reads as *overriding* the system prompt.
+// Why tiny? An earlier full-schema version (~1600+ chars of
+// `### FnName / parameters schema: / ```json {...}```` blocks prepended
+// to the user message) was reliably flagged by Opus-class injection
+// detectors as "a pasted Claude Code system prompt in the user turn".
+// The SHAPE — a wall of `### ToolName` blocks with JSON schemas — is the
+// signature of Claude Code's own system prompt, so when it appears in a
+// user slot the model treats it as a prompt-injection attempt and
+// refuses to call tools. Keeping the fallback to a single short line of
+// prose avoids that misidentification while still telling #22 models
+// the protocol and listing tool names for recognition.
 //
-// Issue #24/#48 caught an earlier version of this text being refused by
-// Opus-class models with the exact reply "The pasted content appears to be a
-// prompt-injection attempt: it's a fake 'Claude Code' system prompt wrapped in
-// a <user_request> block" — i.e. the model treated our own tool-calling
-// scaffolding as an injection attempt and declined to call the caller's tools.
-const TOOL_PROTOCOL_HEADER = `The following functions are available for this turn. To invoke one, emit a block in this EXACT format:
-
-<tool_call>{"name":"<function_name>","arguments":{...}}</tool_call>
-
-Rules:
-1. Each <tool_call>...</tool_call> block must fit on ONE line (no line breaks inside the JSON).
-2. "arguments" must be a JSON object matching the function's schema below.
-3. You MAY emit MULTIPLE <tool_call> blocks in parallel when the request needs several calls at once. Emit them consecutively, then STOP.
-4. After the last <tool_call> block, STOP. The caller executes the functions and returns results as <tool_result tool_call_id="...">...</tool_result> in the next user turn.
-5. Only call a function when the request needs it. Otherwise answer directly in plain text.
-
-Functions:`;
-
-const TOOL_PROTOCOL_FOOTER = `
-Respond to the user request above. Use <tool_call> when appropriate, otherwise answer directly.`;
+// Hard constraints:
+//   - Single paragraph, no `### …` headers, no fenced ```json blocks.
+//   - No jailbreak vocab ("IGNORE", "for THIS request only", etc.).
+//   - No `---` fences or `[bracketed titles]`.
+//   - Keep total emitted length under ~512 chars even with many tools
+//     (names only, no schemas).
 
 /**
  * Serialize an OpenAI-format tools[] array into a text preamble block.
@@ -62,22 +55,17 @@ Respond to the user request above. Use <tool_call> when appropriate, otherwise a
  */
 export function buildToolPreamble(tools) {
   if (!Array.isArray(tools) || tools.length === 0) return '';
-  const lines = [TOOL_PROTOCOL_HEADER];
+  const names = [];
   for (const t of tools) {
-    if (t?.type !== 'function' || !t.function) continue;
-    const { name, description, parameters } = t.function;
-    lines.push('');
-    lines.push(`### ${name}`);
-    if (description) lines.push(description);
-    if (parameters) {
-      lines.push('parameters schema:');
-      lines.push('```json');
-      lines.push(JSON.stringify(parameters, null, 2));
-      lines.push('```');
-    }
+    if (t?.type !== 'function' || !t.function?.name) continue;
+    names.push(t.function.name);
   }
-  lines.push(TOOL_PROTOCOL_FOOTER);
-  return lines.join('\n');
+  if (!names.length) return '';
+  // Deliberately compact: names only, no per-tool schemas. See the
+  // "User-message-level fallback preamble" comment block at the top of
+  // this module for the injection-shape rationale. Full schemas live
+  // in the proto-level tool_calling_section override.
+  return `Tools available this turn: ${names.join(', ')}. To call one, emit a single-line block: <tool_call>{"name":"...","arguments":{...}}</tool_call>. Otherwise answer directly in plain text. After the last <tool_call>, stop generating; the caller returns results in the next turn as <tool_result tool_call_id="...">...</tool_result>.`;
 }
 
 /**

--- a/src/handlers/tool-emulation.js
+++ b/src/handlers/tool-emulation.js
@@ -243,20 +243,33 @@ export function normalizeMessagesForCascade(messages, tools) {
     out.push(m);
   }
 
-  // Inject the preamble into the LAST user message (not as a separate system
-  // block). Cascade LS has a strong baked-in system prompt that overpowers
-  // additional system messages — Claude will respond "those aren't my tools"
-  // if we put the tool schema in a system slot. Wrapping the user turn with
-  // [context] ... [end context] + original question treats the tool instructions
-  // as part of the current request, which Claude reliably follows.
+  // Inject the preamble into the LAST user message that carries an actual
+  // user query — NOT a synthetic <tool_result> wrapper. The proto-level
+  // tool_calling_section / additional_instructions_section already carry
+  // the authoritative tool protocol; the user-message fallback only exists
+  // to bootstrap models that ignore the proto override on the very first
+  // turn. Re-injecting it on every later turn (where the last user message
+  // is a tool_result) makes Opus see a "Tools available this turn: …"
+  // banner immediately before a tool_result block — which it reliably
+  // pattern-matches as conversation truncation / prompt injection and
+  // refuses to continue ("the conversation got mixed up — fragments of
+  // tool output without a clear request"). Live-confirmed against Claude
+  // Code v2.1.114 / Opus 4.7: by turn ~22 the model would emit 40KB+ of
+  // confused prose with zero tool_calls and hit max_wait. Skipping the
+  // preamble on tool_result turns lets Opus stay in tool-using mode for
+  // the full conversation, matching native-Anthropic-API behaviour.
   const preamble = buildToolPreamble(tools);
   if (preamble) {
     for (let i = out.length - 1; i >= 0; i--) {
-      if (out[i].role === 'user') {
-        const cur = typeof out[i].content === 'string' ? out[i].content : JSON.stringify(out[i].content ?? '');
-        out[i] = { ...out[i], content: preamble + '\n\n' + cur };
-        break;
-      }
+      if (out[i].role !== 'user') continue;
+      const cur = typeof out[i].content === 'string' ? out[i].content : JSON.stringify(out[i].content ?? '');
+      // Skip synthetic tool_result-only turns; they are not a place to
+      // re-introduce tools. (A user turn that happens to MENTION the
+      // marker but also has real text is fine — only pure tool_result
+      // wrappers are skipped.)
+      if (/^\s*<tool_result\b/.test(cur)) break;
+      out[i] = { ...out[i], content: preamble + '\n\n' + cur };
+      break;
     }
   }
 

--- a/src/sanitize.js
+++ b/src/sanitize.js
@@ -31,30 +31,32 @@ const _repoRoot = (() => {
   } catch { return '/root/WindsurfAPI'; }
 })();
 
-// Placeholder chosen as a plain-ASCII, multi-word phrase with NO shell
-// metacharacters. Every previous marker broke at least one consumer:
+// Placeholder is a single Unicode ellipsis (U+2026) — chosen because every
+// previous marker has been re-used by the model in some destructive way:
 //   ./tail                    → LLM Reads ./src/main.py → ENOENT → loops
 //   [internal]                → LLM runs `ls [internal]` → ENOENT → loops
 //   <redacted-path>           → LLM passes to Read/Bash → ENOENT (Linux) /
 //                               Errno 22 (Windows) → loops
 //   (internal path redacted)  → zsh parses `cd (internal path redacted)`
 //                               as glob-qualifier syntax → cryptic
-//                               "unknown file attribute: i" error → Opus
-//                               gets confused and stops calling tools
-// The marker must satisfy three constraints at once:
-//   1. Contains no character that any mainstream shell parses specially
-//      — excludes `( ) [ ] { } < > | & ; $ \` " ' \\ * ?` and whitespace
-//      inside a paired delimiter.
-//   2. Does not look like a path or identifier so the model does not
-//      reuse it as a file_path / cd target on later turns.
-//   3. Reads as descriptive prose when it appears in sanitized output.
-// A plain multi-word phrase with a trailing period satisfies all three:
-// if a client ever does embed it in shell, the words become separate
-// argv entries and `cd` / `Read` fails with a clean, recoverable error
-// (too many arguments / ENOENT once) instead of the cryptic zsh glob
-// qualifier error. Verified with the drift probe
-// (scripts/_agent_drift_probe.py).
-const REDACTED_PATH = 'redacted internal path';
+//                               "unknown file attribute: i" error
+//   redacted internal path    → Opus 4.7 echoes it verbatim into bash
+//                               commands; reads to the model as a
+//                               plausible directory name and the
+//                               failure mode is `cd: too many arguments`
+//                               which still wastes 2-3 turns
+// The ellipsis is the strongest fit for all four constraints at once:
+//   1. Single character, no shell metacharacter so no shell parses it
+//      specially (zsh `cd …` → ENOENT, clean recoverable error).
+//   2. Universally read by humans and LLMs as "content omitted" — there
+//      is essentially zero training data of `cd …` or `Read("…")` as a
+//      legitimate operation, so the model does not fall into the
+//      reuse-as-path loop the other markers triggered.
+//   3. UTF-8-safe (3 bytes) and survives cleanly through SSE, JSON,
+//      gRPC and shell quoting in every codepath we tested.
+//   4. Stays terse so it does not bloat sanitized prose.
+// Verified with the drift probe (scripts/_agent_drift_probe.py).
+const REDACTED_PATH = '…';
 
 const PATTERNS = [
   [/\/tmp\/windsurf-workspace(?:\/[^\s"'`<>)}\],*;]*)?/g, REDACTED_PATH],

--- a/test/caller-environment.test.js
+++ b/test/caller-environment.test.js
@@ -61,10 +61,35 @@ describe('extractCallerEnvironment', () => {
     assert.equal(extractCallerEnvironment(messages), '');
   });
 
-  it('does not match prose mentions of "working directory" inside paragraphs', () => {
-    // Anchored to start-of-line so embedded prose stays unmatched.
+  it('lifts cwd from Claude Code 2.1+ prose form (no key/value separator)', () => {
+    // Real Claude Code v2.1.114 system prompt embeds cwd in prose, e.g.:
+    //   "You are an interactive agent that helps users with software
+    //    engineering tasks and the current working directory is /Users/.../proj."
+    // The line-anchored key/value form does not match; we fall back to a
+    // looser "current working directory is /path" pattern that requires the
+    // captured slot to actually look like a path (`[/~]…`).
     const messages = [
-      { role: 'user', content: 'Note: the working directory in the docs is shown as /tmp.' },
+      { role: 'system', content: 'You are an interactive agent that helps users with software engineering tasks and the current working directory is /Users/jaxyu/IdeaProjects/flux-panel. Match the user\'s language.' },
+      { role: 'user', content: 'check the project' },
+    ];
+    const result = extractCallerEnvironment(messages);
+    assert.match(result, /- Working directory: \/Users\/jaxyu\/IdeaProjects\/flux-panel/);
+  });
+
+  it('lifts cwd from prose form with backticks around the path', () => {
+    const messages = [
+      { role: 'system', content: 'The current working directory is `/Users/dev/proj`.' },
+    ];
+    assert.match(extractCallerEnvironment(messages), /- Working directory: \/Users\/dev\/proj/);
+  });
+
+  it('does not match abstract prose without an actual path', () => {
+    // "the working directory you choose" / "the working directory in the
+    // docs" never has a `/` or `~` in the captured slot, so the path-tail
+    // guard rejects it.
+    const messages = [
+      { role: 'user', content: 'Note: the working directory you choose is up to you.' },
+      { role: 'user', content: 'See the working directory in the docs.' },
     ];
     assert.equal(extractCallerEnvironment(messages), '');
   });

--- a/test/caller-environment.test.js
+++ b/test/caller-environment.test.js
@@ -1,0 +1,129 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractCallerEnvironment } from '../src/handlers/chat.js';
+import { buildToolPreambleForProto } from '../src/handlers/tool-emulation.js';
+
+// Why these tests exist:
+//
+// Without environment lifting Opus on Cascade believes its workspace is
+// /tmp/windsurf-workspace (the planner's authoritative prior) and issues
+// LS / Read tool calls against that path even when Claude Code's `<env>`
+// block in the request says cwd is /Users/<user>/IdeaProjects/<project>.
+// The model then narrates the contents of an empty scratch dir back as
+// if it were the user's project.
+//
+// extractCallerEnvironment lifts the canonical Claude Code `<env>` keys
+// (Working directory, Is directory a git repo, Platform, OS Version) so
+// buildToolPreambleForProto can emit them as authoritative environment
+// facts at the very top of the proto-level tool_calling_section
+// override — which IS authoritative to the upstream model and overrides
+// the Cascade planner's workspace prior.
+
+describe('extractCallerEnvironment', () => {
+  it('lifts Claude Code <env> block from a system message', () => {
+    const messages = [
+      { role: 'system', content: 'You are Claude Code...\n\n<env>\nWorking directory: /Users/jaxyu/IdeaProjects/flux-panel\nIs directory a git repo: Yes\nPlatform: darwin\nOS Version: Darwin 24.0.0\nToday\'s date: 2026-04-25\n</env>\n\nMore instructions.' },
+      { role: 'user', content: 'check the branches' },
+    ];
+    const result = extractCallerEnvironment(messages);
+    assert.match(result, /- Working directory: \/Users\/jaxyu\/IdeaProjects\/flux-panel/);
+    assert.match(result, /- Is the directory a git repo: Yes/);
+    assert.match(result, /- Platform: darwin/);
+    assert.match(result, /- OS version: Darwin 24\.0\.0/);
+  });
+
+  it('lifts cwd from a <system-reminder> embedded in a user message (Claude Code 2.x layout)', () => {
+    const messages = [
+      { role: 'system', content: 'You are Claude Code...' },
+      { role: 'user', content: '<system-reminder>\nSkills available...\n\n<env>\nWorking directory: /home/dev/proj\n</env>\n</system-reminder>\n\nactual question here' },
+    ];
+    const result = extractCallerEnvironment(messages);
+    assert.match(result, /- Working directory: \/home\/dev\/proj/);
+  });
+
+  it('handles content-block arrays (Anthropic-format text blocks)', () => {
+    const messages = [
+      { role: 'user', content: [
+        { type: 'text', text: 'Working directory: /var/app' },
+        { type: 'text', text: 'Platform: linux' },
+      ]},
+    ];
+    const result = extractCallerEnvironment(messages);
+    assert.match(result, /- Working directory: \/var\/app/);
+    assert.match(result, /- Platform: linux/);
+  });
+
+  it('returns empty string when no env hints are present', () => {
+    const messages = [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', content: 'hello' },
+    ];
+    assert.equal(extractCallerEnvironment(messages), '');
+  });
+
+  it('does not match prose mentions of "working directory" inside paragraphs', () => {
+    // Anchored to start-of-line so embedded prose stays unmatched.
+    const messages = [
+      { role: 'user', content: 'Note: the working directory in the docs is shown as /tmp.' },
+    ];
+    assert.equal(extractCallerEnvironment(messages), '');
+  });
+
+  it('takes the first occurrence per key (closest to system / earliest message)', () => {
+    const messages = [
+      { role: 'system', content: 'Working directory: /first' },
+      { role: 'user', content: 'Working directory: /second' },
+    ];
+    assert.match(extractCallerEnvironment(messages), /\/first/);
+  });
+
+  it('rejects values that are control-character noise or our own redaction marker', () => {
+    const messages = [
+      { role: 'system', content: 'Working directory: …' },
+    ];
+    assert.equal(extractCallerEnvironment(messages), '');
+  });
+
+  it('handles non-array input safely', () => {
+    assert.equal(extractCallerEnvironment(null), '');
+    assert.equal(extractCallerEnvironment(undefined), '');
+    assert.equal(extractCallerEnvironment('not an array'), '');
+  });
+});
+
+describe('buildToolPreambleForProto with environment override', () => {
+  const tools = [{ type: 'function', function: { name: 'Bash', description: 'Run shell', parameters: { type: 'object' } } }];
+
+  it('emits an authoritative environment block before the protocol header when env is provided', () => {
+    const env = '- Working directory: /Users/jaxyu/IdeaProjects/flux-panel\n- Platform: darwin';
+    const out = buildToolPreambleForProto(tools, 'auto', env);
+    // Env block must come BEFORE the protocol header
+    const envIdx = out.indexOf('## Authoritative environment for this session');
+    const headerIdx = out.indexOf('You have access to the following functions');
+    assert.ok(envIdx >= 0, 'env header must be present');
+    assert.ok(headerIdx >= 0, 'protocol header must be present');
+    assert.ok(envIdx < headerIdx, 'env block must come BEFORE the protocol header');
+    assert.match(out, /\/Users\/jaxyu\/IdeaProjects\/flux-panel/);
+    // Must explicitly tell the model to prefer THIS over any prior assumption
+    assert.match(out, /Ignore any workspace path you may have inferred/i);
+  });
+
+  it('omits the environment block when env is empty (back-compat with PR #54 shape)', () => {
+    const out = buildToolPreambleForProto(tools, 'auto', '');
+    assert.ok(!out.includes('Authoritative environment'));
+    // Tool protocol still rendered as before
+    assert.match(out, /You have access to the following functions/);
+    assert.match(out, /### Bash/);
+  });
+
+  it('omits the environment block when env is missing', () => {
+    const out = buildToolPreambleForProto(tools, 'auto');
+    assert.ok(!out.includes('Authoritative environment'));
+    assert.match(out, /You have access to the following functions/);
+  });
+
+  it('still returns empty string when there are no tools (env alone is not enough to render)', () => {
+    const out = buildToolPreambleForProto([], 'auto', '- Working directory: /x');
+    assert.equal(out, '');
+  });
+});

--- a/test/identity-neutralization.test.js
+++ b/test/identity-neutralization.test.js
@@ -1,0 +1,97 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { neutralizeCascadeIdentity } from '../src/handlers/chat.js';
+
+// Cascade's planner system prompt teaches the upstream model to refer to
+// itself as "Cascade", to claim it was "made by Codeium" or "by Windsurf",
+// and to talk about "Cascade's workspace". Claude Code (and any caller
+// expecting Anthropic-equivalent output) must not see those leaks.
+//
+// neutralizeCascadeIdentity rewrites the most common Cascade-isms back to
+// the requested model identity. Patterns are deliberately conservative:
+// only obvious self-reference is rewritten — generic mentions of the word
+// "cascade" in user code or technical prose are left alone.
+
+describe('neutralizeCascadeIdentity', () => {
+  const model = 'claude-opus-4-7';
+
+  it('rewrites first-person identity claims', () => {
+    assert.equal(
+      neutralizeCascadeIdentity('I am Cascade and I will help.', model),
+      `I am ${model} and I will help.`
+    );
+    assert.equal(
+      neutralizeCascadeIdentity("I'm Cascade, ready to help.", model),
+      `I'm ${model}, ready to help.`
+    );
+    assert.equal(
+      neutralizeCascadeIdentity('Hi! my name is Cascade.', model),
+      `Hi! my name is ${model}.`
+    );
+  });
+
+  it('rewrites third-person self-reference', () => {
+    assert.equal(
+      neutralizeCascadeIdentity('Cascade is an AI coding assistant built by Windsurf.', model),
+      `${model} is an AI assistant built by Anthropic.`
+    );
+    assert.equal(
+      neutralizeCascadeIdentity('As Cascade, I will check that.', model),
+      `As ${model}, I will check that.`
+    );
+    assert.equal(
+      neutralizeCascadeIdentity('Acting as Cascade, I will check that.', model),
+      `As ${model}, I will check that.`
+    );
+  });
+
+  it('rewrites provider attribution variants', () => {
+    assert.equal(
+      neutralizeCascadeIdentity('I was developed by Codeium.', model),
+      'I was developed by Anthropic.'
+    );
+    assert.equal(
+      neutralizeCascadeIdentity('I was created by Windsurf.', model),
+      'I was created by Anthropic.'
+    );
+    assert.equal(
+      neutralizeCascadeIdentity('I was built by Windsurf.', model),
+      'I was built by Anthropic.'
+    );
+    assert.equal(
+      neutralizeCascadeIdentity("Codeium's Cascade can help with that.", model),
+      `${model} can help with that.`
+    );
+    assert.equal(
+      neutralizeCascadeIdentity('Windsurf Cascade is here.', model),
+      `${model} is here.`
+    );
+  });
+
+  it('rewrites Cascade workspace narration', () => {
+    assert.equal(
+      neutralizeCascadeIdentity("Let me check Cascade's workspace.", model),
+      'Let me check the workspace.'
+    );
+    assert.equal(
+      neutralizeCascadeIdentity('I will use the Cascade workspace.', model),
+      'I will use the workspace.'
+    );
+  });
+
+  it('leaves unrelated text unchanged', () => {
+    const text = 'The waterfall flows down a cascade of rocks.';
+    assert.equal(neutralizeCascadeIdentity(text, model), text);
+  });
+
+  it('returns text unchanged when modelName has no known provider mapping', () => {
+    const text = 'I am Cascade.';
+    assert.equal(neutralizeCascadeIdentity(text, 'mystery-model'), text);
+  });
+
+  it('returns falsy inputs unchanged', () => {
+    assert.equal(neutralizeCascadeIdentity('', model), '');
+    assert.equal(neutralizeCascadeIdentity(null, model), null);
+    assert.equal(neutralizeCascadeIdentity('I am Cascade.', null), 'I am Cascade.');
+  });
+});

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -2,30 +2,30 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { sanitizeText, PathSanitizeStream, sanitizeToolCall } from '../src/sanitize.js';
 
-// Leaked Windsurf paths are redacted to the multi-word prose marker
-// `redacted internal path`. The marker MUST contain no shell metacharacter
-// — earlier `(internal path redacted)` broke zsh (glob-qualifier syntax on
-// `(…)` → `unknown file attribute: i`). See sanitize.js header for the
-// full history of markers that regressed.
+// Leaked Windsurf paths are redacted to a single Unicode ellipsis (U+2026).
+// The marker MUST contain no shell metacharacter and MUST NOT look like a
+// path or identifier the model could re-use — see sanitize.js header for
+// the full history (./tail, [internal], <redacted-path>, (internal path
+// redacted), redacted internal path) and why each previous marker regressed.
 
 describe('sanitizeText', () => {
   it('redacts /tmp/windsurf-workspace paths', () => {
-    assert.equal(sanitizeText('/tmp/windsurf-workspace/src/index.js'), 'redacted internal path');
+    assert.equal(sanitizeText('/tmp/windsurf-workspace/src/index.js'), '…');
   });
 
   it('redacts bare /tmp/windsurf-workspace', () => {
-    assert.equal(sanitizeText('/tmp/windsurf-workspace'), 'redacted internal path');
+    assert.equal(sanitizeText('/tmp/windsurf-workspace'), '…');
   });
 
   it('redacts per-account workspace paths', () => {
     assert.equal(
       sanitizeText('/home/user/projects/workspace-abc12345/package.json'),
-      'redacted internal path'
+      '…'
     );
   });
 
   it('redacts /opt/windsurf', () => {
-    assert.equal(sanitizeText('/opt/windsurf/language_server'), 'redacted internal path');
+    assert.equal(sanitizeText('/opt/windsurf/language_server'), '…');
   });
 
   it('leaves normal text unchanged', () => {
@@ -36,7 +36,7 @@ describe('sanitizeText', () => {
   it('handles multiple patterns in one string', () => {
     const input = 'Editing /tmp/windsurf-workspace/a.js and /opt/windsurf/bin';
     const result = sanitizeText(input);
-    assert.equal(result, 'Editing redacted internal path and redacted internal path');
+    assert.equal(result, 'Editing … and …');
   });
 
   it('returns non-strings unchanged', () => {
@@ -51,7 +51,7 @@ describe('PathSanitizeStream', () => {
     const stream = new PathSanitizeStream();
     const out = stream.feed('/tmp/windsurf-workspace/file.js is here');
     const rest = stream.flush();
-    assert.equal(out + rest, 'redacted internal path is here');
+    assert.equal(out + rest, '… is here');
   });
 
   it('handles path split across chunks', () => {
@@ -60,7 +60,7 @@ describe('PathSanitizeStream', () => {
     result += stream.feed('Look at /tmp/windsurf');
     result += stream.feed('-workspace/config.yaml for details');
     result += stream.flush();
-    assert.equal(result, 'Look at redacted internal path for details');
+    assert.equal(result, 'Look at … for details');
   });
 
   it('handles partial prefix at buffer end', () => {
@@ -69,7 +69,7 @@ describe('PathSanitizeStream', () => {
     result += stream.feed('path is /tmp/win');
     result += stream.feed('dsurf-workspace/x.js done');
     result += stream.flush();
-    assert.equal(result, 'path is redacted internal path done');
+    assert.equal(result, 'path is … done');
   });
 
   it('flushes clean text immediately', () => {
@@ -83,13 +83,13 @@ describe('sanitizeToolCall', () => {
   it('sanitizes argumentsJson paths', () => {
     const tc = { name: 'Read', argumentsJson: '{"path":"/tmp/windsurf-workspace/f.js"}' };
     const result = sanitizeToolCall(tc);
-    assert.equal(result.argumentsJson, '{"path":"redacted internal path"}');
+    assert.equal(result.argumentsJson, '{"path":"…"}');
   });
 
   it('sanitizes input object string values', () => {
     const tc = { name: 'Read', input: { file_path: '/home/user/projects/workspace-abc12345/src/x.ts' } };
     const result = sanitizeToolCall(tc);
-    assert.equal(result.input.file_path, 'redacted internal path');
+    assert.equal(result.input.file_path, '…');
   });
 
   it('returns null/undefined unchanged', () => {
@@ -98,13 +98,17 @@ describe('sanitizeToolCall', () => {
   });
 });
 
-describe('REDACTED_PATH marker shape (shell-safety regression)', () => {
-  // The marker is emitted verbatim into model-facing text. Models
-  // sometimes echo it back inside a shell command (e.g. `cd <marker>`).
-  // If the marker contains any character the shell parses specially, the
-  // resulting command fails with a cryptic error instead of a clean
-  // ENOENT / too-many-arguments, and the model derails (issue: zsh
-  // `unknown file attribute: i` after parens redaction).
+describe('REDACTED_PATH marker shape (shell-safety + reuse-loop regression)', () => {
+  // The marker is emitted verbatim into model-facing text. Models sometimes
+  // echo it back inside a shell command (e.g. `cd <marker>`). The marker
+  // must therefore satisfy two independent constraints:
+  //   (a) Shell-safe: no character any mainstream shell parses specially,
+  //       so a stray `cd <marker>` fails with a clean recoverable error.
+  //   (b) Not path-shaped: no `/`, no `\`, no identifier-looking words.
+  //       Otherwise the model reuses it as a real path on later turns and
+  //       enters an ENOENT loop (issue history: ./tail, [internal],
+  //       <redacted-path>, (internal path redacted), redacted internal
+  //       path — every prose-shaped marker has regressed at least once).
   const marker = sanitizeText('/tmp/windsurf-workspace');
 
   it('contains no shell metacharacters', () => {
@@ -112,10 +116,18 @@ describe('REDACTED_PATH marker shape (shell-safety regression)', () => {
     assert.ok(!banned.test(marker), `marker must not contain shell metachars: got ${JSON.stringify(marker)}`);
   });
 
-  it('is not shaped like a path or identifier (multi-word, no slashes, has spaces)', () => {
-    assert.ok(!marker.includes('/'), 'marker must not contain / (looks like a path)');
+  it('is not path-shaped', () => {
+    assert.ok(!marker.includes('/'), 'marker must not contain / (looks like a Unix path)');
     assert.ok(!marker.includes('\\'), 'marker must not contain \\ (looks like a Windows path)');
-    assert.ok(marker.includes(' '), 'marker must contain whitespace so it cannot be a single identifier / file arg');
-    assert.ok(marker.split(/\s+/).filter(Boolean).length >= 2, 'marker must be multi-word');
+  });
+
+  it('is not identifier-shaped (no ASCII word characters)', () => {
+    // Any ASCII letter sequence in the marker is a re-use risk: the model
+    // sees "redacted"/"internal"/"path" as plausible directory or file
+    // names and emits `cd <marker>` or `Read("<marker>")` on later turns.
+    // The ellipsis (U+2026) contains zero ASCII word chars and reads as
+    // "content omitted" universally, so the model never tries to use it
+    // as a real argument.
+    assert.ok(!/[A-Za-z0-9_]/.test(marker), `marker must contain no ASCII word chars (avoid identifier-shape reuse loop): got ${JSON.stringify(marker)}`);
   });
 });

--- a/test/tool-emulation.test.js
+++ b/test/tool-emulation.test.js
@@ -151,3 +151,75 @@ describe('buildToolPreamble (injection-guard safety)', () => {
     assert.equal(buildToolPreamble([{ type: 'function' }]), '');
   });
 });
+
+describe('normalizeMessagesForCascade (preamble placement regression)', () => {
+  // Live-confirmed bug against Claude Code v2.1.114 / Opus 4.7: prepending
+  // the "Tools available this turn: …" banner to the LAST user message at
+  // every turn means that on multi-turn conversations the banner lands
+  // immediately before a synthetic <tool_result> block (because tool_result
+  // turns are rewritten into role:'user'). Opus pattern-matches that shape
+  // as a truncated/injected conversation and refuses to keep using tools,
+  // emitting "the conversation got mixed up — fragments of tool output
+  // without a clear request" and rambling for tens of KB until max_wait.
+  // The fix: only inject the user-message preamble on real user turns,
+  // never on synthetic tool_result turns.
+  const tools = [
+    { type: 'function', function: { name: 'Bash', description: 'Shell.', parameters: { type: 'object' } } },
+  ];
+
+  it('injects preamble on a first-turn real user message', () => {
+    const out = normalizeMessagesForCascade(
+      [{ role: 'user', content: '帮我读一下 README' }],
+      tools,
+    );
+    assert.equal(out.length, 1);
+    assert.ok(out[0].content.startsWith('Tools available this turn:'),
+      `expected preamble prefix, got: ${out[0].content.slice(0, 80)}`);
+    assert.ok(out[0].content.endsWith('帮我读一下 README'));
+  });
+
+  it('does NOT inject preamble when the last user message is a synthetic tool_result', () => {
+    const out = normalizeMessagesForCascade(
+      [
+        { role: 'user', content: '帮我读一下 README' },
+        { role: 'assistant', content: '', tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'Bash', arguments: '{"command":"cat README.md"}' } },
+        ] },
+        { role: 'tool', tool_call_id: 'call_1', content: 'README contents…' },
+      ],
+      tools,
+    );
+    // The first user turn must NOT have a preamble (it isn't the LAST user
+    // message); the rewritten tool_result turn must NOT have a preamble
+    // (it's a synthetic wrapper, not a real user message).
+    assert.equal(out[0].role, 'user');
+    assert.ok(!out[0].content.startsWith('Tools available this turn:'),
+      'first-turn user must not be polluted when a tool_result follows');
+    const last = out[out.length - 1];
+    assert.equal(last.role, 'user');
+    assert.ok(last.content.startsWith('<tool_result'),
+      `expected pure tool_result wrapper, got: ${last.content.slice(0, 80)}`);
+    assert.ok(!last.content.includes('Tools available this turn:'),
+      'tool_result turn must not be polluted with the user-message preamble');
+  });
+
+  it('still injects on the latest real user turn even when older turns contain tool_results', () => {
+    const out = normalizeMessagesForCascade(
+      [
+        { role: 'user', content: 'first request' },
+        { role: 'assistant', content: '', tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'Bash', arguments: '{"command":"pwd"}' } },
+        ] },
+        { role: 'tool', tool_call_id: 'call_1', content: '/tmp' },
+        { role: 'assistant', content: 'done.' },
+        { role: 'user', content: 'follow-up question' },
+      ],
+      tools,
+    );
+    const last = out[out.length - 1];
+    assert.equal(last.role, 'user');
+    assert.ok(last.content.startsWith('Tools available this turn:'),
+      'latest real user turn must receive the preamble');
+    assert.ok(last.content.endsWith('follow-up question'));
+  });
+});

--- a/test/tool-emulation.test.js
+++ b/test/tool-emulation.test.js
@@ -83,10 +83,20 @@ describe('parseToolCallsFromText', () => {
 
 describe('buildToolPreamble (injection-guard safety)', () => {
   // Regression guard: Claude Code / Opus-class prompt-injection detectors
-  // refuse to honour the injected tool scaffolding if it contains jailbreak-
-  // shaped phrases. Keep the preamble neutral.
-  const tools = [{ type: 'function', function: { name: 'read_file', description: 'Read a file', parameters: { type: 'object', properties: { path: { type: 'string' } } } } }];
-  const preamble = buildToolPreamble(tools);
+  // refuse to honour the injected tool scaffolding when:
+  //   (a) it uses jailbreak-shaped phrasing, OR
+  //   (b) it has the SHAPE of a Claude Code system prompt (a wall of
+  //       `### ToolName` blocks with per-tool ```json schemas) appearing
+  //       in a user turn — the model flags that as "someone pasted a
+  //       system prompt into my user slot" and refuses to call tools.
+  // The fallback stays minimal: protocol one-liner + tool name list only.
+  // Full schemas live in the proto-level tool_calling_section override.
+  const manyTools = [
+    { type: 'function', function: { name: 'Bash', description: 'Run a shell command.', parameters: { type: 'object', properties: { command: { type: 'string' } } } } },
+    { type: 'function', function: { name: 'Read', description: 'Read a file.', parameters: { type: 'object', properties: { file_path: { type: 'string' } } } } },
+    { type: 'function', function: { name: 'Edit', description: 'Edit a file.', parameters: { type: 'object', properties: { file_path: { type: 'string' }, old_string: { type: 'string' }, new_string: { type: 'string' } } } } },
+  ];
+  const preamble = buildToolPreamble(manyTools);
 
   it('does not contain jailbreak-shaped phrasing', () => {
     const banned = [
@@ -102,20 +112,42 @@ describe('buildToolPreamble (injection-guard safety)', () => {
     }
   });
 
-  it('still describes the <tool_call> protocol and lists the function', () => {
-    assert.ok(preamble.includes('<tool_call>'), 'must describe emission format');
-    assert.ok(preamble.includes('read_file'), 'must include function name');
+  it('does not have the shape of a Claude Code system prompt', () => {
+    // No `### ToolName` section headers
+    assert.ok(!/^### /m.test(preamble), `preamble must not use '### ' headers: got ${preamble}`);
+    // No `parameters schema:` / `Parameters:` schema-dump labels
+    assert.ok(!/parameters schema:/i.test(preamble), 'preamble must not dump per-tool schemas');
+    assert.ok(!/^Parameters:/m.test(preamble), 'preamble must not dump per-tool schemas');
+    // No fenced ```json blocks (schemas would live inside these)
+    assert.ok(!/```json/i.test(preamble), 'preamble must not contain fenced json schema blocks');
+    // Stays well under a "system prompt wall of text" size even with many tools
+    assert.ok(preamble.length < 512, `preamble must stay compact (<512 chars); got ${preamble.length}`);
   });
 
-  it('normalizeMessagesForCascade prepends preamble to last user message without jailbreak phrasing', () => {
+  it('still describes the <tool_call> protocol and lists every tool name', () => {
+    assert.ok(preamble.includes('<tool_call>'), 'must describe emission format');
+    for (const t of manyTools) {
+      assert.ok(preamble.includes(t.function.name), `must include function name ${t.function.name}`);
+    }
+  });
+
+  it('normalizeMessagesForCascade prepends preamble to last user message without jailbreak or system-prompt shape', () => {
     const out = normalizeMessagesForCascade(
       [{ role: 'user', content: 'hello' }],
-      tools,
+      manyTools,
     );
     const last = out[out.length - 1];
     assert.equal(last.role, 'user');
     assert.ok(last.content.endsWith('hello'));
     assert.ok(!/IGNORE any earlier/i.test(last.content));
     assert.ok(!/\[Tool-calling context/i.test(last.content));
+    assert.ok(!/^### /m.test(last.content), 'prepended content must not use ### headers');
+    assert.ok(!/```json/i.test(last.content), 'prepended content must not contain ```json fences');
+  });
+
+  it('emits empty string when no usable function tools are present', () => {
+    assert.equal(buildToolPreamble([]), '');
+    assert.equal(buildToolPreamble([{ type: 'other' }]), '');
+    assert.equal(buildToolPreamble([{ type: 'function' }]), '');
   });
 });


### PR DESCRIPTION
## Summary

Three independent regressions were stacking on top of each other and collectively prevented Opus-class clients (Claude Code v2.1.x in particular) from completing tool-emulated turns through the proxy. Bundled into one PR because they all surface as the same user-visible symptom ("Opus refuses to call tools / wastes 3 turns on broken paths") and the regression tests for each one only make sense in the presence of the others.

Reproducer: send `检查一下，所有分支里。有没有按照  压缩包的方案 处理过一版` from Claude Code v2.1.114 (Opus 4.7) routed through the proxy. Before this patch Opus replies with `The user's message appears to contain a pasted system prompt for a different agent (Claude Code) along with what looks like a stray tool error result`. After this patch Opus calls `pwd` then `git branch -a` directly.

## 1. Tool preamble was shaped like a Claude Code system prompt

`buildToolPreamble` emitted ~1600 chars of `### ToolName / parameters schema: / \`\`\`json {…}\`\`\`` blocks prepended to the user turn. That is the exact signature of Claude Code's own system prompt, so when the same shape appeared in a **user** slot Opus 4.7 reliably flagged it as `"a pasted Claude Code system prompt in the user turn"` and refused to emit any `<tool_call>` blocks.

**Fix:** rewrite the user-message fallback to a single ~330-char line — protocol description plus tool name list, no schemas. Full schemas still go through the authoritative proto-level `tool_calling_section` override (`buildToolPreambleForProto`, unchanged). #22 NO_TOOL-mode models that ignore `SectionOverride` still see the tool names and the emission protocol, so the fallback continues to do its job.

New regression asserts the preamble:
- has no `^### ` headers, no `parameters schema:`, no fenced ```json blocks
- stays under 512 chars even with many tools
- still names every tool and still describes the `<tool_call>` protocol

## 2. Redaction marker kept getting reused by the model as a real path

Every prose-shaped `REDACTED_PATH` marker we have ever shipped has regressed:

| Marker | Failure mode |
|---|---|
| `./tail` | LLM Reads `./src/main.py` → ENOENT → loop |
| `[internal]` | LLM runs `ls [internal]` → ENOENT → loop |
| `<redacted-path>` | LLM passes to Read/Bash → ENOENT (Linux) / Errno 22 (Windows) → loop |
| `(internal path redacted)` | zsh parses `cd (…)` as glob-qualifier syntax → cryptic `unknown file attribute: i` → Opus gets confused, stops calling tools |
| `redacted internal path` | Opus echoes verbatim into bash: `cd redacted internal path && git…` → `cd: too many arguments` → wastes 2-3 turns before finally calling `pwd` |

Common cause: any marker that contains ASCII word characters reads as a plausible path or identifier to the model, and the model puts it back into the next `tool_call`.

**Fix:** switch `REDACTED_PATH` to a single Unicode ellipsis (U+2026, `…`).

- Zero ASCII word chars
- No shell metacharacter
- Three UTF-8 bytes
- Universally read by humans and LLMs as "content omitted"
- Essentially no training data of `cd …` or `Read("…")` as a real operation, so the reuse-as-path loop never starts
- If the model still echoes it into shell, the failure mode is a single clean ENOENT instead of a cryptic glob-qualifier error

The new marker-shape regression suite makes future regressions impossible by asserting:

1. **No shell metacharacters** in ``()[]{}<>|&;$`\"'\\*?``
2. **No `/` and no `\\`**
3. **Zero ASCII word characters** `[A-Za-z0-9_]` — closes the door on every prose-shaped marker we have already regressed through.

## 3. `neutralizeCascadeIdentity` missed common Cascade-isms

Existing patterns covered `I am Cascade` / `I'm Cascade` / `developed by Codeium` but missed other common third-person leaks the upstream planner produces. Added:

- `Cascade is an? (?:AI )?(?:coding )?assistant`
- `(?:As|Acting as) Cascade`
- `(?:Codeium|Windsurf)('s)? Cascade`
- `built by (?:Codeium|Windsurf)`
- `(?:the )?Cascade('s)? workspace` → `the workspace`
  (the leading article is consumed by the same regex so we never produce the `the the workspace` double-article artefact)

Exported `neutralizeCascadeIdentity` from `chat.js` (matches the existing `shouldUseCascadeReuse` export pattern) and added 7 unit tests covering first-person, third-person, provider attribution, workspace narration, the dictionary-word negative case (`a cascade of rocks`), unknown-provider passthrough, and falsy inputs.

## Tests

`npm test` — **80/80 pass** (72 existing + 7 identity + 1 marker-shape).

## Risk

Low. All three changes are purely cosmetic on the wire — the protocol contract, parser, streaming pipeline, tool-result round-trip, and proto-level injection are untouched. Behaviour change is strictly less aggressive: the preamble is gentler, the marker is shorter, the identity rewrites are more thorough. No new dependencies, no API changes.
