### PR TITLE
fix: resolve nginx shared memory error and missing join import

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -26,7 +26,8 @@ http {
         # But 'hash' works better with explicit servers or using a DNS resolver dynamically if needed.
         # Nginx free version requires manual IP listings for sticky sessions, 
         # or we rely on ip_hash for generic load balancing if behind a single reverse proxy.
-        server windsurf-api:3003 resolve;
+        zone windsurf_backend_zone 64k;
+	server windsurf-api:3003 resolve;
     }
 
     server {

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, mkdirSync } from 'fs';
-import { resolve, dirname } from 'path';
+import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
<!-- 感谢贡献 / Thanks for contributing -->

## 改了什么 / What changed

- 在 `nginx.conf` 的 `upstream windsurf_backend` 块中添加 `zone` 指令，分配共享内存区域
- 在 `src/config.js` 顶部补充 `import { join } from 'path';` 语句

<!-- 一两句话说明 / One or two sentences -->

## 为什么 / Why

<!-- 修哪个 bug 加哪个功能 关联 issue #xx / Which bug / feature / issue does this address? -->

修复部署后所有 Windsurf 相关容器（`windsurf-lb` 和三个 `windsurfapi-windsurf-api` 副本）持续重启的问题。

- **Nginx**：当 `upstream` 中使用 `server … resolve` 动态解析后端地址时，Nginx 要求通过 `zone` 指令显式分配共享内存，否则报错 `resolving names at run time requires upstream … to be in shared memory`
- **API 服务**：`config.js` 中直接使用了 `join()`，但未从 `path` 模块导入，导致 `ReferenceError: join is not defined`，进程启动失败

~~这么简单的问题，难道没人用docker吗？~~

## 测试 / Testing

<!-- 怎么验证改对了 / How did you verify it works?
     例子 / examples:
     - curl -X POST localhost:3003/v1/chat/completions -d '...' 返回了正确的 ...
     - dashboard 面板手动点了 ...
     - 没跑自动测试（项目暂无测试套件） -->

`docker-compose up --build -d`后所有容器状态正常，不再处于 `Restarting` 循环

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies (project is zero-dep)
- [x] 涉及 LS binary 协议改动时 在 PR 描述里注明字段号来源 / If touching LS protocol, document field-number source in the PR description
- [x] 涉及 dashboard UI 用 App.confirm / App.prompt 不用浏览器原生 alert/confirm / Uses App.confirm / App.prompt, not native dialogs (if dashboard)
