### PR TITLE
fix(dashboard): 修复 Credits 文案导致控制台空白

### DIFF
--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -4731,7 +4731,7 @@ const App = {
       weightLabel: '第四次出手 · 三件事打包修',
       mergedAt: '2026-04-25',
       title: 'fix: bring Claude Code tool-call flow back to Anthropic-equivalent behaviour',
-      summary: '一个 PR 解了三个独立 regression。① tool preamble 从 1600 字符瘦身到 330 字符 —— 老版本的 ### Tool / parameters schema: / ```json {…} 形态正是 Claude Code 自家 system prompt 的指纹，出现在 user 槽位时 Opus 4.7 会判 "pasted system prompt" 拒答。② redact 标记升到第 6 代单字符 U+2026 省略号 `…`：第 5 代 redacted internal path 仍被 Opus 塞进 cd redacted internal path && git ... 浪费 2-3 turn；新 marker 0 ASCII word char + 0 shell 元字符 + 训练数据里没 cd … 当真路径的样本，模型不会再当参数用。③ neutralizeCascadeIdentity 加 5 个新 pattern（Cascade is an? AI assistant / As Cascade / Codeium\\'s Cascade / built by Codeium / Cascade\\'s workspace），漏网的 Cascade 自称口吻全部封死。回归套装含 banned-shape regex 锁死未来不会再倒退到含 ASCII 字符的 marker。',
+      summary: '一个 PR 解了三个独立 regression。① tool preamble 从 1600 字符瘦身到 330 字符 —— 老版本的 ### Tool / parameters schema: / ```json {…} 形态正是 Claude Code 自家 system prompt 的指纹，出现在 user 槽位时 Opus 4.7 会判 "pasted system prompt" 拒答。② redact 标记升到第 6 代单字符 U+2026 省略号 `…`：第 5 代 redacted internal path 仍被 Opus 塞进 cd redacted internal path && git ... 浪费 2-3 turn；新 marker 0 ASCII word char + 0 shell 元字符 + 训练数据里没 cd … 当真路径的样本，模型不会再当参数用。③ neutralizeCascadeIdentity 加 5 个新 pattern（Cascade is an? AI assistant / As Cascade / Codeium\'s Cascade / built by Codeium / Cascade\'s workspace），漏网的 Cascade 自称口吻全部封死。回归套装含 banned-shape regex 锁死未来不会再倒退到含 ASCII 字符的 marker。',
     },
     {
       login: 'aict666',

--- a/test/dashboard-syntax.test.js
+++ b/test/dashboard-syntax.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+test('dashboard inline scripts are syntactically valid', () => {
+  const html = readFileSync(join(root, 'src/dashboard/index.html'), 'utf8');
+  const scripts = [...html.matchAll(/<script([^>]*)>([\s\S]*?)<\/script>/gi)]
+    .map((match, index) => ({ index, attrs: match[1] || '', source: match[2] || '' }))
+    .filter(({ attrs }) => !/\bsrc\s*=/.test(attrs))
+    .filter(({ attrs }) => !/\btype\s*=\s*["']module["']/i.test(attrs));
+
+  assert.ok(scripts.length > 0, 'expected at least one non-module inline script');
+  for (const { index, source } of scripts) {
+    assert.doesNotThrow(() => new Function(source), `inline script #${index} should parse`);
+  }
+});


### PR DESCRIPTION
## 解决的问题

最新 Credits 贡献者文案里出现了过度转义的 `Codeium\\'s` / `Cascade\\'s`。在单引号 JS 字符串里这会变成语法错误，导致 dashboard 主脚本整体不执行，表现为控制台能打开但 stats 等页面没有任何数据。

## 修复内容

- 修正 Credits 文案里的单引号转义，恢复 dashboard 主脚本解析。
- 新增 dashboard inline script 语法回归测试，后续类似文案/转义问题会在 `npm test` 阶段失败。

## 验证

- `npm test`：106 pass。