### PR TITLE
ci: add release workflow (Docker + GitHub Release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,8 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=latest
+            # Only tag as latest for stable releases (no pre-release suffix like -rc, -alpha, -beta)
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
             # v2.0.6 -> 2.0.6
             type=semver,pattern={{version}}
             # v2.0.6 -> 2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  # ──────────────────────────────────────────────
+  # Job 1: Build & Push Docker Image (GHCR)
+  # ──────────────────────────────────────────────
+  docker:
+    name: Docker Build & Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            # v2.0.6 -> 2.0.6
+            type=semver,pattern={{version}}
+            # v2.0.6 -> 2.0
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "## 🐳 Docker Image Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Tags:**" >> "$GITHUB_STEP_SUMMARY"
+          echo '${{ steps.meta.outputs.tags }}' | tr ',' '\n' | sed 's/^/- `/' | sed 's/$/`/' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Platform:** \`linux/amd64\`" >> "$GITHUB_STEP_SUMMARY"
+
+  # ──────────────────────────────────────────────
+  # Job 2: Create GitHub Release with source code
+  # ──────────────────────────────────────────────
+  release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Check for release notes
+        id: notes
+        run: |
+          NOTES_FILE="RELEASE_NOTES_${{ steps.version.outputs.VERSION }}.md"
+          if [[ -f "$NOTES_FILE" ]]; then
+            echo "file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: v${{ steps.version.outputs.VERSION }}
+          body_path: ${{ steps.notes.outputs.found == 'true' && steps.notes.outputs.file || '' }}
+          generate_release_notes: ${{ steps.notes.outputs.found != 'true' }}
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   windsurf-api:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/dwgx/windsurf-api:latest
     # Remove container_name to allow Compose to scale replicas
     restart: unless-stopped
     init: true

--- a/nginx.conf
+++ b/nginx.conf
@@ -27,7 +27,7 @@ http {
         # Nginx free version requires manual IP listings for sticky sessions, 
         # or we rely on ip_hash for generic load balancing if behind a single reverse proxy.
         zone windsurf_backend_zone 64k;
-	server windsurf-api:3003 resolve;
+        server windsurf-api:3003 resolve;
     }
 
     server {


### PR DESCRIPTION
<!-- 感谢贡献 / Thanks for contributing -->

## 改了什么 / What changed

<!-- 一两句话说明 / One or two sentences -->

新增 `.github/workflows/release.yml`，仅在推送 `v*` tag 时触发，自动完成两件事：
1. **Docker 镜像构建 & 推送** — 构建 `linux/amd64` 镜像并推送到 GHCR (`ghcr.io`)
2. **GitHub Release 创建** — 自动创建 Release 页面，附带 Source code (zip/tar.gz) 下载

同时将 `docker-compose.yml` 从本地构建 (`build:`) 改为拉取预构建镜像 (`image: ghcr.io/dwgx/windsurf-api:latest`)，用户无需 clone 代码即可部署。

## 为什么 / Why

<!-- 修哪个 bug 加哪个功能 关联 issue #xx / Which bug / feature / issue does this address? -->

- 项目缺少 CI/CD 自动发布流程，每次发版需要手动构建 Docker 镜像和创建 Release
- 用户部署时需要本地 clone 代码再 `docker compose build`，改为直接 `docker pull` 更方便

~~我有强迫症，用了docker 就不想下载源码，作者按需合并吧~~

## 测试 / Testing

<!-- 怎么验证改对了 / How did you verify it works? -->

- 在 fork 仓库推送 `vtest` tag 触发 workflow，两个 job 均成功通过
- Docker 镜像成功推送到 GHCR (`ghcr.io/abwuge/windsurf-api:latest`)
- GitHub Release 页面成功创建，release notes 正确读取
- 测试完成后已清理 `vtest` tag 和对应 Release

## ⚠️ 合并后注意 / Post-merge notes

> 没什么注意的，push 下一个 tag 就自动发布好了

### 发版流程
```bash
git tag v2.0.7
git push origin v2.0.7
```
- 仓库中存在 `RELEASE_NOTES_2.0.7.md` → 自动作为 Release body
- 不存在 → 自动生成 changelog
- tag 含 `-`，例如 `-alpha` / `-beta` / `-rc` → 自动标记为 Pre-release

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies (project is zero-dep)
- [x] 涉及 LS binary 协议改动时 在 PR 描述里注明字段号来源 / If touching LS protocol, document field-number source in the PR description
- [x] 涉及 dashboard UI 用 App.confirm / App.prompt 不用浏览器原生 alert/confirm / Uses App.confirm / App.prompt, not native dialogs (if dashboard)
