### PR TITLE
Add proxy support for add account by token

### DIFF
--- a/src/dashboard/api.js
+++ b/src/dashboard/api.js
@@ -295,6 +295,23 @@ export async function handleDashboardApi(method, subpath, body, req, res) {
       } else {
         return json(res, 400, { error: 'Provide api_key or token' });
       }
+
+      // Handle optional proxy configuration
+      if (body.proxy) {
+        const parsed = parseProxyUrl(body.proxy);
+        if (!parsed) {
+          return json(res, 400, { error: 'ERR_PROXY_FORMAT_INVALID' });
+        }
+        // Validate proxy host (respect ALLOW_PRIVATE_PROXY_HOSTS config)
+        if (config.allowPrivateProxyHosts) {
+          await validateHostFormat(parsed.host);
+        } else {
+          await assertPublicUrlHost(parsed.host);
+        }
+        setAccountProxy(account.id, parsed);
+        ensureLsForAccount(account.id).catch(e => log.warn(`LS ensure failed: ${e.message}`));
+      }
+
       // Fire-and-forget probe so the UI gets tier info shortly after add
       probeAccount(account.id).catch(e => log.warn(`Auto-probe failed: ${e.message}`));
       return json(res, 200, {

--- a/src/dashboard/i18n/en.json
+++ b/src/dashboard/i18n/en.json
@@ -356,6 +356,11 @@
       "label": "Label",
       "placeholder": "Optional"
     },
+    "proxy": {
+      "label": "Proxy",
+      "placeholder": "http://proxy:8080 or socks5://user:pass@host:port (optional)",
+      "hint": "Leave empty to use global proxy settings"
+    },
     "batchInput": {
       "label": "Batch Import",
       "hint": "One account per line. Format: [proxy] email password. Proxy is optional, supports http/socks5. Proxy will be automatically bound to corresponding account."
@@ -872,6 +877,7 @@
     "ERR_FORMAT_INVALID": "Invalid format. Expected: [proxy] email password",
     "ERR_IDTOKEN_REQUIRED": "ID token is required",
     "ERR_PROXY_PRIVATE_IP": "Proxy cannot point to private/local address",
+    "ERR_PROXY_FORMAT_INVALID": "Invalid proxy format. Expected: protocol://[user:pass@]host:port",
     "ERR_PROXY_HTTP_ERROR": "Proxy returned HTTP error",
     "ERR_PROXY_PRIVATE_HOST": "Private/local host is not allowed",
     "ERR_CONNECTION_FAILED": "Connection failed",

--- a/src/dashboard/i18n/zh-CN.json
+++ b/src/dashboard/i18n/zh-CN.json
@@ -339,6 +339,11 @@
       "label": "标签",
       "placeholder": "可选"
     },
+    "proxy": {
+      "label": "代理",
+      "placeholder": "http://proxy:8080 或 socks5://user:pass@host:port（可选）",
+      "hint": "留空则使用全局代理设置"
+    },
     "batchInput": {
       "label": "批量导入",
       "hint": "每行一个账号。格式：[代理] 邮箱 密码。代理可选，支持 http/socks5。会自动绑定代理到对应账号。"
@@ -872,6 +877,7 @@
     "ERR_FORMAT_INVALID": "格式错误 需要 [proxy] email password",
     "ERR_IDTOKEN_REQUIRED": "缺少 idToken",
     "ERR_PROXY_PRIVATE_IP": "代理地址不能指向内网/本机",
+    "ERR_PROXY_FORMAT_INVALID": "代理格式错误，应为：protocol://[user:pass@]host:port",
     "ERR_PROXY_HTTP_ERROR": "代理返回 HTTP 错误",
     "ERR_PROXY_PRIVATE_HOST": "内网/本地主机不允许",
     "ERR_CONNECTION_FAILED": "连接失败",

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -1764,6 +1764,13 @@ window._firebaseOAuth = async function(provider) {
             <input id="acc-label" class="input" data-i18n-placeholder="field.label.placeholder" placeholder="可选">
           </div>
         </div>
+        <div class="field-row" style="margin-top:12px">
+          <div class="field" style="flex:1">
+            <label class="field-label" data-i18n="field.proxy.label">代理</label>
+            <input id="acc-proxy" class="input" data-i18n-placeholder="field.proxy.placeholder" placeholder="http://proxy:8080 或 socks5://user:pass@host:port（可选）">
+          </div>
+        </div>
+        <div class="field-hint" style="margin-top:4px" data-i18n="field.proxy.hint">留空则使用全局代理设置</div>
         <div class="field-row-actions">
           <button class="btn btn-primary" onclick="App.addAccount()" data-i18n="action.add">添加账号</button>
         </div>
@@ -3624,10 +3631,11 @@ const App = {
     const type = document.getElementById('acc-type').value;
     const key = document.getElementById('acc-key').value.trim();
     const label = document.getElementById('acc-label').value.trim();
+    const proxy = document.getElementById('acc-proxy').value.trim();
     if (!key) return this.toast(I18n.t('toast.enterKeyOrToken'), 'error');
-    const body = type === 'api_key' ? { api_key: key, label } : { token: key, label };
+    const body = type === 'api_key' ? { api_key: key, label, proxy } : { token: key, label, proxy };
     const r = await this.api('POST', '/accounts', body);
-    if (r.success) { this.toast(I18n.t('account.addSuccess')); document.getElementById('acc-key').value = ''; document.getElementById('acc-label').value = ''; this.loadAccounts(); }
+    if (r.success) { this.toast(I18n.t('account.addSuccess')); document.getElementById('acc-key').value = ''; document.getElementById('acc-label').value = ''; document.getElementById('acc-proxy').value = ''; this.loadAccounts(); }
     else this.toast(r.error || I18n.t('toast.addFailed'), 'error');
   },
 


### PR DESCRIPTION
## 改了什么 / What changed

Added an optional proxy field to the "Add Account" form in the Account Pool dashboard. Users can now specify a proxy (in `protocol://[user:pass@]host:port` format) when adding an account via API Key or Auth Token, instead of having to configure it separately after the account is created.

## 为什么 / Why

Previously, when adding an account to the pool, users had to:
1. Add the account first (which would use the global proxy)
2. Then separately configure a per-account proxy after creation

This was inconvenient, especially when managing multiple accounts with different proxies. The batch import feature already supported specifying proxies inline, but the single account addition form did not. This change brings feature parity between batch import and single account addition.

## 测试 / Testing

- Tested proxy validation:
  - Invalid format (e.g., `not-a-proxy`) returns `ERR_PROXY_FORMAT_INVALID`
  - Private IP (e.g., `http://192.168.1.1:8080`) is blocked by default (returns `ERR_PROXY_PRIVATE_IP`)
  - Private IP allowed when `ALLOW_PRIVATE_PROXY_HOSTS=1` is set
  - Valid public proxy (e.g., `http://proxy.example.com:8080`) works correctly
  - SOCKS5 with auth (e.g., `socks5://user:pass@host:port`) parses correctly

- Tested dashboard UI:
  - Proxy field accepts input and clears after successful account addition
  - Empty proxy field omits proxy from request (uses global proxy)
  - i18n translations display correctly in both English and Chinese

- Verified proxy is applied immediately:
  - Account is created → proxy is set → LS instance is spawned for the proxy

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies (project is zero-dep)
- [ ] 涉及 LS binary 协议改动时 在 PR 描述里注明字段号来源 / If touching LS protocol, document field-number source in the PR description (N/A - no LS protocol changes)
- [x] 涉及 dashboard UI 用 App.confirm / App.prompt 不用浏览器原生 alert/confirm / Uses App.confirm / App.prompt, not native dialogs (if dashboard)
