### PR TITLE
fix: fall back to compact tool preamble before rejecting oversized tool payloads

### DIFF
--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -80,6 +80,81 @@ export function chatStreamError(message, type = 'upstream_error', code = null) {
   return { error: { message: sanitizeText(message || 'Upstream stream error'), type, code } };
 }
 
+export function applyToolPreambleBudget(toolPreamble, tools, toolChoice, callerEnv, limits = {}) {
+  const softBytes = parseInt(
+    limits.softBytes ?? process.env.TOOL_PREAMBLE_SOFT_BYTES ?? '24000',
+    10,
+  );
+  const hardBytes = parseInt(
+    limits.hardBytes ?? process.env.TOOL_PREAMBLE_HARD_BYTES ?? '48000',
+    10,
+  );
+  const full = typeof toolPreamble === 'string' ? toolPreamble : '';
+  const fullBytes = Buffer.byteLength(full, 'utf8');
+
+  if (!full) {
+    return {
+      toolPreamble: full,
+      fullBytes,
+      compact: '',
+      compactBytes: 0,
+      softBytes,
+      hardBytes,
+      decision: 'none',
+    };
+  }
+
+  if (fullBytes <= softBytes) {
+    return {
+      toolPreamble: full,
+      fullBytes,
+      compact: '',
+      compactBytes: 0,
+      softBytes,
+      hardBytes,
+      decision: 'full',
+    };
+  }
+
+  const compact = buildCompactToolPreambleForProto(tools || [], toolChoice, callerEnv);
+  const compactBytes = Buffer.byteLength(compact, 'utf8');
+  const compactUsable = !!compact && compactBytes > 0 && compactBytes <= hardBytes && compactBytes < fullBytes;
+
+  if (compactUsable) {
+    return {
+      toolPreamble: compact,
+      fullBytes,
+      compact,
+      compactBytes,
+      softBytes,
+      hardBytes,
+      decision: 'compact',
+    };
+  }
+
+  if (fullBytes <= hardBytes) {
+    return {
+      toolPreamble: full,
+      fullBytes,
+      compact,
+      compactBytes,
+      softBytes,
+      hardBytes,
+      decision: 'full_over_soft',
+    };
+  }
+
+  return {
+    toolPreamble: full,
+    fullBytes,
+    compact,
+    compactBytes,
+    softBytes,
+    hardBytes,
+    decision: 'reject',
+  };
+}
+
 /**
  * Extract a clean JSON payload from a model response. Handles three common
  * shapes a non-constrained-decoding model produces when asked for JSON:
@@ -607,17 +682,20 @@ export async function handleChatCompletions(body, context = {}) {
   // knows what tools exist and how to invoke them, just not parameter
   // shapes. Past the hard cap we abort with a 413-style 400 so callers
   // can trim instead of failing in panel-state retries.
-  const TOOL_PREAMBLE_SOFT_BYTES = parseInt(process.env.TOOL_PREAMBLE_SOFT_BYTES || '24000', 10);
-  const TOOL_PREAMBLE_HARD_BYTES = parseInt(process.env.TOOL_PREAMBLE_HARD_BYTES || '48000', 10);
   if (emulateTools && toolPreamble) {
-    const fullBytes = Buffer.byteLength(toolPreamble, 'utf8');
-    if (fullBytes > TOOL_PREAMBLE_HARD_BYTES) {
-      log.warn(`Probe[${reqId}]: toolPreamble ${Math.round(fullBytes / 1024)}KB exceeds hard cap ${Math.round(TOOL_PREAMBLE_HARD_BYTES / 1024)}KB; rejecting (${(tools || []).length} tools)`);
+    const budget = applyToolPreambleBudget(toolPreamble, tools || [], tool_choice, callerEnv);
+    if (budget.decision === 'reject') {
+      const compactInfo = budget.compactBytes
+        ? `; compact fallback still ${Math.round(budget.compactBytes / 1024)}KB`
+        : '; compact fallback unavailable';
+      log.warn(
+        `Probe[${reqId}]: toolPreamble ${Math.round(budget.fullBytes / 1024)}KB exceeds hard cap ${Math.round(budget.hardBytes / 1024)}KB${compactInfo}; rejecting (${(tools || []).length} tools)`,
+      );
       return {
         status: 400,
         body: {
           error: {
-            message: `Tool definitions are too large (${Math.round(fullBytes / 1024)}KB > ${Math.round(TOOL_PREAMBLE_HARD_BYTES / 1024)}KB). Reduce the number of tools or shorten parameter schemas.`,
+            message: `Tool definitions are too large (${Math.round(budget.fullBytes / 1024)}KB > ${Math.round(budget.hardBytes / 1024)}KB). Reduce the number of tools or shorten parameter schemas.`,
             type: 'invalid_request_error',
             param: 'tools',
             code: 'tool_preamble_too_large',
@@ -625,11 +703,15 @@ export async function handleChatCompletions(body, context = {}) {
         },
       };
     }
-    if (fullBytes > TOOL_PREAMBLE_SOFT_BYTES) {
-      const compact = buildCompactToolPreambleForProto(tools || [], tool_choice, callerEnv);
-      const compactBytes = Buffer.byteLength(compact, 'utf8');
-      log.warn(`Probe[${reqId}]: toolPreamble ${Math.round(fullBytes / 1024)}KB exceeds soft cap ${Math.round(TOOL_PREAMBLE_SOFT_BYTES / 1024)}KB; falling back to names-only preamble (${Math.round(compactBytes / 1024)}KB, ${(tools || []).length} tools)`);
-      toolPreamble = compact;
+    if (budget.decision === 'compact') {
+      log.warn(
+        `Probe[${reqId}]: toolPreamble ${Math.round(budget.fullBytes / 1024)}KB exceeds soft/hard budget; falling back to names-only preamble (${Math.round(budget.compactBytes / 1024)}KB, ${(tools || []).length} tools)`,
+      );
+      toolPreamble = budget.toolPreamble;
+    } else if (budget.decision === 'full_over_soft') {
+      log.warn(
+        `Probe[${reqId}]: toolPreamble ${Math.round(budget.fullBytes / 1024)}KB exceeds soft cap ${Math.round(budget.softBytes / 1024)}KB, but compact fallback was not smaller/usable; keeping full preamble (${(tools || []).length} tools)`,
+      );
     }
   }
   // Diagnostic: surface whether environment lifting actually fired so a real

--- a/test/chat-tool-preamble-budget.test.js
+++ b/test/chat-tool-preamble-budget.test.js
@@ -1,0 +1,51 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyToolPreambleBudget } from '../src/handlers/chat.js';
+import { buildToolPreambleForProto } from '../src/handlers/tool-emulation.js';
+
+describe('applyToolPreambleBudget', () => {
+  const bigTools = Array.from({ length: 30 }, (_, i) => ({
+    type: 'function',
+    function: {
+      name: `tool_${i}`,
+      description: `Description for tool ${i} that goes on for a while to bulk up the schema.`,
+      parameters: {
+        type: 'object',
+        properties: Object.fromEntries(
+          Array.from({ length: 15 }, (_, j) => [`param_${j}`, {
+            type: 'string',
+            description: `Parameter ${j} of tool ${i}, with verbose explanation that runs long.`,
+            enum: ['option_a', 'option_b', 'option_c', 'option_d', 'option_e'],
+          }]),
+        ),
+        required: Array.from({ length: 15 }, (_, j) => `param_${j}`),
+      },
+    },
+  }));
+
+  it('falls back to compact preamble before rejecting when full schema exceeds the hard cap', () => {
+    const full = buildToolPreambleForProto(bigTools, 'auto');
+    const result = applyToolPreambleBudget(full, bigTools, 'auto', '- Working directory: /repo', {
+      softBytes: 24_000,
+      hardBytes: 48_000,
+    });
+
+    assert.equal(result.decision, 'compact');
+    assert.ok(result.fullBytes > result.hardBytes, `expected fullBytes > hardBytes, got ${result.fullBytes} <= ${result.hardBytes}`);
+    assert.ok(result.compactBytes > 0 && result.compactBytes <= result.hardBytes, `expected compactBytes <= hardBytes, got ${result.compactBytes}`);
+    assert.ok(result.toolPreamble.includes('Available functions:'));
+    assert.ok(!result.toolPreamble.includes('param_0'), 'compact preamble must omit parameter schema details');
+  });
+
+  it('rejects only when neither full nor compact form fits within the hard cap', () => {
+    const full = buildToolPreambleForProto(bigTools, 'auto');
+    const result = applyToolPreambleBudget(full, bigTools, 'auto', '- Working directory: /repo', {
+      softBytes: 1,
+      hardBytes: 512,
+    });
+
+    assert.equal(result.decision, 'reject');
+    assert.ok(result.fullBytes > result.hardBytes);
+    assert.ok(result.compactBytes > result.hardBytes, `expected compact fallback to exceed hard cap, got ${result.compactBytes}`);
+  });
+});


### PR DESCRIPTION
## 问题

最近引入的 tool preamble 预算逻辑会在 **完整 tool 定义** 超过 hard cap 时直接返回：

```json
{
  "type": "error",
  "error": {
    "type": "invalid_request_error",
    "message": "Tool definitions are too large (74KB > 47KB). Reduce the number of tools or shorten parameter schemas."
  }
}
```

在 Claude Code / opencode / Cline 这类客户端里，首轮请求通常会附带 20+ 个工具和较大的参数 schema。这样会导致：

- **首次 prompt 直接 400**，还没进入正常对话就失败
- 用户看到的是 Claude Code 前端报错，以为服务不可用
- 代理虽然已经有 `buildCompactToolPreambleForProto()`，但这条 fallback 根本没有被用到

## 影响

这不是偶发上游错误，而是本地预算逻辑的回归：

- 只要完整 preamble 超过 hard cap，就会在入口被拒绝
- 即使 compact preamble 只有 1~2KB、完全可以继续请求，也不会尝试 fallback
- 对 Claude Code 影响尤其明显，因为它默认会携带完整工具定义，用户在升级到最新版本后会在**第一条消息**就遇到 400

## 根因

当前逻辑顺序是：

1. 先计算 full preamble 大小
2. `full > hard cap` 时直接 `tool_preamble_too_large`
3. 只有 `full > soft cap && full <= hard cap` 时才会走 compact fallback

也就是说，**最需要 compact fallback 的场景反而被提前 reject 了**。

## 修复

这次改动把预算决策抽成独立 helper，并改成下面的顺序：

1. `full <= soft`：继续使用完整 preamble
2. `full > soft`：先尝试 compact fallback
3. `compact <= hard`：使用 compact preamble 继续请求
4. 只有 `full` 和 `compact` 都超过 hard cap 时，才返回 400

这样可以保证：

- 大工具集请求优先降级到 names-only compact preamble
- 只有真正塞不下时才拒绝
- Claude Code 首次 prompt 不会再因为 `74KB > 47KB` 在入口直接报错

## 验证

新增回归测试覆盖两种情况：

1. `full > hard` 且 `compact <= hard`：必须 fallback 到 compact
2. `full > hard` 且 `compact > hard`：才允许 reject

本地聚焦测试：

```bash
node --test test/chat-tool-preamble-budget.test.js test/tool-emulation.test.js
```

另外用一份 30 个工具的大请求实测，本地日志现在会出现：

```text
toolPreamble 118KB exceeds soft/hard budget; falling back to names-only preamble (1KB, 30 tools)
```

请求可以继续返回 200，而不是直接 400。
