### PR TITLE
Fix missing/broken i18n 

### DIFF
--- a/src/dashboard/i18n/en.json
+++ b/src/dashboard/i18n/en.json
@@ -862,6 +862,7 @@
     "ERR_IDTOKEN_REQUIRED": "ID token is required",
     "ERR_PROXY_PRIVATE_IP": "Proxy cannot point to private/local address",
     "ERR_PROXY_HTTP_ERROR": "Proxy returned HTTP error",
+    "ERR_PROXY_PRIVATE_HOST": "Private/local host is not allowed",
     "ERR_CONNECTION_FAILED": "Connection failed",
     "ERR_TIMEOUT": "Timeout (10s)",
     "ERR_TLS_TUNNEL_ERROR": "TLS tunnel established but returned abnormal content",

--- a/src/dashboard/i18n/zh-CN.json
+++ b/src/dashboard/i18n/zh-CN.json
@@ -862,6 +862,7 @@
     "ERR_IDTOKEN_REQUIRED": "缺少 idToken",
     "ERR_PROXY_PRIVATE_IP": "代理地址不能指向内网/本机",
     "ERR_PROXY_HTTP_ERROR": "代理返回 HTTP 错误",
+    "ERR_PROXY_PRIVATE_HOST": "内网/本地主机不允许",
     "ERR_CONNECTION_FAILED": "连接失败",
     "ERR_TIMEOUT": "超时（10s）",
     "ERR_TLS_TUNNEL_ERROR": "TLS 隧道建立但返回内容异常",

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -2705,7 +2705,8 @@ const App = {
     } catch (err) {
       status.style.color = '#ef4444';
       status.textContent = I18n.t('oauth.status.loginFailed', { label, error: err.message });
-      this.toast(I18n.t('toast.loginFailed', { label, error: err.message }), 'error');
+      const translatedErr = I18n.t(err.message) !== err.message ? I18n.t(err.message) : err.message;
+      this.toast(I18n.t('toast.loginFailed', { label, error: translatedErr }), 'error');
     } finally {
       if (btn) btn.disabled = false;
     }
@@ -2784,7 +2785,7 @@ const App = {
           <div class="section-title" style="color:var(--error)">${I18n.t('loginResult.fail')}</div>
         </div>
       </div>
-      <div class="section-body"><p class="text-sm">${this.esc(r.error || I18n.t('error.unknown'))}</p>${this.getWindsurfLoginFailActions(r)}</div>`);
+      <div class="section-body"><p class="text-sm">${this.esc((r.error && I18n.t(r.error) !== r.error) ? I18n.t(r.error) : (r.error || I18n.t('error.unknown')))}</p>${this.getWindsurfLoginFailActions(r)}</div>`);
   },
 
   renderBatchWindsurfLoginResult(results, autoAdd) {
@@ -2808,7 +2809,7 @@ const App = {
                   <td><span class="badge ${r.success ? 'active' : 'error'}">${r.success ? I18n.t('batch.success') : I18n.t('batch.fail')}</span></td>
                   <td class="text-sm">${r.success
                     ? `<span class="break-all"><code>${this.esc(r.apiKey_masked || (r.apiKey ? r.apiKey.slice(0, 16) + '...' : '-'))}</code>${r.account ? ` · ${I18n.t('table.header.account')} ${this.esc(r.account.id)}` : ''}</span>`
-                    : `<span style="color:var(--error)">${this.esc(r.error || I18n.t('error.unknown'))}</span>`}</td>
+                    : `<span style="color:var(--error)">${this.esc((r.error && I18n.t(r.error) !== r.error) ? I18n.t(r.error) : (r.error || I18n.t('error.unknown')))}</span>`}</td>
                 </tr>
               `).join('')}
             </tbody>
@@ -2880,11 +2881,11 @@ const App = {
       } else {
         entry.status = 'error: ' + (r.error || 'unknown');
         this.renderSingleWindsurfLoginResult(r, autoAdd);
-        this.toast(r.error || I18n.t('toast.loginFailed'), 'error');
+        this.toast((r.error && I18n.t(r.error) !== r.error) ? I18n.t(r.error) : (r.error || I18n.t('toast.loginFailed')), 'error');
       }
     } catch (err) {
       entry.status = 'error: ' + err.message;
-      this.toast(err.message, 'error');
+      this.toast(I18n.t(err.message) !== err.message ? I18n.t(err.message) : err.message, 'error');
     }
 
     this.pushLoginHistory(entry);
@@ -2916,8 +2917,9 @@ const App = {
           <div class="section-header">
             <div><div class="section-title" style="color:var(--error)">${I18n.t('loginResult.fail')}</div></div>
           </div>
-          <div class="section-body"><p class="text-sm">${this.esc(r.error || I18n.t('error.unknown'))}</p></div>`);
-        return this.toast(r.error || I18n.t('batch.importFailed'), 'error');
+          <div class="section-body"><p class="text-sm">${this.esc((r.error && I18n.t(r.error) !== r.error) ? I18n.t(r.error) : (r.error || I18n.t('error.unknown')))}</p></div>`);
+        const translatedErr = r.error && I18n.t(r.error) !== r.error ? I18n.t(r.error) : r.error;
+        return this.toast(translatedErr || I18n.t('batch.importFailed'), 'error');
       }
 
       this.renderBatchWindsurfLoginResult(r.results, autoAdd);
@@ -2938,8 +2940,9 @@ const App = {
         <div class="section-header">
           <div><div class="section-title" style="color:var(--error)">${I18n.t('loginResult.fail')}</div></div>
         </div>
-        <div class="section-body"><p class="text-sm">${this.esc(err.message)}</p></div>`);
-      this.toast(err.message, 'error');
+        <div class="section-body"><p class="text-sm">${this.esc(I18n.t(err.message) !== err.message ? I18n.t(err.message) : err.message)}</p></div>`);
+      const translatedErr = I18n.t(err.message) !== err.message ? I18n.t(err.message) : err.message;
+      this.toast(translatedErr, 'error');
     } finally {
       btn.disabled = false;
       btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M3 5h18"/><path d="M3 12h18"/><path d="M3 19h18"/></svg> ' + I18n.t('action.batchImport');

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -1521,8 +1521,8 @@ window._firebaseOAuth = async function(provider) {
     </div>
   </nav>
   <div class="footer">
-    <button class="btn btn-ghost btn-xs" onclick="App.toggleLang()" title="Switch language" style="margin-right:8px">
-      <span id="lang-indicator">中</span> / EN
+    <button id="lang-toggle-btn" class="btn btn-ghost btn-xs" onclick="App.toggleLang()" title="Switch language" style="margin-right:8px">
+      <span id="lang-indicator">中文</span>
     </button>
     <span>© Windsurf</span>
     <span class="ver" id="sidebar-ver" data-i18n-title="footer.version" title="版本">v1.2.0</span>
@@ -2295,8 +2295,11 @@ const I18n = {
     document.documentElement.lang = this.locale === 'zh' || this.locale === 'zh-CN' ? 'zh-CN' : 'en';
 
     // Update language indicator
+    const zhMode = this.locale === 'zh' || this.locale === 'zh-CN';
     const indicator = document.getElementById('lang-indicator');
-    if (indicator) indicator.textContent = (this.locale === 'zh' || this.locale === 'zh-CN') ? '中' : 'EN';
+    if (indicator) indicator.textContent = zhMode ? '中文' : 'English';
+    const toggleBtn = document.getElementById('lang-toggle-btn');
+    if (toggleBtn) toggleBtn.title = zhMode ? 'Switch to English' : '切换到中文';
   },
 
   async setLocale(lang) {
@@ -2336,10 +2339,24 @@ const App = {
     I18n.apply();
   },
 
-  toggleLang() {
+  async toggleLang() {
     const newLang = I18n.locale === 'zh' || I18n.locale === 'zh-CN' ? 'en' : 'zh';
-    I18n.setLocale(newLang);
+    await I18n.setLocale(newLang);
     this.lang = newLang;
+    this.refreshActivePanelI18n();
+  },
+
+  refreshActivePanelI18n() {
+    const activePanelId = document.querySelector('.panel.active')?.id?.replace(/^p-/, '');
+    if (!activePanelId) return;
+    const loaders = {
+      overview: 'loadOverview', 'windsurf-login': 'loadWindsurfLogin',
+      accounts: 'loadAccounts', models: 'loadModels', proxy: 'loadProxy',
+      logs: 'loadLogs', stats: 'loadStats', bans: 'loadBans',
+      experimental: 'loadExperimental', credits: 'loadCredits',
+    };
+    const loader = loaders[activePanelId];
+    if (loader && typeof this[loader] === 'function') this[loader]();
   },
 
   // Register a polling loader. Guarantees exactly one timer per key even if
@@ -2705,7 +2722,8 @@ const App = {
     } catch (err) {
       status.style.color = '#ef4444';
       status.textContent = I18n.t('oauth.status.loginFailed', { label, error: err.message });
-      const translatedErr = I18n.t(err.message) !== err.message ? I18n.t(err.message) : err.message;
+      const errKey = err.message ? `error.${err.message}` : null;
+      const translatedErr = (errKey && I18n.t(errKey) !== errKey) ? I18n.t(errKey) : err.message;
       this.toast(I18n.t('toast.loginFailed', { label, error: translatedErr }), 'error');
     } finally {
       if (btn) btn.disabled = false;
@@ -2779,13 +2797,15 @@ const App = {
         </div>`);
       return;
     }
+    const errKey = r.error ? `error.${r.error}` : null;
+    const errMsg = (errKey && I18n.t(errKey) !== errKey) ? I18n.t(errKey) : (r.error || I18n.t('error.unknown'));
     this.showWindsurfLoginResult(`
       <div class="section-header">
         <div>
           <div class="section-title" style="color:var(--error)">${I18n.t('loginResult.fail')}</div>
         </div>
       </div>
-      <div class="section-body"><p class="text-sm">${this.esc((r.error && I18n.t(r.error) !== r.error) ? I18n.t(r.error) : (r.error || I18n.t('error.unknown')))}</p>${this.getWindsurfLoginFailActions(r)}</div>`);
+      <div class="section-body"><p class="text-sm">${this.esc(errMsg)}</p>${this.getWindsurfLoginFailActions(r)}</div>`);
   },
 
   renderBatchWindsurfLoginResult(results, autoAdd) {
@@ -2809,7 +2829,7 @@ const App = {
                   <td><span class="badge ${r.success ? 'active' : 'error'}">${r.success ? I18n.t('batch.success') : I18n.t('batch.fail')}</span></td>
                   <td class="text-sm">${r.success
                     ? `<span class="break-all"><code>${this.esc(r.apiKey_masked || (r.apiKey ? r.apiKey.slice(0, 16) + '...' : '-'))}</code>${r.account ? ` · ${I18n.t('table.header.account')} ${this.esc(r.account.id)}` : ''}</span>`
-                    : `<span style="color:var(--error)">${this.esc((r.error && I18n.t(r.error) !== r.error) ? I18n.t(r.error) : (r.error || I18n.t('error.unknown')))}</span>`}</td>
+                    : (() => { const errKey = r.error ? `error.${r.error}` : null; return `<span style="color:var(--error)">${this.esc((errKey && I18n.t(errKey) !== errKey) ? I18n.t(errKey) : (r.error || I18n.t('error.unknown')))}</span>`; })()}</td>
                 </tr>
               `).join('')}
             </tbody>
@@ -2881,11 +2901,13 @@ const App = {
       } else {
         entry.status = 'error: ' + (r.error || 'unknown');
         this.renderSingleWindsurfLoginResult(r, autoAdd);
-        this.toast((r.error && I18n.t(r.error) !== r.error) ? I18n.t(r.error) : (r.error || I18n.t('toast.loginFailed')), 'error');
+        const errKey = r.error ? `error.${r.error}` : null;
+        this.toast((errKey && I18n.t(errKey) !== errKey) ? I18n.t(errKey) : (r.error || I18n.t('toast.loginFailed')), 'error');
       }
     } catch (err) {
       entry.status = 'error: ' + err.message;
-      this.toast(I18n.t(err.message) !== err.message ? I18n.t(err.message) : err.message, 'error');
+      const errKey = err.message ? `error.${err.message}` : null;
+      this.toast((errKey && I18n.t(errKey) !== errKey) ? I18n.t(errKey) : err.message, 'error');
     }
 
     this.pushLoginHistory(entry);
@@ -2913,12 +2935,13 @@ const App = {
     try {
       const r = await this.api('POST', '/batch-import', { text: input, autoAdd });
       if (!r.success || !Array.isArray(r.results)) {
+        const errKey = r.error ? `error.${r.error}` : null;
         this.showWindsurfLoginResult(`
           <div class="section-header">
             <div><div class="section-title" style="color:var(--error)">${I18n.t('loginResult.fail')}</div></div>
           </div>
-          <div class="section-body"><p class="text-sm">${this.esc((r.error && I18n.t(r.error) !== r.error) ? I18n.t(r.error) : (r.error || I18n.t('error.unknown')))}</p></div>`);
-        const translatedErr = r.error && I18n.t(r.error) !== r.error ? I18n.t(r.error) : r.error;
+          <div class="section-body"><p class="text-sm">${this.esc((errKey && I18n.t(errKey) !== errKey) ? I18n.t(errKey) : (r.error || I18n.t('error.unknown')))}</p></div>`);
+        const translatedErr = errKey && I18n.t(errKey) !== errKey ? I18n.t(errKey) : r.error;
         return this.toast(translatedErr || I18n.t('batch.importFailed'), 'error');
       }
 
@@ -2936,12 +2959,13 @@ const App = {
         document.getElementById('wl-batch-input').value = '';
       }
     } catch (err) {
+      const errKey = err.message ? `error.${err.message}` : null;
       this.showWindsurfLoginResult(`
         <div class="section-header">
           <div><div class="section-title" style="color:var(--error)">${I18n.t('loginResult.fail')}</div></div>
         </div>
-        <div class="section-body"><p class="text-sm">${this.esc(I18n.t(err.message) !== err.message ? I18n.t(err.message) : err.message)}</p></div>`);
-      const translatedErr = I18n.t(err.message) !== err.message ? I18n.t(err.message) : err.message;
+        <div class="section-body"><p class="text-sm">${this.esc((errKey && I18n.t(errKey) !== errKey) ? I18n.t(errKey) : err.message)}</p></div>`);
+      const translatedErr = (errKey && I18n.t(errKey) !== errKey) ? I18n.t(errKey) : err.message;
       this.toast(translatedErr, 'error');
     } finally {
       btn.disabled = false;
@@ -2959,7 +2983,7 @@ const App = {
         <td>${this.esc(h.email)}</td>
         <td>
           <span class="badge ${ok ? 'active' : 'error'}">${ok ? I18n.t('batch.success') : I18n.t('batch.fail')}</span>
-          ${!ok ? `<div class="text-xs" style="color:var(--error);margin-top:3px;max-width:240px;overflow:hidden;text-overflow:ellipsis">${this.esc((h.status||'').replace('error: ',''))}</div>` : ''}
+          ${!ok ? (() => { const errCode = (h.status||'').replace('error: ',''); const errKey = `error.${errCode}`; const errMsg = I18n.t(errKey) !== errKey ? I18n.t(errKey) : errCode; return `<div class="text-xs" style="color:var(--error);margin-top:3px;max-width:240px;overflow:hidden;text-overflow:ellipsis" title="${this.esc(errCode)}">${this.esc(errMsg)}</div>`; })() : ''}
         </td>
         <td class="text-sm">${this.esc(h.proxy || '-')}</td>
         <td><button class="btn btn-ghost btn-xs" onclick="App.removeLoginHistory(${i})">${I18n.t('action.delete')}</button></td>

--- a/src/net-safety.js
+++ b/src/net-safety.js
@@ -88,9 +88,9 @@ export function isPrivateIp(address) {
 
 export async function resolvePublicAddresses(hostname, lookupFn = dnsLookup) {
   const host = String(hostname || '').replace(/^\[|\]$/g, '');
-  if (!host || host.toLowerCase() === 'localhost') throw new Error('ERR_PRIVATE_HOST');
+  if (!host || host.toLowerCase() === 'localhost') throw new Error('ERR_PROXY_PRIVATE_HOST');
   if (net.isIP(host)) {
-    if (isPrivateIp(host)) throw new Error('ERR_PRIVATE_IP');
+    if (isPrivateIp(host)) throw new Error('ERR_PROXY_PRIVATE_IP');
     return [{ address: host, family: net.isIP(host) }];
   }
   const result = await new Promise((resolve, reject) => {
@@ -98,7 +98,7 @@ export async function resolvePublicAddresses(hostname, lookupFn = dnsLookup) {
   });
   const addrs = Array.isArray(result) ? result : [result];
   for (const a of addrs) {
-    if (isPrivateIp(a.address)) throw new Error('ERR_PRIVATE_IP');
+    if (isPrivateIp(a.address)) throw new Error('ERR_PROXY_PRIVATE_IP');
   }
   return addrs;
 }

--- a/test/ssrf.test.js
+++ b/test/ssrf.test.js
@@ -20,7 +20,7 @@ describe('SSRF private address detection', () => {
 
   it('rejects hostnames after DNS resolution to private IPs', async () => {
     const lookup = (host, opts, cb) => cb(null, [{ address: '127.0.0.1', family: 4 }]);
-    await assert.rejects(() => resolvePublicAddresses('evil.example', lookup), /ERR_PRIVATE_IP/);
+    await assert.rejects(() => resolvePublicAddresses('evil.example', lookup), /ERR_PROXY_PRIVATE_IP/);
   });
 
   it('rejects oversized generic data URLs', () => {
@@ -28,4 +28,3 @@ describe('SSRF private address detection', () => {
     assert.throws(() => parseGenericDataUrl(tooLarge), /Data URL exceeds/);
   });
 });
-


### PR DESCRIPTION
## 改了什么 / What changed

- Fixed i18n translation for all error codes in dashboard login flows (toasts, result displays, and login history)
- Standardized error code naming: `ERR_PRIVATE_IP` → `ERR_PROXY_PRIVATE_IP`, `ERR_PRIVATE_HOST` → `ERR_PROXY_PRIVATE_HOST`
- Added missing `ERR_PROXY_PRIVATE_HOST` translation key to both en.json and zh-CN.json
- Improved language toggle UI with dynamic tooltip showing target language

## 为什么 / Why

Fixes the issue where error codes like `ERR_NO_PASSWORD_SET` were displayed raw in toasts and login history instead of human-readable translations. Also aligns error code naming with existing `ERR_PROXY_PRIVATE_IP` for consistency.

## 测试 / Testing

- Dashboard login with OAuth/password errors now shows translated messages in toasts
- Login History table displays translated error messages with original code in tooltip
- Language switcher tooltip correctly shows "Switch to English" / "切换到中文" based on current locale
- No new npm dependencies (zero-dep project)

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies (project is zero-dep)
- [ ] 涉及 LS binary 协议改动时 在 PR 描述里注明字段号来源 / If touching LS protocol, document field-number source in the PR description
- [x] 涉及 dashboard UI 用 App.confirm / App.prompt 不用浏览器原生 alert/confirm / Uses App.confirm / App.prompt, not native dialogs (if dashboard)