### PR TITLE
feat: add ALLOW_PRIVATE_PROXY_HOSTS config for local proxy testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,9 @@ CODEIUM_API_URL=https://server.self-serve.windsurf.com
 DEFAULT_MODEL=claude-4.5-sonnet-thinking
 MAX_TOKENS=8192
 LOG_LEVEL=info
+
+# ========== Security ==========
+# Allow private/internal hosts (e.g., 192.168.x.x, 10.x.x.x, localhost) in proxy tests.
+# Set to 1 for local deployments where you need to test proxies on private networks.
+# Leave empty or set to 0 for public-facing deployments (default: only public hosts allowed).
+ALLOW_PRIVATE_PROXY_HOSTS=

--- a/README.en.md
+++ b/README.en.md
@@ -268,6 +268,7 @@ In your client's settings for **Custom OpenAI Compatible**:
 | `LS_PORT` | `42100` | LS gRPC port. |
 | `LS_DATA_DIR` | `/opt/windsurf` | Per-proxy LS data directory root. |
 | `DASHBOARD_PASSWORD` | empty | Dashboard password. Leave empty for no password. |
+| `ALLOW_PRIVATE_PROXY_HOSTS` | empty | Set to `1` to allow private/internal IPs (e.g., `192.168.x.x`, `10.x.x.x`) in proxy tests and login. Leave empty to only allow public addresses (default). |
 | `CASCADE_REUSE_STRICT` | `0` | Set to `1` for strict conversation reuse mode (waits for same fingerprint). |
 | `CASCADE_REUSE_STRICT_RETRY_MS` | `60000` | Retry delay in ms for strict reuse mode. |
 | `CASCADE_REUSE_HASH_SYSTEM` | `0` | Set to `1` to include system messages in conversation reuse hash. |

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ curl http://localhost:3003/v1/messages \
 | `LS_BINARY_PATH` | `/opt/windsurf/language_server_linux_x64` | LS 二进制位置 |
 | `LS_PORT` | `42100` | LS gRPC 端口 |
 | `DASHBOARD_PASSWORD` | 空 | 后台密码 留空不设密码 |
+| `ALLOW_PRIVATE_PROXY_HOSTS` | 空 | 设为 `1` 允许在代理测试和登录时使用内网 IP（如 `192.168.x.x`、`10.x.x.x`）。默认留空仅允许公网地址 |
 
 ## Dashboard 功能面板
 

--- a/setup.sh
+++ b/setup.sh
@@ -32,6 +32,7 @@ LOG_LEVEL=info
 LS_BINARY_PATH=/opt/windsurf/language_server_linux_x64
 LS_PORT=42100
 DASHBOARD_PASSWORD=
+ALLOW_PRIVATE_PROXY_HOSTS=
 ENVEOF
   echo "       Edit .env to set your API_KEY and DASHBOARD_PASSWORD"
 else

--- a/src/config.js
+++ b/src/config.js
@@ -83,6 +83,9 @@ export const config = {
 
   // Dashboard
   dashboardPassword: process.env.DASHBOARD_PASSWORD || '',
+
+  // Proxy testing
+  allowPrivateProxyHosts: process.env.ALLOW_PRIVATE_PROXY_HOSTS === '1',
 };
 
 const levels = { debug: 0, info: 1, warn: 2, error: 3 };

--- a/src/dashboard/api.js
+++ b/src/dashboard/api.js
@@ -25,6 +25,7 @@ import { windsurfLogin, refreshFirebaseToken, reRegisterWithCodeium } from './wi
 import { getModelAccessConfig, setModelAccessMode, setModelAccessList, addModelToList, removeModelFromList } from './model-access.js';
 import { checkMessageRateLimit } from '../windsurf-api.js';
 import { assertPublicUrlHost } from '../image.js';
+import { validateHostFormat } from '../net-safety.js';
 
 export function buildBatchProxyBinding(result, proxy) {
   const accountId = result?.account?.id || null;
@@ -746,7 +747,11 @@ async function gitStatus() {
 }
 
 async function testProxy({ host, port, username, password, type }) {
-  await assertPublicUrlHost(host);
+  if (config.allowPrivateProxyHosts) {
+    await validateHostFormat(host);
+  } else {
+    await assertPublicUrlHost(host);
+  }
   const { isSocks, createSocksTunnel } = await import('../socks.js');
   const tls = await import('node:tls');
   const targetHost = 'api.ipify.org';

--- a/src/dashboard/api.js
+++ b/src/dashboard/api.js
@@ -27,20 +27,26 @@ import { checkMessageRateLimit } from '../windsurf-api.js';
 import { assertPublicUrlHost } from '../image.js';
 import { validateHostFormat } from '../net-safety.js';
 
-export function buildBatchProxyBinding(result, proxy) {
-  const accountId = result?.account?.id || null;
-  if (!result?.success || !proxy || !accountId) return null;
+export function parseProxyUrl(proxy) {
   const proxyParts = String(proxy).match(/^(?:(\w+):\/\/)?(?:([^:]+):([^@]+)@)?([^:]+):(\d+)$/);
   if (!proxyParts) return null;
   return {
+    type: proxyParts[1] || 'http',
+    host: proxyParts[4],
+    port: parseInt(proxyParts[5]),
+    username: proxyParts[2] || '',
+    password: proxyParts[3] || '',
+  };
+}
+
+export function buildBatchProxyBinding(result, proxy) {
+  const accountId = result?.account?.id || null;
+  if (!result?.success || !proxy || !accountId) return null;
+  const parsed = parseProxyUrl(proxy);
+  if (!parsed) return null;
+  return {
     accountId,
-    proxy: {
-      type: proxyParts[1] || 'http',
-      host: proxyParts[4],
-      port: parseInt(proxyParts[5]),
-      username: proxyParts[2] || '',
-      password: proxyParts[3] || '',
-    },
+    proxy: parsed,
   };
 }
 
@@ -597,7 +603,7 @@ export async function handleDashboardApi(method, subpath, body, req, res) {
           continue;
         }
         try {
-          const loginProxy = proxy ? { host: proxy } : getProxyConfig().global;
+          const loginProxy = proxy ? parseProxyUrl(proxy) : getProxyConfig().global;
           const result = await processWindsurfLogin({ email, password, loginProxy, autoAdd });
           const binding = buildBatchProxyBinding(result, proxy);
           if (binding) {

--- a/src/net-safety.js
+++ b/src/net-safety.js
@@ -103,3 +103,15 @@ export async function resolvePublicAddresses(hostname, lookupFn = dnsLookup) {
   return addrs;
 }
 
+export async function validateHostFormat(hostname, lookupFn = dnsLookup) {
+  const host = String(hostname || '').replace(/^\[|\]$/g, '');
+  if (!host) throw new Error('ERR_INVALID_HOST');
+  if (net.isIP(host)) {
+    return [{ address: host, family: net.isIP(host) }];
+  }
+  const result = await new Promise((resolve, reject) => {
+    lookupFn(host, { all: true }, (err, addrs) => err ? reject(err) : resolve(addrs));
+  });
+  return Array.isArray(result) ? result : [result];
+}
+


### PR DESCRIPTION
## 改了什么 / What changed

Add opt-in flag to allow private/internal hosts (192.168.x.x, 10.x.x.x, localhost) in dashboard proxy tests. Default remains public-only for security. When enabled, testProxy() uses validateHostFormat() instead of assertPublicUrlHost() - still validates DNS/IP format but skips SSRF guards.

New validateHostFormat() helper in net-safety.js mirrors resolvePublicAddresses() structure without private-range rejection. Config wired through .env.example, setup.sh, and config

## 测试 / Testing

tested locally in dashboard

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies (project is zero-dep)
- [ ] 涉及 LS binary 协议改动时 在 PR 描述里注明字段号来源 / If touching LS protocol, document field-number source in the PR description
- [ ] 涉及 dashboard UI 用 App.confirm / App.prompt 不用浏览器原生 alert/confirm / Uses App.confirm / App.prompt, not native dialogs (if dashboard)
