### PR TITLE
feat: sticky session for multi-turn conversation continuity

### DIFF
--- a/src/account/sticky-session.js
+++ b/src/account/sticky-session.js
@@ -1,0 +1,203 @@
+/**
+ * Sticky Session Manager.
+ *
+ * Binds a caller (identified by callerKey + modelKey) to a specific account
+ * so that multi-turn conversations stay on the same upstream account. This
+ * prevents context loss when the conversation pool reuses a cascade_id that
+ * is only valid on the originating account.
+ *
+ * Design:
+ *   - (callerKey, modelKey) → accountId binding with configurable TTL
+ *   - Model dimension prevents cross-model collision: the same session
+ *     using opus and sonnet can be bound to different accounts
+ *   - Binding is created when a successful response is returned
+ *   - On next request, getApiKey checks the binding first
+ *   - If the bound account is unavailable (rate limited, etc.),
+ *     the stale binding is immediately cleared so retries don't
+ *     keep hitting the same unavailable account
+ *   - Bindings are cleared on session reset or TTL expiry
+ *   - The binding table is in-memory only (no persistence needed)
+ *
+ * Why this matters:
+ *   Multi-turn conversations (Claude Code "fix → test → fix again")
+ *   currently re-select an account on every request. If the chosen account
+ *   runs out of quota or hits RPM mid-conversation, the cascade_id from
+ *   the previous turn is invalid on the new account — context is lost.
+ *   Sticky binding prevents this by keeping the same account for the
+ *   duration of a conversation.
+ *
+ * Configure via env:
+ *   STICKY_SESSION_ENABLED=1     — enable (default: 0, opt-in)
+ *   STICKY_SESSION_TTL_MS=1800000 — binding TTL in ms (default: 30 min)
+ *   STICKY_SESSION_MAX=10000     — max concurrent bindings (default: 10000)
+ *
+ * Related issues: #93, #133 (context loss mid-task)
+ */
+
+const ENABLED = process.env.STICKY_SESSION_ENABLED === '1';
+
+const TTL_MS = (() => {
+  const n = parseInt(process.env.STICKY_SESSION_TTL_MS || '', 10);
+  return Number.isFinite(n) && n > 0 ? n : 30 * 60 * 1000;  // 30 minutes
+})();
+
+const MAX_BINDINGS = (() => {
+  const n = parseInt(process.env.STICKY_SESSION_MAX || '', 10);
+  return Number.isFinite(n) && n > 0 ? n : 10000;
+})();
+
+// Map<bindingKey, { accountId, apiKey, createdAt, lastAccess }>
+// bindingKey = callerKey + '\0' + modelKey
+const _bindings = new Map();
+const _stats = {
+  hits: 0, misses: 0, creates: 0,
+  expires: 0, evictions: 0, fallbacks: 0,
+};
+
+/**
+ * Build the internal map key from caller + model dimensions.
+ * Using \0 delimiter (valid in Map keys but never appears in user input).
+ */
+function bindingKey(callerKey, modelKey) {
+  return callerKey + '\0' + (modelKey || '*');
+}
+
+// ── Periodic cleanup ─────────────────────────────────────────────
+// Clean expired bindings every 5 minutes so memory doesn't grow
+// unbounded. The per-lookup path also checks TTL, so this is a safety
+// net, not the primary enforcement.
+let _cleanupTimer = null;
+function ensureCleanupTimer() {
+  if (_cleanupTimer) return;
+  _cleanupTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [key, binding] of _bindings) {
+      if (now - binding.lastAccess > TTL_MS) {
+        _bindings.delete(key);
+        _stats.expires++;
+      }
+    }
+  }, 5 * 60 * 1000).unref();
+}
+
+// ─── Public API ──────────────────────────────────────────────────
+
+/**
+ * Check if sticky sessions are enabled.
+ */
+export function isStickyEnabled() {
+  return ENABLED;
+}
+
+/**
+ * Look up the bound account for a caller + model pair.
+ *
+ * @param {string} callerKey - Caller identity key (e.g. session id, IP hash)
+ * @param {string} [modelKey] - Model being requested
+ * @returns {{ accountId: string, apiKey: string } | null}
+ */
+export function getStickyBinding(callerKey, modelKey = '') {
+  if (!ENABLED || !callerKey) return null;
+  ensureCleanupTimer();
+
+  const key = bindingKey(callerKey, modelKey);
+  const binding = _bindings.get(key);
+  if (!binding) {
+    _stats.misses++;
+    return null;
+  }
+
+  const now = Date.now();
+  if (now - binding.lastAccess > TTL_MS) {
+    _bindings.delete(key);
+    _stats.expires++;
+    return null;
+  }
+
+  binding.lastAccess = now;
+  _stats.hits++;
+  return { accountId: binding.accountId, apiKey: binding.apiKey };
+}
+
+/**
+ * Set (or refresh) a sticky binding.
+ *
+ * @param {string} callerKey
+ * @param {string} modelKey
+ * @param {string} accountId
+ * @param {string} apiKey
+ */
+export function setStickyBinding(callerKey, modelKey, accountId, apiKey) {
+  if (!ENABLED || !callerKey || !accountId) return;
+  ensureCleanupTimer();
+
+  // Evict oldest if at capacity
+  if (_bindings.size >= MAX_BINDINGS && !_bindings.has(bindingKey(callerKey, modelKey))) {
+    let oldestKey = null;
+    let oldestTime = Infinity;
+    for (const [k, b] of _bindings) {
+      if (b.lastAccess < oldestTime) {
+        oldestTime = b.lastAccess;
+        oldestKey = k;
+      }
+    }
+    if (oldestKey) {
+      _bindings.delete(oldestKey);
+      _stats.evictions++;
+    }
+  }
+
+  const key = bindingKey(callerKey, modelKey);
+  const now = Date.now();
+  const existing = _bindings.get(key);
+
+  _bindings.set(key, {
+    accountId,
+    apiKey,
+    createdAt: existing?.createdAt || now,
+    lastAccess: now,
+  });
+
+  if (!existing) _stats.creates++;
+}
+
+/**
+ * Clear the sticky binding for a caller+model pair.
+ * Called when the bound account becomes unavailable (rate limited, banned, etc.)
+ *
+ * @param {string} callerKey
+ * @param {string} [modelKey]
+ */
+export function clearStickyBinding(callerKey, modelKey = '') {
+  if (!ENABLED || !callerKey) return;
+  _bindings.delete(bindingKey(callerKey, modelKey));
+}
+
+/**
+ * Clear all bindings for a caller (all models).
+ * Called on session reset or disconnection.
+ *
+ * @param {string} callerKey
+ */
+export function clearCallerBindings(callerKey) {
+  if (!ENABLED || !callerKey) return;
+  const prefix = callerKey + '\0';
+  for (const key of _bindings.keys()) {
+    if (key.startsWith(prefix)) _bindings.delete(key);
+  }
+}
+
+/**
+ * Reset all bindings. Useful for testing or full session reset.
+ */
+export function resetAllBindings() {
+  _bindings.clear();
+}
+
+/**
+ * Get stats for monitoring.
+ * @returns {{ hits: number, misses: number, creates: number, expires: number, evictions: number, fallbacks: number, size: number }}
+ */
+export function getStickyStats() {
+  return { ..._stats, size: _bindings.size };
+}

--- a/src/auth.js
+++ b/src/auth.js
@@ -6,9 +6,12 @@
  *   - Account health tracking (error count, auto-disable)
  *   - Dynamic add/remove via API
  *   - Token-based registration via api.codeium.com
+ *   - Optional sticky sessions (STICKY_SESSION_ENABLED=1) for multi-turn
+ *     conversation continuity (#93, #133)
  */
 
 import { createHash, randomUUID, timingSafeEqual } from 'crypto';
+import { isStickyEnabled, getStickyBinding, setStickyBinding, clearStickyBinding } from './account/sticky-session.js';
 import { readFileSync, writeFileSync, existsSync, renameSync, unlinkSync, readdirSync } from 'fs';
 import { config, log } from './config.js';
 import { getEffectiveProxy } from './dashboard/proxy-config.js';
@@ -613,8 +616,42 @@ export function removeAccount(id) {
  * Returns null when every account is temporarily full — callers should
  * wait a moment and retry (see handlers/chat.js queue loop).
  */
-export function getApiKey(excludeKeys = [], modelKey = null) {
+export function getApiKey(excludeKeys = [], modelKey = null, callerKey = null) {
   const now = Date.now();
+
+  // ── Sticky session: prefer the account from the last turn ────────
+  // When enabled, this keeps multi-turn conversations on the same upstream
+  // account so the cascade_id from the previous turn is still valid.
+  // Falls through to normal selection if the bound account is unavailable.
+  if (callerKey && isStickyEnabled()) {
+    const bound = getStickyBinding(callerKey, modelKey);
+    if (bound) {
+      const acct = accounts.find(a => a.id === bound.accountId && a.status === 'active' && a.apiKey === bound.apiKey);
+      if (acct) {
+        const limit = rpmLimitFor(acct);
+        const used = pruneRpmHistory(acct, now);
+        if (limit > 0 && used < limit && !isRateLimitedForModel(acct, modelKey, now)) {
+          if (!modelKey || isModelAllowedForAccount(acct, modelKey)) {
+            const reservationTimestamp = nextReservationToken(now);
+            acct._rpmHistory.push(reservationTimestamp);
+            acct.lastUsed = now;
+            acct._inflight = (acct._inflight || 0) + 1;
+            return {
+              id: acct.id, email: acct.email, apiKey: acct.apiKey,
+              apiServerUrl: acct.apiServerUrl || '',
+              proxy: getEffectiveProxy(acct.id) || null,
+              reservationTimestamp,
+              _sticky: true,
+            };
+          }
+        }
+      }
+      // Bound account is no longer usable — clear it so the next call
+      // falls through to normal selection instead of looping.
+      clearStickyBinding(callerKey, modelKey);
+    }
+  }
+
   const candidates = [];
   for (const a of accounts) {
     if (a.status !== 'active') continue;

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -6,6 +6,7 @@
 import { createHash, randomUUID } from 'crypto';
 import { WindsurfClient, contentToString, isCascadeTransportError } from '../client.js';
 import { getApiKey, acquireAccountByKey, releaseAccount, getAccountAvailability, reportError, reportSuccess, markRateLimited, reportInternalError, updateCapability, getAccountList, isAllRateLimited, isAllTemporarilyUnavailable, refundReservation, looksLikeBanSignal, reportBanSignal, clearBanSignals, isModelBlockedByDrought, getDroughtSummary } from '../auth.js';
+import { isStickyEnabled, setStickyBinding } from '../account/sticky-session.js';
 import { resolveModel, getModelInfo, pickRateLimitFallback } from '../models.js';
 import { getLsFor, ensureLs } from '../langserver.js';
 import { config, log } from '../config.js';
@@ -1140,14 +1141,14 @@ export function buildUsageBody(serverUsage, messages, completionText, thinkingTe
 // Wait until getApiKey returns a non-null account, or until maxWaitMs expires.
 // Used when every account has momentarily exhausted its RPM budget so the
 // client is queued instead of getting a 503.
-async function waitForAccount(tried, signal, maxWaitMs = QUEUE_MAX_WAIT_MS, modelKey = null) {
+async function waitForAccount(tried, signal, maxWaitMs = QUEUE_MAX_WAIT_MS, modelKey = null, callerKey = null) {
   const deadline = Date.now() + maxWaitMs;
-  let acct = getApiKey(tried, modelKey);
+  let acct = getApiKey(tried, modelKey, callerKey);
   while (!acct) {
     if (signal?.aborted) return null;
     if (Date.now() >= deadline) return null;
     await new Promise(r => setTimeout(r, QUEUE_RETRY_MS));
-    acct = getApiKey(tried, modelKey);
+    acct = getApiKey(tried, modelKey, callerKey);
   }
   return acct;
 }
@@ -1864,7 +1865,7 @@ async function _handleChatCompletionsInner(body, context = {}) {
       }
     }
     if (!acct) {
-      acct = await waitForAccountFn(tried, null, QUEUE_MAX_WAIT_MS, routingModelKey);
+      acct = await waitForAccountFn(tried, null, QUEUE_MAX_WAIT_MS, routingModelKey, callerKey);
       if (!acct) {
         // Same diagnostic-error fix as the stream path — surface real reason
         // for the queue timeout (rate limit / no entitlement / upstream stall)
@@ -2420,6 +2421,13 @@ async function nonStreamResponse(client, id, created, model, modelKey, messages,
         historyCoverage: cascadeMeta.historyCoverage || poolCtx.reuseEntry?.historyCoverage || null,
         createdAt: poolCtx.reuseEntry?.createdAt,
       }, poolCtx.callerKey || '', ttlHint === undefined ? 0 : ttlHint);
+
+      // Bind caller to this account for the next turn in the
+      // conversation. Without this, the next request picks a different
+      // account from the pool and the cascade_id becomes invalid.
+      if (poolCtx.callerKey && isStickyEnabled() && acct) {
+        setStickyBinding(poolCtx.callerKey, modelKey, acct.id, acct.apiKey);
+      }
     }
 
     reportSuccess(apiKey);

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -3160,6 +3160,11 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
                 historyCoverage: cascadeResult.historyCoverage || reuseEntry?.historyCoverage || null,
                 createdAt: reuseEntry?.createdAt,
               }, callerKey, ttlHint === undefined ? 0 : ttlHint);
+
+              // Bind caller to this account for the next turn
+              if (callerKey && isStickyEnabled() && acct) {
+                setStickyBinding(callerKey, modelKey, acct.id, acct.apiKey);
+              }
             }
             // success
             if (hadSuccess) reportSuccess(currentApiKey);


### PR DESCRIPTION
## Summary

Adds an opt-in sticky session feature that binds a caller (identified by `callerKey`) to a specific upstream Windsurf account for the duration of a multi-turn conversation.

## Problem

When using Claude Code, Cursor, or any multi-turn agent with WindsurfAPI, the account pool selects a different account for each request. The `cascade_id` from the previous turn is only valid on the originating account — switching accounts mid-conversation causes context loss (#93, #133).

## Solution

New module `src/account/sticky-session.js` maintains an in-memory binding map:

- **Key**: `(callerKey, modelKey)` — model dimension prevents cross-model collision
- **Binding created** when a response completes successfully
- **Binding checked** on the next request before falling through to normal pool selection
- **Auto-cleared** when the bound account becomes unavailable (rate limited, banned)
- **TTL-based expiry**: 30 minutes by default
- **LRU eviction** when at capacity (default: 10,000)

## Integration

- `src/auth.js`: `getApiKey()` now accepts optional `callerKey` parameter, checks sticky binding first
- `src/handlers/chat.js`: calls `setStickyBinding()` after successful response

## Configuration (opt-in)

```bash
STICKY_SESSION_ENABLED=1        # default: 0 (off)
STICKY_SESSION_TTL_MS=1800000   # default: 30 minutes
STICKY_SESSION_MAX=10000        # default: 10000 max bindings
```

## Backward Compatibility

- `STICKY_SESSION_ENABLED` defaults to `0` (off)
- `callerKey` is `null` by default in `getApiKey()`, existing callers unaffected
- No breaking changes to public API

Closes #93, #133