### PR TITLE
feat: add Codex Responses WebSocket support

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -16,15 +16,23 @@ http {
         default $remote_addr; # Fallback to IP hash if no token is provided
     }
 
+    # Preserve real WebSocket upgrades for Codex Responses endpoints. Without
+    # this, nginx forwards the request as plain HTTP and the Node upgrade
+    # handler never sees a WebSocket handshake.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' '';
+    }
+
     # Upstream with hash-based load balancing (Sticky Sessions)
     # The hash uses the user's API Key so the same API Key always hits the same node,
     # preserving the cascade_id context in memory.
     upstream windsurf_backend {
         hash $auth_token consistent;
-        
+
         # In a real Swarm/Compose environment with scale=3, Docker DNS resolves 'windsurf-api' to all IPs.
         # But 'hash' works better with explicit servers or using a DNS resolver dynamically if needed.
-        # Nginx free version requires manual IP listings for sticky sessions, 
+        # Nginx free version requires manual IP listings for sticky sessions,
         # or we rely on ip_hash for generic load balancing if behind a single reverse proxy.
         zone windsurf_backend_zone 64k;
         server windsurf-api:3003 resolve;
@@ -32,19 +40,40 @@ http {
 
     server {
         listen 80;
-        
-        location / {
+
+        location ~ ^/(v1/(ws/)?responses|backend-api/codex/responses)$ {
             limit_req zone=mylimit burst=20 nodelay;
-            
+
             proxy_pass http://windsurf_backend;
             proxy_http_version 1.1;
-            
-            # SSE and streaming requirements
-            proxy_set_header Connection '';
+
+            # Responses can stream over SSE or WebSocket for long Codex turns.
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
             proxy_buffering off;
             proxy_cache off;
             chunked_transfer_encoding on;
-            
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location / {
+            limit_req zone=mylimit burst=20 nodelay;
+
+            proxy_pass http://windsurf_backend;
+            proxy_http_version 1.1;
+
+            # Streaming requirements
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_buffering off;
+            proxy_cache off;
+            chunked_transfer_encoding on;
+
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/src/auth.js
+++ b/src/auth.js
@@ -52,6 +52,11 @@ function positiveIntEnv(name, fallback) {
   return Number.isFinite(n) && n > 0 ? n : fallback;
 }
 
+function nonNegativeIntEnv(name, fallback) {
+  const n = parseInt(process.env[name] || '', 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
 function rpmLimitFor(account) {
   return TIER_RPM[account.tier || 'unknown'] ?? 20;
 }
@@ -734,6 +739,16 @@ export function acquireAccountByKey(apiKey, modelKey = null) {
 }
 
 /**
+ * Try to reserve a specific account by account id. Codex-style sticky
+ * sessions persist account ids rather than raw upstream API keys, so this
+ * mirrors acquireAccountByKey while keeping secrets out of the sticky store.
+ */
+export function acquireAccountById(id, modelKey = null) {
+  const a = accounts.find(x => x.id === id);
+  return a ? acquireAccountByKey(a.apiKey, modelKey) : null;
+}
+
+/**
  * Explain why a pinned account cannot be used right now. Used by strict
  * Cascade reuse mode, where switching accounts would lose server-side
  * conversation context.
@@ -1391,7 +1406,11 @@ async function _probeAccountImpl(account) {
       ...PROBE_CANARIES,
       ...Object.keys(account.capabilities || {}),
     ]);
-    const MAX_CLOUD_PROBES = positiveIntEnv('MAX_CLOUD_PROBES', 10);
+    // Dynamic cloud probes are real Cascade requests. On free accounts they can
+    // consume the same low per-model/hour budget operators are trying to pool,
+    // so keep them opt-in for free tier. Set MAX_CLOUD_PROBES=N to re-enable.
+    const defaultCloudProbeCap = status?.tierName === 'free' ? 0 : 10;
+    const MAX_CLOUD_PROBES = nonNegativeIntEnv('MAX_CLOUD_PROBES', defaultCloudProbeCap);
     const cloudCandidates = allModels.filter(k => {
       if (alreadyProbed.has(k)) return false;
       const info = getModelInfo(k);

--- a/src/dashboard/api.js
+++ b/src/dashboard/api.js
@@ -24,8 +24,10 @@ import {
   getExperimental, setExperimental, getSystemPrompts, setSystemPrompts, resetSystemPrompt,
   getCredentials, setRuntimeApiKey, setRuntimeDashboardPassword,
   verifyPassword, getEffectiveApiKey, getEffectiveDashboardPasswordStored,
+  getCodexSettings, setCodexSettings,
 } from '../runtime-config.js';
 import { poolStats as convPoolStats, poolClear as convPoolClear } from '../conversation-pool.js';
+import { stickyStats, clearStickySessions } from '../sticky-sessions.js';
 import { getLogs, subscribeToLogs, unsubscribeFromLogs } from './logger.js';
 import { getProxyConfig, getProxyConfigMasked, setGlobalProxy, setAccountProxy, removeProxy, getEffectiveProxy } from './proxy-config.js';
 import { MODELS, MODEL_TIER_ACCESS as _TIER_TABLE, getTierModels as _getTierModels } from '../models.js';
@@ -266,6 +268,17 @@ export async function handleDashboardApi(method, subpath, body, req, res) {
   if (subpath === '/experimental/conversation-pool' && method === 'DELETE') {
     const n = convPoolClear();
     return json(res, 200, { success: true, cleared: n });
+  }
+  if (subpath === '/codex' && method === 'GET') {
+    return json(res, 200, { settings: getCodexSettings(), sticky: stickyStats() });
+  }
+  if (subpath === '/codex' && method === 'PUT') {
+    const settings = setCodexSettings(body || {});
+    return json(res, 200, { success: true, settings, sticky: stickyStats() });
+  }
+  if (subpath === '/codex/sticky-sessions' && method === 'DELETE') {
+    const n = clearStickySessions();
+    return json(res, 200, { success: true, cleared: n, sticky: stickyStats() });
   }
 
   // ─── System prompts (tool reinforcement, communication) ──

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -2222,6 +2222,57 @@ window._firebaseOAuth = async function(provider) {
     </div>
     <div class="section" style="margin-top:24px">
       <div class="section-header">
+        <div class="section-title">Codex WebSocket / Sticky Sessions</div>
+      </div>
+      <div class="section-body">
+        <div class="section-desc" style="margin-bottom:12px">Codex-compatible Responses WebSocket endpoints plus durable account affinity. Keep this on for Codex CLI; turn sticky off for pure round-robin OpenAI/Anthropic traffic.</div>
+        <div style="display:grid;gap:12px;padding:12px;background:var(--surface-2);border-radius:var(--radius)">
+          <div style="display:flex;align-items:center;gap:16px;flex-wrap:wrap">
+            <label class="switch">
+              <input type="checkbox" id="codex-ws-enabled">
+              <span class="switch-slider"></span>
+            </label>
+            <div style="min-width:220px">
+              <div style="font-weight:500">Enable Responses WebSocket</div>
+              <div class="text-sm text-muted">Serves /v1/responses, /v1/ws/responses and /backend-api/codex/responses over WebSocket.</div>
+            </div>
+          </div>
+          <div style="display:flex;align-items:center;gap:16px;flex-wrap:wrap">
+            <label class="switch">
+              <input type="checkbox" id="codex-sticky-enabled">
+              <span class="switch-slider"></span>
+            </label>
+            <div style="min-width:220px">
+              <div style="font-weight:500">Enable durable sticky routing</div>
+              <div class="text-sm text-muted">Pins Codex turn/session/prompt-cache keys to the same Windsurf account when possible.</div>
+            </div>
+          </div>
+          <div style="display:flex;gap:12px;align-items:center;flex-wrap:wrap">
+            <label class="text-sm text-muted">Mode</label>
+            <select id="codex-sticky-mode" class="input" style="max-width:180px">
+              <option value="auto">auto</option>
+              <option value="off">off</option>
+              <option value="codex_session">codex_session</option>
+              <option value="prompt_cache">prompt_cache</option>
+              <option value="sticky_thread">sticky_thread</option>
+            </select>
+            <label class="text-sm text-muted">Prompt-cache TTL seconds</label>
+            <input id="codex-prompt-cache-ttl" class="input" type="number" min="1" max="2592000" style="max-width:140px">
+            <label style="display:flex;gap:8px;align-items:center">
+              <input type="checkbox" id="codex-derive-cache-key"> <span class="text-sm">derive cache key</span>
+            </label>
+            <label style="display:flex;gap:8px;align-items:center">
+              <input type="checkbox" id="codex-reallocate-sticky"> <span class="text-sm">reallocate fallback</span>
+            </label>
+            <button class="btn btn-primary btn-sm" onclick="App.saveCodexSettings()">Save</button>
+            <button class="btn btn-outline btn-sm" onclick="App.clearStickySessions()">Clear sticky</button>
+          </div>
+        </div>
+        <div class="metrics-grid" id="codex-sticky-cards" style="margin-top:12px"></div>
+      </div>
+    </div>
+    <div class="section" style="margin-top:24px">
+      <div class="section-header">
         <div class="section-title" data-i18n="section.droughtRestrict.title">配额低水位时屏蔽 premium 模型</div>
       </div>
       <div class="section-body">
@@ -5318,6 +5369,7 @@ docker compose up -d --force-recreate</pre>
     const cbQw = document.getElementById('exp-quiet-window');
     if (cbQw) cbQw.checked = !!d.flags?.autoUpdateQuietWindow;
     this.loadQuietWindowStatus();
+    this.loadCodexSettings();
     // Reflect current skin cookie in the dropdown so reload state is visible.
     const skinSel = document.getElementById('skin-select');
     if (skinSel) {
@@ -5426,6 +5478,58 @@ docker compose up -d --force-recreate</pre>
       this.toast(I18n.t('toast.toggleFailed', { error: e.message }), 'error');
       this.loadExperimental();
     }
+  },
+
+  async loadCodexSettings() {
+    const holder = document.getElementById('codex-sticky-cards');
+    try {
+      const r = await this.api('GET', '/codex');
+      const s = r.settings || {};
+      const sticky = r.sticky || {};
+      const ws = document.getElementById('codex-ws-enabled');
+      const se = document.getElementById('codex-sticky-enabled');
+      const mode = document.getElementById('codex-sticky-mode');
+      const ttl = document.getElementById('codex-prompt-cache-ttl');
+      const derive = document.getElementById('codex-derive-cache-key');
+      const realloc = document.getElementById('codex-reallocate-sticky');
+      if (ws) ws.checked = !!s.websocketEnabled;
+      if (se) se.checked = !!s.stickySessionsEnabled;
+      if (mode) mode.value = s.stickySessionMode || 'auto';
+      if (ttl) ttl.value = s.promptCacheMaxAgeSeconds || 1800;
+      if (derive) derive.checked = !!s.derivePromptCacheKey;
+      if (realloc) realloc.checked = !!s.reallocateSticky;
+      if (holder) {
+        holder.innerHTML = `
+          <div class="card"><div class="card-header"><div class="card-title">Sticky entries</div></div><div class="card-value">${sticky.size || 0}</div><div class="card-sub">max ${sticky.maxSize || 0}</div></div>
+          <div class="card"><div class="card-header"><div class="card-title">Hit rate</div></div><div class="card-value">${sticky.hitRate || '0.0'}%</div><div class="card-sub">${sticky.hits || 0} hits / ${sticky.misses || 0} misses</div></div>
+          <div class="card"><div class="card-header"><div class="card-title">Stores</div></div><div class="card-value">${sticky.stores || 0}</div><div class="card-sub">${sticky.expired || 0} expired / ${sticky.evictions || 0} evicted</div></div>
+        `;
+      }
+    } catch (e) {
+      if (holder) holder.innerHTML = `<div class="text-sm text-danger">${this.esc(e.message)}</div>`;
+    }
+  },
+
+  async saveCodexSettings() {
+    const patch = {
+      websocketEnabled: !!document.getElementById('codex-ws-enabled')?.checked,
+      stickySessionsEnabled: !!document.getElementById('codex-sticky-enabled')?.checked,
+      stickySessionMode: document.getElementById('codex-sticky-mode')?.value || 'auto',
+      promptCacheMaxAgeSeconds: parseInt(document.getElementById('codex-prompt-cache-ttl')?.value || '1800', 10),
+      derivePromptCacheKey: !!document.getElementById('codex-derive-cache-key')?.checked,
+      reallocateSticky: !!document.getElementById('codex-reallocate-sticky')?.checked,
+    };
+    await this.api('PUT', '/codex', patch);
+    this.toast(I18n.t('toast.saved') || 'Saved', 'success');
+    this.loadCodexSettings();
+  },
+
+  async clearStickySessions() {
+    const ok = await this.confirm('Clear sticky sessions', 'Clear all Codex sticky account mappings?', { okText: I18n.t('action.clear') || 'Clear' });
+    if (!ok) return;
+    const r = await this.api('DELETE', '/codex/sticky-sessions');
+    this.toast(`Cleared ${r.cleared || 0} sticky sessions`, 'success');
+    this.loadCodexSettings();
   },
 
   // v2.0.70 (#112 follow-up) — quiet-window status panel + manual run.

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -5,7 +5,7 @@
 
 import { createHash, randomUUID } from 'crypto';
 import { WindsurfClient, contentToString, isCascadeTransportError } from '../client.js';
-import { getApiKey, acquireAccountByKey, releaseAccount, getAccountAvailability, reportError, reportSuccess, markRateLimited, reportInternalError, updateCapability, getAccountList, isAllRateLimited, isAllTemporarilyUnavailable, refundReservation, looksLikeBanSignal, reportBanSignal, clearBanSignals, isModelBlockedByDrought, getDroughtSummary } from '../auth.js';
+import { getApiKey, acquireAccountByKey, acquireAccountById, releaseAccount, getAccountAvailability, reportError, reportSuccess, markRateLimited, reportInternalError, updateCapability, getAccountList, isAllRateLimited, isAllTemporarilyUnavailable, refundReservation, looksLikeBanSignal, reportBanSignal, clearBanSignals, isModelBlockedByDrought, getDroughtSummary } from '../auth.js';
 import { resolveModel, getModelInfo, pickRateLimitFallback } from '../models.js';
 import { getLsFor, ensureLs } from '../langserver.js';
 import { config, log } from '../config.js';
@@ -31,6 +31,9 @@ import {
 } from '../cascade-native-bridge.js';
 import { sanitizeText, sanitizeToolCall, PathSanitizeStream } from '../sanitize.js';
 import { registerSseController } from '../sse-registry.js';
+import {
+  buildStickyContext, getStickyAccountId, bindStickyAccount, shouldPreserveStickyFallback,
+} from '../sticky-sessions.js';
 
 const HEARTBEAT_MS = 15_000;
 const QUEUE_RETRY_MS = 1_000;
@@ -81,6 +84,21 @@ async function internalErrorBackoff(retryIdx) {
   const ms = Math.min(500 * Math.pow(2, retryIdx), 5000);
   await new Promise(r => setTimeout(r, ms));
   return ms;
+}
+
+function stickyFromContext(body, context, callerKey) {
+  return context.sticky || buildStickyContext(body, context.headers || {}, callerKey);
+}
+
+function bindStickyAfterSuccess(sticky, selectedAccount, existingAccountId, reqId) {
+  if (!sticky || !selectedAccount?.id) return;
+  const preserveExisting = shouldPreserveStickyFallback(sticky, existingAccountId, selectedAccount.id);
+  const stored = bindStickyAccount(sticky, selectedAccount.id, { preserveExisting });
+  if (stored) {
+    log.info(`Chat[${reqId}]: sticky ${sticky.kind} bound key=${sticky.keyHash} account=${selectedAccount.id}`);
+  } else if (preserveExisting) {
+    log.info(`Chat[${reqId}]: sticky ${sticky.kind} preserved original account=${existingAccountId} during fallback`);
+  }
 }
 
 function upstreamTransientErrorMessage(model, triedCount, reason = 'internal_error') {
@@ -1232,7 +1250,9 @@ export async function handleChatCompletions(body, context = {}) {
   // original-model request will look up, instead of the fallback-model
   // slot that the next request will miss.
   const originalCkey = cacheKey(body, context.callerKey || body.__callerKey || '');
-  const result = await _handleChatCompletionsInner(body, { ...context, __originalCkey: originalCkey });
+  const innerContext = { ...context, __originalCkey: originalCkey };
+  const result = await _handleChatCompletionsInner(body, innerContext);
+  if (result && typeof result === 'object' && !result.context) result.context = innerContext;
   if (shouldAutoFallback(body, context, result)) {
     // v2.0.88 (audit H-1) — `body.model` is the RAW request string; the
     // inner handler resolves it through mergeReasoningEffortIntoModel +
@@ -1248,14 +1268,16 @@ export async function handleChatCompletions(body, context = {}) {
     const originalModel = body.model;
     const fallbackModel = result.body.error.fallback_model;
     log.info(`auto-fallback: ${originalModel} → ${fallbackModel} (alias-key=${originalRoutingKey} whole pool rate_limited)`);
+    const fallbackContext = { ...context, __fallbackAttempt: true, __aliasModelKey: originalRoutingKey, __originalCkey: originalCkey };
     const fallbackResult = await _handleChatCompletionsInner(
       { ...body, model: fallbackModel },
       // __aliasModelKey carries the resolved/merged ORIGINAL routing
       // key so cascade pool dual-index hits the slot the next turn
       // will actually look up. __originalCkey threads through so
       // cacheSet writes also go to the original-model cache slot.
-      { ...context, __fallbackAttempt: true, __aliasModelKey: originalRoutingKey, __originalCkey: originalCkey },
+      fallbackContext,
     );
+    if (fallbackResult && typeof fallbackResult === 'object' && !fallbackResult.context) fallbackResult.context = fallbackContext;
     // Restore original model id in the response body so client code
     // matching on `response.model === requested model` still works.
     if (fallbackResult?.body) {
@@ -1812,6 +1834,13 @@ async function _handleChatCompletionsInner(body, context = {}) {
   // instead of putting a known-dead cascadeId back in the pool.
   let reuseEntryDead = false;
   if (reuseEntry) log.info(`Chat[${reqId}]: reuse HIT cascade=${reuseEntry.cascadeId.slice(0, 8)} model=${displayModel}`);
+  const sticky = stickyFromContext(body, context, callerKey);
+  const preferredAccountId = context.preferredAccountId || '';
+  const requirePreferredAccount = !!(context.requirePreferredAccount && preferredAccountId);
+  const stickyAccountId = preferredAccountId || (sticky && !reuseEntry ? getStickyAccountId(sticky) : null);
+  if (sticky) {
+    log.info(`Chat[${reqId}]: sticky ${sticky.kind} key=${sticky.keyHash} ${stickyAccountId ? `HIT account=${stickyAccountId}` : 'MISS'}`);
+  }
 
   // Non-stream: retry with a different account on model-not-available errors
   const tried = [];
@@ -1860,6 +1889,25 @@ async function _handleChatCompletionsInner(body, context = {}) {
             };
           }
           reuseEntry = null;
+        }
+      }
+    }
+    if (!acct) {
+      if (stickyAccountId && attempt === 0) {
+        acct = acquireAccountById(stickyAccountId, routingModelKey);
+        if (!acct) {
+          if (requirePreferredAccount) {
+            return {
+              status: 409,
+              body: {
+                error: {
+                  message: 'Previous response owner account is unavailable; retry later.',
+                  type: 'previous_response_unavailable',
+                },
+              },
+            };
+          }
+          log.info(`Chat[${reqId}]: sticky ${sticky?.kind || 'preferred'} owner unavailable account=${stickyAccountId}; falling back`);
         }
       }
     }
@@ -2422,6 +2470,9 @@ async function nonStreamResponse(client, id, created, model, modelKey, messages,
       }, poolCtx.callerKey || '', ttlHint === undefined ? 0 : ttlHint);
     }
 
+    if (acct?.id) context.__selectedAccountId = acct.id;
+    if (apiKey) context.__selectedApiKey = apiKey;
+    bindStickyAfterSuccess(sticky, acct, stickyAccountId, reqId);
     reportSuccess(apiKey);
     updateCapability(apiKey, modelKey, true, 'success');
     recordRequest(model, true, Date.now() - startTime, apiKey);
@@ -2719,6 +2770,13 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
       // v2.0.25 HIGH-2: same dead-entry signal as the non-stream path.
       let reuseEntryDead = false;
       if (reuseEntry) log.info(`Chat: cascade reuse HIT cascadeId=${reuseEntry.cascadeId.slice(0, 8)}… stream model=${model}`);
+      const sticky = stickyFromContext({ model, messages }, deps.context || {}, callerKey);
+      const preferredAccountId = deps.context?.preferredAccountId || '';
+      const requirePreferredAccount = !!(deps.context?.requirePreferredAccount && preferredAccountId);
+      const stickyAccountId = preferredAccountId || (sticky && !reuseEntry ? getStickyAccountId(sticky) : null);
+      if (sticky) {
+        log.info(`Chat[${reqId}]: sticky ${sticky.kind} key=${sticky.keyHash} ${stickyAccountId ? `HIT account=${stickyAccountId}` : 'MISS'} stream`);
+      }
 
       // Strip <tool_call>/<tool_result> blocks in Cascade mode.
       // In emulation mode, parsed calls are emitted as OpenAI tool_calls.
@@ -2910,6 +2968,21 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
                   break;
                 }
                 reuseEntry = null;
+              }
+            }
+          }
+          if (!acct) {
+            if (stickyAccountId && attempt === 0) {
+              acct = acquireAccountById(stickyAccountId, modelKey);
+              if (!acct) {
+                if (requirePreferredAccount) {
+                  send({ id, object: 'chat.completion.chunk', created, model,
+                    choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+                    error: { message: 'Previous response owner account is unavailable; retry later.', type: 'previous_response_unavailable' } });
+                  if (!res.writableEnded) { res.write('data: [DONE]\n\n'); res.end(); }
+                  return;
+                }
+                log.info(`Chat[${reqId}]: sticky ${sticky?.kind || 'preferred'} owner unavailable account=${stickyAccountId}; falling back stream`);
               }
             }
           }
@@ -3154,6 +3227,9 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
               }, callerKey, ttlHint === undefined ? 0 : ttlHint);
             }
             // success
+            if (acct?.id && deps.context) deps.context.__selectedAccountId = acct.id;
+            if (currentApiKey && deps.context) deps.context.__selectedApiKey = currentApiKey;
+            bindStickyAfterSuccess(sticky, acct, stickyAccountId, reqId);
             if (hadSuccess) reportSuccess(currentApiKey);
             updateCapability(currentApiKey, modelKey, true, 'success');
             recordRequest(model, true, Date.now() - startTime, currentApiKey);

--- a/src/handlers/responses.js
+++ b/src/handlers/responses.js
@@ -8,6 +8,7 @@
 import { randomUUID } from 'crypto';
 import { handleChatCompletions } from './chat.js';
 import { log } from '../config.js';
+import { buildStickyContext } from '../sticky-sessions.js';
 
 function genResponseId() {
   return 'resp_' + randomUUID().replace(/-/g, '').slice(0, 24);
@@ -834,7 +835,10 @@ function createCaptureRes(translator, realRes) {
 
 export async function handleResponses(body, deps = {}) {
   const chatHandler = deps.handleChatCompletions || handleChatCompletions;
-  const context = deps.context || {};
+  const context = { ...(deps.context || {}) };
+  if (!context.sticky) {
+    context.sticky = buildStickyContext(body, context.headers || {}, context.callerKey || body.__callerKey || '');
+  }
   const responseId = genResponseId();
   const requestedModel = body.model || 'claude-sonnet-4.6';
   let chatBody;
@@ -843,6 +847,7 @@ export async function handleResponses(body, deps = {}) {
   } catch (err) {
     return {
       status: 400,
+      context,
       body: {
         error: {
           message: err?.message || 'Invalid Responses request',
@@ -856,16 +861,19 @@ export async function handleResponses(body, deps = {}) {
 
   if (!body.stream) {
     const result = await chatHandler({ ...chatBody, stream: false, __route: 'responses' }, context);
-    if (result.status !== 200) return result;
-    return { status: 200, body: chatToResponse(result.body, requestedModel, responseId, genMessageId(), requestedTools) };
+    const resultContext = result.context || context;
+    if (result.status !== 200) return { ...result, context: resultContext };
+    return { status: 200, context: resultContext, body: chatToResponse(result.body, requestedModel, responseId, genMessageId(), requestedTools) };
   }
 
   const streamResult = await chatHandler({ ...chatBody, stream: true, __route: 'responses' }, context);
-  if (!streamResult.stream) return streamResult;
+  const streamContext = streamResult.context || context;
+  if (!streamResult.stream) return { ...streamResult, context: streamContext };
 
   return {
     status: 200,
     stream: true,
+    context: streamContext,
     headers: {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-store',

--- a/src/runtime-config.js
+++ b/src/runtime-config.js
@@ -51,6 +51,17 @@ const DEFAULTS = {
     cooldownHours: 24,
     coldStartGraceMs: 600000,
   },
+  // Codex compatibility knobs. These are runtime settings because Codex
+  // clients vary a lot: some need durable session affinity, while normal
+  // OpenAI/Anthropic users may prefer pure load balancing.
+  codex: {
+    websocketEnabled: true,
+    stickySessionsEnabled: true,
+    stickySessionMode: 'auto', // auto | off | codex_session | prompt_cache | sticky_thread
+    promptCacheMaxAgeSeconds: 1800,
+    derivePromptCacheKey: true,
+    reallocateSticky: false,
+  },
   // System-level prompt templates injected into Cascade proto fields.
   // Editable from Dashboard so users can tune without code changes.
   systemPrompts: {
@@ -135,6 +146,38 @@ export function setExperimental(patch) {
   }
   persist();
   return getExperimental();
+}
+
+const STICKY_MODES = new Set(['auto', 'off', 'codex_session', 'prompt_cache', 'sticky_thread']);
+
+function positiveInt(value, fallback, min = 1, max = 86400 * 30) {
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, n));
+}
+
+export function getCodexSettings() {
+  return { ...DEFAULTS.codex, ...(_state.codex || {}) };
+}
+
+export function setCodexSettings(patch) {
+  if (!patch || typeof patch !== 'object') return getCodexSettings();
+  const cur = getCodexSettings();
+  const next = { ...cur };
+  if ('websocketEnabled' in patch) next.websocketEnabled = !!patch.websocketEnabled;
+  if ('stickySessionsEnabled' in patch) next.stickySessionsEnabled = !!patch.stickySessionsEnabled;
+  if ('derivePromptCacheKey' in patch) next.derivePromptCacheKey = !!patch.derivePromptCacheKey;
+  if ('reallocateSticky' in patch) next.reallocateSticky = !!patch.reallocateSticky;
+  if ('stickySessionMode' in patch) {
+    const mode = String(patch.stickySessionMode || '').trim();
+    if (STICKY_MODES.has(mode)) next.stickySessionMode = mode;
+  }
+  if ('promptCacheMaxAgeSeconds' in patch) {
+    next.promptCacheMaxAgeSeconds = positiveInt(patch.promptCacheMaxAgeSeconds, cur.promptCacheMaxAgeSeconds);
+  }
+  _state.codex = next;
+  persist();
+  return getCodexSettings();
 }
 
 export function getSystemPrompts() {
@@ -292,4 +335,3 @@ import('./auth.js').then(m => {
     m.setDroughtRestrictResolver(() => isExperimentalEnabled('droughtRestrictPremium'));
   }
 }).catch(() => { /* auth not yet ready, validateApiKey falls back to env */ });
-

--- a/src/server.js
+++ b/src/server.js
@@ -31,6 +31,7 @@ import { setAccountProxy } from './dashboard/proxy-config.js';
 import { config, log } from './config.js';
 import { VERSION } from './version.js';
 import { callerKeyFromRequest } from './caller-key.js';
+import { handleResponsesWebSocketUpgrade } from './ws-responses.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
@@ -334,7 +335,7 @@ async function route(req, res) {
     }
 
     const reqStartedAt = Date.now();
-    const result = await handleChatCompletions(body, { callerKey: callerKeyFromRequest(req, extractToken(req), body) });
+    const result = await handleChatCompletions(body, { callerKey: callerKeyFromRequest(req, extractToken(req), body), headers: req.headers });
     const processingMs = Date.now() - reqStartedAt;
     const modelHeaders = {
       'x-request-id': 'req-' + randomUUID(),
@@ -384,7 +385,7 @@ async function route(req, res) {
     }
 
     const reqStartedAt = Date.now();
-    const result = await handleResponses(body, { context: { callerKey: callerKeyFromRequest(req, extractToken(req), body) } });
+    const result = await handleResponses(body, { context: { callerKey: callerKeyFromRequest(req, extractToken(req), body), headers: req.headers } });
     const processingMs = Date.now() - reqStartedAt;
     const modelHeaders = {
       'x-request-id': 'req-' + randomUUID(),
@@ -455,6 +456,11 @@ export function startServer() {
 
   server.keepAliveTimeout = 65_000;
   server.headersTimeout = 66_000;
+  server.on('upgrade', (req, socket, head) => {
+    if (handleResponsesWebSocketUpgrade(req, socket, head)) return;
+    socket.write('HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n');
+    socket.destroy();
+  });
 
   let retryCount = 0;
   const maxRetries = 10;

--- a/src/sticky-sessions.js
+++ b/src/sticky-sessions.js
@@ -1,0 +1,255 @@
+/**
+ * Durable Codex-style sticky routing.
+ *
+ * This complements the in-memory Cascade conversation pool: sticky sessions
+ * decide which account should serve a downstream Codex/OpenAI session, while
+ * the Cascade pool decides whether a specific upstream cascade_id can be
+ * resumed once that account/LS pair is selected.
+ */
+
+import { createHash, randomUUID } from 'crypto';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { writeJsonAtomic } from './fs-atomic.js';
+import { config, log } from './config.js';
+import { getCodexSettings } from './runtime-config.js';
+
+const FILE = join(config.sharedDataDir || config.dataDir, 'sticky-sessions.json');
+const VALID_KINDS = new Set(['codex_session', 'prompt_cache', 'sticky_thread']);
+const MAX_ENTRIES = 5000;
+
+const _state = {
+  version: 1,
+  entries: {},
+  stats: { hits: 0, misses: 0, stores: 0, evictions: 0, expired: 0 },
+};
+
+function sha256(value) {
+  return createHash('sha256').update(String(value || '')).digest('hex');
+}
+
+function short(value, n = 12) {
+  return sha256(value).slice(0, n);
+}
+
+function load() {
+  if (!existsSync(FILE)) return;
+  try {
+    const raw = JSON.parse(readFileSync(FILE, 'utf-8'));
+    if (raw && typeof raw === 'object') {
+      if (raw.entries && typeof raw.entries === 'object') _state.entries = raw.entries;
+      if (raw.stats && typeof raw.stats === 'object') _state.stats = { ..._state.stats, ...raw.stats };
+    }
+  } catch (e) {
+    log.warn(`sticky-sessions: failed to load ${FILE}: ${e.message}`);
+  }
+}
+
+function persist() {
+  try {
+    writeJsonAtomic(FILE, _state);
+  } catch (e) {
+    log.warn(`sticky-sessions: failed to persist: ${e.message}`);
+  }
+}
+
+load();
+
+function normalizeHeaders(headers = {}) {
+  const out = {};
+  for (const [k, v] of Object.entries(headers || {})) {
+    const value = Array.isArray(v) ? v[0] : v;
+    if (value != null) out[String(k).toLowerCase()] = String(value);
+  }
+  return out;
+}
+
+function cleanString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : '';
+}
+
+function promptCacheKeyFromBody(body = {}) {
+  return cleanString(body.prompt_cache_key)
+    || cleanString(body.promptCacheKey)
+    || cleanString(body?.metadata?.prompt_cache_key)
+    || cleanString(body?.metadata?.promptCacheKey);
+}
+
+function firstUserText(body = {}) {
+  const input = body.input ?? body.messages;
+  if (typeof input === 'string') return input.slice(0, 512);
+  if (!Array.isArray(input)) return '';
+  for (const item of input) {
+    if (!item || typeof item !== 'object') continue;
+    if (item.role && item.role !== 'user') continue;
+    const content = item.content ?? item.text ?? item.input;
+    if (typeof content === 'string') return content.slice(0, 512);
+    if (Array.isArray(content)) {
+      for (const part of content) {
+        if (typeof part === 'string') return part.slice(0, 512);
+        if (typeof part?.text === 'string') return part.text.slice(0, 512);
+      }
+    }
+  }
+  return '';
+}
+
+function derivePromptCacheKey(body = {}, callerKey = '') {
+  const parts = [];
+  const model = cleanString(body.model);
+  if (model) parts.push(model.includes('codex') ? 'codex' : model.includes('mini') ? 'mini' : 'std');
+  if (callerKey) parts.push(short(callerKey));
+  if (body.instructions) parts.push(short(String(body.instructions).slice(0, 512)));
+  const first = firstUserText(body);
+  if (first) parts.push(short(first));
+  return parts.length ? parts.join('-') : `anon-${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+}
+
+function sessionKeyFromHeaders(headers = {}) {
+  const h = normalizeHeaders(headers);
+  return cleanString(h['x-codex-turn-state'])
+    || cleanString(h.session_id)
+    || cleanString(h['x-codex-session-id'])
+    || cleanString(h['x-codex-conversation-id'])
+    || cleanString(h['x-session-id']);
+}
+
+function entryId(sticky) {
+  return sha256(`${sticky.scope || ''}\0${sticky.kind}\0${sticky.key}`);
+}
+
+function pruneExpired(now = Date.now()) {
+  let removed = 0;
+  for (const [id, entry] of Object.entries(_state.entries)) {
+    if (!entry || !entry.maxAgeSeconds) continue;
+    if ((entry.updatedAt || 0) + entry.maxAgeSeconds * 1000 < now) {
+      delete _state.entries[id];
+      removed++;
+    }
+  }
+  if (removed) {
+    _state.stats.expired += removed;
+    persist();
+  }
+  return removed;
+}
+
+function evictIfNeeded() {
+  const entries = Object.entries(_state.entries);
+  if (entries.length <= MAX_ENTRIES) return 0;
+  entries.sort((a, b) => (a[1].updatedAt || 0) - (b[1].updatedAt || 0));
+  const removeCount = entries.length - MAX_ENTRIES;
+  for (let i = 0; i < removeCount; i++) delete _state.entries[entries[i][0]];
+  _state.stats.evictions += removeCount;
+  return removeCount;
+}
+
+export function buildStickyContext(body = {}, headers = {}, callerKey = '') {
+  const settings = getCodexSettings();
+  if (!settings.stickySessionsEnabled) return null;
+  const mode = settings.stickySessionMode || 'auto';
+  if (mode === 'off') return null;
+
+  const headerKey = sessionKeyFromHeaders(headers);
+  const explicitPromptKey = promptCacheKeyFromBody(body);
+  const promptKey = explicitPromptKey
+    || (settings.derivePromptCacheKey ? derivePromptCacheKey(body, callerKey) : '');
+
+  let kind = null;
+  let key = '';
+  if (mode === 'auto') {
+    if (headerKey) {
+      kind = 'codex_session';
+      key = headerKey;
+    } else if (promptKey) {
+      kind = 'prompt_cache';
+      key = promptKey;
+    }
+  } else {
+    kind = mode;
+    key = kind === 'codex_session' ? (headerKey || promptKey) : (promptKey || headerKey);
+  }
+  if (!key || !VALID_KINDS.has(kind)) return null;
+
+  const maxAgeSeconds = kind === 'prompt_cache'
+    ? Math.max(1, parseInt(settings.promptCacheMaxAgeSeconds || 1800, 10))
+    : 0;
+  return {
+    key,
+    kind,
+    scope: callerKey || '',
+    keyHash: short(key, 16),
+    maxAgeSeconds,
+    reallocate: !!settings.reallocateSticky || kind === 'sticky_thread',
+  };
+}
+
+export function getStickyAccountId(sticky) {
+  if (!sticky?.key || !sticky?.kind) return null;
+  pruneExpired();
+  const id = entryId(sticky);
+  const entry = _state.entries[id];
+  if (!entry) {
+    _state.stats.misses++;
+    return null;
+  }
+  if (entry.maxAgeSeconds && (entry.updatedAt || 0) + entry.maxAgeSeconds * 1000 < Date.now()) {
+    delete _state.entries[id];
+    _state.stats.expired++;
+    _state.stats.misses++;
+    persist();
+    return null;
+  }
+  _state.stats.hits++;
+  return entry.accountId || null;
+}
+
+export function bindStickyAccount(sticky, accountId, options = {}) {
+  if (!sticky?.key || !sticky?.kind || !accountId) return false;
+  const id = entryId(sticky);
+  const existing = _state.entries[id];
+  if (options.preserveExisting && existing && existing.accountId && existing.accountId !== accountId) {
+    return false;
+  }
+  const now = Date.now();
+  _state.entries[id] = {
+    id,
+    kind: sticky.kind,
+    keyHash: sticky.keyHash || short(sticky.key, 16),
+    scopeHash: sticky.scope ? short(sticky.scope, 16) : '',
+    accountId,
+    maxAgeSeconds: sticky.maxAgeSeconds || 0,
+    createdAt: existing?.createdAt || now,
+    updatedAt: now,
+  };
+  _state.stats.stores++;
+  evictIfNeeded();
+  persist();
+  return true;
+}
+
+export function shouldPreserveStickyFallback(sticky, existingAccountId, chosenAccountId) {
+  if (!sticky || !existingAccountId || !chosenAccountId) return false;
+  if (existingAccountId === chosenAccountId) return false;
+  if (sticky.reallocate) return false;
+  return sticky.kind === 'prompt_cache';
+}
+
+export function stickyStats() {
+  pruneExpired();
+  const total = _state.stats.hits + _state.stats.misses;
+  return {
+    enabled: getCodexSettings().stickySessionsEnabled,
+    size: Object.keys(_state.entries).length,
+    maxSize: MAX_ENTRIES,
+    ..._state.stats,
+    hitRate: total ? ((_state.stats.hits / total) * 100).toFixed(1) : '0.0',
+  };
+}
+
+export function clearStickySessions() {
+  const n = Object.keys(_state.entries).length;
+  _state.entries = {};
+  persist();
+  return n;
+}

--- a/src/ws-responses.js
+++ b/src/ws-responses.js
@@ -1,0 +1,718 @@
+/**
+ * Minimal Codex/OpenAI Responses WebSocket facade.
+ *
+ * Upstream Windsurf is still served through the existing HTTP/SSE Responses
+ * adapter. This layer speaks downstream WebSocket so Codex-style clients can
+ * send `response.create` frames and receive Responses event JSON frames.
+ */
+
+import { createHash, randomUUID } from 'crypto';
+import { handleResponses } from './handlers/responses.js';
+import { validateApiKey, isAuthenticated } from './auth.js';
+import { callerKeyFromRequest } from './caller-key.js';
+import { getCodexSettings } from './runtime-config.js';
+import { log } from './config.js';
+
+let handleResponsesImpl = handleResponses;
+
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+const WS_PATHS = new Set([
+  '/v1/responses',
+  '/v1/ws/responses',
+  '/backend-api/codex/responses',
+]);
+const MAX_WS_FRAME_BYTES = 16 * 1024 * 1024;
+const MAX_WS_MESSAGE_BYTES = 16 * 1024 * 1024;
+const MAX_WS_BUFFER_BYTES = MAX_WS_FRAME_BYTES + 14;
+const MAX_WS_FRAGMENTS = 4096;
+const WS_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const WS_PARTIAL_TIMEOUT_MS = 30 * 1000;
+const TURN_STATE_RE = /^[A-Za-z0-9._:-]{1,256}$/;
+const HEADER_NAME_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const UTF8_DECODER = new TextDecoder('utf-8', { fatal: true });
+const RESPONSE_OWNER_MAX = 5000;
+const RESPONSE_OWNER_TTL_MS = 6 * 60 * 60 * 1000;
+const _responseOwners = new Map();
+
+class WebSocketProtocolError extends Error {
+  constructor(message, closeCode = 1002) {
+    super(message);
+    this.closeCode = closeCode;
+  }
+}
+
+function extractToken(req) {
+  const authHeader = String(req.headers['authorization'] || '').trim();
+  if (authHeader && authHeader.includes(',')) return '';
+  const m = authHeader.match(/^Bearer\s+(.+)$/i);
+  if (m) return m[1].trim();
+  const apiKey = req.headers['x-api-key'];
+  return Array.isArray(apiKey) ? apiKey[0] : String(apiKey || '');
+}
+
+function safeHttpHeaderLines(headers) {
+  return Object.entries(headers)
+    .filter(([k, v]) => HEADER_NAME_RE.test(k) && !/[\r\n]/.test(String(v)))
+    .map(([k, v]) => `${k}: ${v}\r\n`)
+    .join('');
+}
+
+function httpReject(socket, status, message, headers = {}) {
+  const body = JSON.stringify({ error: { message } });
+  const extraHeaders = safeHttpHeaderLines(headers);
+  socket.write(
+    `HTTP/1.1 ${status} ${message}\r\n`
+    + 'Content-Type: application/json\r\n'
+    + `Content-Length: ${Buffer.byteLength(body)}\r\n`
+    + extraHeaders
+    + 'Connection: close\r\n\r\n'
+    + body
+  );
+  socket.destroy();
+}
+
+function acceptKey(secKey) {
+  return createHash('sha1').update(secKey + WS_GUID).digest('base64');
+}
+
+function headerHasToken(value, token) {
+  return String(value || '')
+    .split(',')
+    .map(v => v.trim().toLowerCase())
+    .includes(token);
+}
+
+function isValidSecWebSocketKey(key) {
+  if (typeof key !== 'string') return false;
+  if (!/^[A-Za-z0-9+/]{22}==$/.test(key)) return false;
+  try {
+    const raw = Buffer.from(key, 'base64');
+    return raw.length === 16;
+  } catch {
+    return false;
+  }
+}
+
+function nextTurnState() {
+  return `turn_${randomUUID().replace(/-/g, '')}`;
+}
+
+function normalizeTurnState(value) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const turnState = String(raw || '').trim();
+  return TURN_STATE_RE.test(turnState) ? turnState : nextTurnState();
+}
+
+function canWrite(socket) {
+  return !socket.destroyed && socket.writableEnded !== true && socket.writable !== false;
+}
+
+function sendFrame(socket, opcode, payload = Buffer.alloc(0)) {
+  if (!canWrite(socket)) return false;
+  const body = Buffer.isBuffer(payload) ? payload : Buffer.from(String(payload));
+  const len = body.length;
+  let header;
+  if (len < 126) {
+    header = Buffer.from([0x80 | opcode, len]);
+  } else if (len <= 0xffff) {
+    header = Buffer.alloc(4);
+    header[0] = 0x80 | opcode;
+    header[1] = 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x80 | opcode;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  socket.write(Buffer.concat([header, body]));
+  return true;
+}
+
+function sendText(socket, payload) {
+  return sendFrame(socket, 0x1, typeof payload === 'string' ? payload : JSON.stringify(payload));
+}
+
+function sendClose(socket, code = 1000, reason = '') {
+  const reasonBuf = Buffer.from(String(reason)).subarray(0, 123);
+  const payload = Buffer.alloc(2 + reasonBuf.length);
+  payload.writeUInt16BE(code, 0);
+  reasonBuf.copy(payload, 2);
+  try { sendFrame(socket, 0x8, payload); } catch {}
+  socket.end();
+}
+
+function parseFrames(state, chunk, { requireMasked = false } = {}) {
+  if (chunk && chunk.length) {
+    state.buffer = state.buffer.length ? Buffer.concat([state.buffer, chunk]) : chunk;
+    if (state.buffer.length > MAX_WS_BUFFER_BYTES) {
+      throw new WebSocketProtocolError('WebSocket frame too large', 1009);
+    }
+  }
+  const frames = [];
+  while (state.buffer.length >= 2) {
+    const b0 = state.buffer[0];
+    const b1 = state.buffer[1];
+    const fin = !!(b0 & 0x80);
+    const rsv = b0 & 0x70;
+    const opcode = b0 & 0x0f;
+    const masked = !!(b1 & 0x80);
+    let len = b1 & 0x7f;
+    let offset = 2;
+    if (rsv) throw new WebSocketProtocolError('Unsupported WebSocket extension bits');
+    if (requireMasked && !masked) throw new WebSocketProtocolError('Client WebSocket frames must be masked');
+    if ((opcode >= 0x3 && opcode <= 0x7) || opcode > 0xA) throw new WebSocketProtocolError('Reserved WebSocket opcode');
+    if (len === 126) {
+      if (state.buffer.length < offset + 2) break;
+      len = state.buffer.readUInt16BE(offset);
+      offset += 2;
+    } else if (len === 127) {
+      if (state.buffer.length < offset + 8) break;
+      const big = state.buffer.readBigUInt64BE(offset);
+      if (big > BigInt(Number.MAX_SAFE_INTEGER)) throw new WebSocketProtocolError('WebSocket frame too large', 1009);
+      len = Number(big);
+      offset += 8;
+    }
+    if (len > MAX_WS_FRAME_BYTES) throw new WebSocketProtocolError('WebSocket frame too large', 1009);
+    if (opcode >= 0x8) {
+      if (!fin) throw new WebSocketProtocolError('Fragmented control frame');
+      if (len > 125) throw new WebSocketProtocolError('Control frame too large');
+    }
+    const maskOffset = offset;
+    if (masked) offset += 4;
+    if (state.buffer.length < offset + len) break;
+    let payload = state.buffer.subarray(offset, offset + len);
+    if (masked) {
+      const mask = state.buffer.subarray(maskOffset, maskOffset + 4);
+      payload = Buffer.from(payload);
+      for (let i = 0; i < payload.length; i++) payload[i] ^= mask[i % 4];
+    }
+    frames.push({ fin, opcode, payload });
+    state.buffer = state.buffer.subarray(offset + len);
+  }
+  return frames;
+}
+
+function normalizeSocketPayload(opcode, payload) {
+  if (opcode !== 0x1 && opcode !== 0x2) return null;
+  let text;
+  try {
+    text = opcode === 0x1 ? UTF8_DECODER.decode(payload) : payload.toString('utf8');
+  } catch {
+    throw new WebSocketProtocolError('Invalid UTF-8 in WebSocket text frame', 1007);
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function errorPayload(message, type = 'invalid_request_error', extra = {}) {
+  return { message, type, ...extra };
+}
+
+function sendErrorEvent(socket, status, error) {
+  sendText(socket, {
+    type: 'error',
+    status,
+    error: error || errorPayload('Invalid request'),
+  });
+}
+
+function normalizeResponseCreatePayload(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  if (payload.type !== 'response.create') return null;
+  const source = payload.response && typeof payload.response === 'object'
+    ? payload.response
+    : payload;
+  const out = { ...source };
+  delete out.type;
+  delete out.event_id;
+  out.stream = true;
+  return out.input == null ? null : out;
+}
+
+function normalizeUsage(usage = {}) {
+  if (!usage || typeof usage !== 'object') return null;
+  const input = usage.input_tokens ?? usage.prompt_tokens ?? 0;
+  const output = usage.output_tokens ?? usage.completion_tokens ?? 0;
+  const total = usage.total_tokens ?? (input + output);
+  if (!input && !output && !total) return null;
+  return { input_tokens: input, output_tokens: output, total_tokens: total };
+}
+
+function pruneResponseOwners(now = Date.now()) {
+  for (const [id, entry] of _responseOwners) {
+    if (!entry || now - (entry.updatedAt || 0) > RESPONSE_OWNER_TTL_MS) _responseOwners.delete(id);
+  }
+  while (_responseOwners.size > RESPONSE_OWNER_MAX) {
+    const oldest = _responseOwners.keys().next().value;
+    if (!oldest) break;
+    _responseOwners.delete(oldest);
+  }
+}
+
+function getResponseOwner(responseId, callerKey) {
+  if (!responseId) return null;
+  pruneResponseOwners();
+  const owner = _responseOwners.get(responseId);
+  if (!owner) return null;
+  if (owner.callerKey && callerKey && owner.callerKey !== callerKey) return null;
+  return owner;
+}
+
+function rememberResponseOwner(responseId, accountId, callerKey, model) {
+  if (!responseId || !accountId) return;
+  _responseOwners.set(responseId, {
+    accountId,
+    callerKey: callerKey || '',
+    model: model || '',
+    updatedAt: Date.now(),
+  });
+  pruneResponseOwners();
+}
+
+function logWebSocketRequest(summary) {
+  const payload = {
+    transport: 'websocket',
+    request_id: summary.requestId || null,
+    model: summary.model || null,
+    status: summary.status || 'unknown',
+    latency_ms: summary.latencyMs || 0,
+    account_id: summary.accountId || null,
+    usage: summary.usage || null,
+    error: summary.error || null,
+  };
+  log.info(`ResponsesWS ${JSON.stringify(payload)}`);
+}
+
+function responseCallerKey(req, apiKey, body) {
+  const scopedBody = body && typeof body === 'object' ? { ...body } : null;
+  if (scopedBody) delete scopedBody.previous_response_id;
+  return callerKeyFromRequest(req, apiKey, scopedBody);
+}
+
+function captureResponseEvent(payload, capture) {
+  if (!payload || typeof payload !== 'object' || !capture) return;
+  if (payload?.response?.id) capture.responseId = payload.response.id;
+  if (payload?.response?.created_at) capture.createdAt = payload.response.created_at;
+  if (payload?.response?.model) capture.model = payload.response.model;
+  const usage = normalizeUsage(payload?.response?.usage);
+  if (usage) capture.usage = usage;
+  if (payload.type === 'response.completed') capture.completed = true;
+  if (payload.type === 'error') {
+    capture.failed = true;
+    capture.error = payload?.error?.message || 'Response failed';
+  }
+  if (payload.type === 'response.failed') {
+    capture.failed = true;
+    capture.error = payload?.response?.error?.message || payload?.error?.message || 'Response failed';
+  }
+}
+
+function streamFailureEvent(capture, model, message, code = 'stream_incomplete') {
+  return {
+    type: 'response.failed',
+    response: {
+      id: capture.responseId,
+      object: 'response',
+      created_at: capture.createdAt || Math.floor(Date.now() / 1000),
+      status: 'failed',
+      model: capture.model || model || '',
+      error: {
+        code,
+        message,
+        type: 'server_error',
+      },
+    },
+  };
+}
+
+function createSseToWebSocketSink(socket, { onEvent } = {}) {
+  const listeners = new Map();
+  let pending = '';
+  const fire = (event) => {
+    const cbs = listeners.get(event) || [];
+    for (const cb of cbs) { try { cb(); } catch {} }
+  };
+  const feed = (chunk) => {
+    pending += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    let idx;
+    while ((idx = pending.indexOf('\n\n')) !== -1) {
+      const frame = pending.slice(0, idx);
+      pending = pending.slice(idx + 2);
+      for (const line of frame.split('\n')) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6);
+        if (!data || data === '[DONE]') continue;
+        let payload;
+        try {
+          payload = JSON.parse(data);
+        } catch {
+          sendErrorEvent(socket, 502, errorPayload('Invalid upstream event', 'server_error'));
+          continue;
+        }
+        if (payload?.type === 'error' && payload.status == null) payload.status = 502;
+        try { onEvent?.(payload); } catch {}
+        sendText(socket, payload);
+      }
+    }
+  };
+  return {
+    writableEnded: false,
+    headersSent: false,
+    writeHead() { this.headersSent = true; },
+    setHeader() {},
+    write(chunk) { if (!this.writableEnded) feed(chunk); return true; },
+    end(chunk) {
+      if (this.writableEnded) return;
+      if (chunk) feed(chunk);
+      this.writableEnded = true;
+      fire('close');
+    },
+    on(event, cb) {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event).push(cb);
+      return this;
+    },
+    once(event, cb) {
+      const wrapped = (...args) => { this.off(event, wrapped); cb(...args); };
+      return this.on(event, wrapped);
+    },
+    off(event, cb) {
+      const arr = listeners.get(event);
+      if (arr) {
+        const i = arr.indexOf(cb);
+        if (i !== -1) arr.splice(i, 1);
+      }
+      return this;
+    },
+    removeListener(event, cb) { return this.off(event, cb); },
+    _clientDisconnected() { fire('close'); },
+  };
+}
+
+async function handleResponseCreate(socket, req, payload, context) {
+  const startedAt = Date.now();
+  const responsesPayload = normalizeResponseCreatePayload(payload);
+  const requestId = payload?.event_id || payload?.id || null;
+  if (!responsesPayload) {
+    sendErrorEvent(socket, 400, errorPayload('Expected response.create payload with type "response.create" and input'));
+    logWebSocketRequest({
+      requestId,
+      model: payload?.model || payload?.response?.model || null,
+      status: 400,
+      latencyMs: Date.now() - startedAt,
+      error: 'invalid_response_create',
+    });
+    return;
+  }
+
+  const apiKey = context.apiKey || extractToken(req);
+  const callerKey = responseCallerKey(req, apiKey, responsesPayload);
+  const requestContext = { ...context, callerKey };
+  const previousResponseId = responsesPayload.previous_response_id;
+  if (previousResponseId) {
+    const previousOwner = getResponseOwner(previousResponseId, callerKey);
+    if (!previousOwner) {
+      sendErrorEvent(socket, 409, errorPayload(
+        'previous_response_id is not available for this caller',
+        'invalid_request_error',
+        { code: 'previous_response_not_found' }
+      ));
+      logWebSocketRequest({
+        requestId,
+        model: responsesPayload.model || null,
+        status: 409,
+        latencyMs: Date.now() - startedAt,
+        error: 'previous_response_not_found',
+      });
+      return;
+    }
+    requestContext.preferredAccountId = previousOwner.accountId;
+    requestContext.requirePreferredAccount = true;
+  }
+
+  let result;
+  try {
+    result = await handleResponsesImpl(responsesPayload, { context: requestContext });
+  } catch (e) {
+    const message = e?.message || 'Response failed';
+    sendErrorEvent(socket, 500, errorPayload(message, 'server_error'));
+    logWebSocketRequest({
+      requestId,
+      model: responsesPayload.model || null,
+      status: 500,
+      latencyMs: Date.now() - startedAt,
+      accountId: requestContext.__selectedAccountId,
+      error: message,
+    });
+    return;
+  }
+
+  const responseContext = result?.context || requestContext;
+  if (!result.stream) {
+    if (result.status >= 400) {
+      const message = result.body?.error?.message || 'Request failed';
+      sendErrorEvent(socket, result.status || 500, result.body?.error || errorPayload(message, 'upstream_error'));
+      logWebSocketRequest({
+        requestId,
+        model: responsesPayload.model || null,
+        status: result.status || 500,
+        latencyMs: Date.now() - startedAt,
+        accountId: responseContext.__selectedAccountId,
+        error: message,
+      });
+    } else {
+      const event = { type: 'response.completed', response: result.body };
+      const capture = {};
+      captureResponseEvent(event, capture);
+      if (capture.responseId && responseContext.__selectedAccountId) {
+        rememberResponseOwner(capture.responseId, responseContext.__selectedAccountId, callerKey, responsesPayload.model);
+      }
+      sendText(socket, event);
+      logWebSocketRequest({
+        requestId: requestId || capture.responseId,
+        model: responsesPayload.model || result.body?.model || null,
+        status: 200,
+        latencyMs: Date.now() - startedAt,
+        accountId: responseContext.__selectedAccountId,
+        usage: capture.usage,
+      });
+    }
+    return;
+  }
+  const capture = {};
+  const sink = createSseToWebSocketSink(socket, { onEvent: event => captureResponseEvent(event, capture) });
+  const onClose = () => sink._clientDisconnected();
+  socket.once('close', onClose);
+  try {
+    await result.handler(sink);
+    if (capture.responseId && !capture.completed && !capture.failed) {
+      capture.failed = true;
+      capture.error = 'Response stream ended before response.completed';
+      sendText(socket, streamFailureEvent(capture, responsesPayload.model, capture.error));
+    }
+    if (capture.responseId && responseContext.__selectedAccountId && capture.completed && !capture.failed) {
+      rememberResponseOwner(capture.responseId, responseContext.__selectedAccountId, callerKey, responsesPayload.model);
+    }
+    logWebSocketRequest({
+      requestId: requestId || capture.responseId,
+      model: responsesPayload.model || null,
+      status: capture.failed ? 502 : 200,
+      latencyMs: Date.now() - startedAt,
+      accountId: responseContext.__selectedAccountId,
+      usage: capture.usage,
+      error: capture.error,
+    });
+  } catch (e) {
+    const message = e?.message || 'Response stream failed';
+    if (capture.responseId && !capture.failed) {
+      capture.failed = true;
+      capture.error = message;
+      sendText(socket, streamFailureEvent(capture, responsesPayload.model, message, 'stream_error'));
+    } else {
+      sendErrorEvent(socket, 500, errorPayload(message, 'server_error'));
+    }
+    logWebSocketRequest({
+      requestId: requestId || capture.responseId,
+      model: responsesPayload.model || null,
+      status: 500,
+      latencyMs: Date.now() - startedAt,
+      accountId: responseContext.__selectedAccountId,
+      usage: capture.usage,
+      error: message,
+    });
+  } finally {
+    socket.removeListener('close', onClose);
+  }
+}
+
+export function handleResponsesWebSocketUpgrade(req, socket, head) {
+  const path = String(req.url || '').split('?')[0];
+  if (!WS_PATHS.has(path)) return false;
+
+  if (req.method && req.method !== 'GET') {
+    httpReject(socket, 405, 'Method Not Allowed');
+    return true;
+  }
+  if (!headerHasToken(req.headers.upgrade, 'websocket') || !headerHasToken(req.headers.connection, 'upgrade')) {
+    httpReject(socket, 400, 'Invalid WebSocket upgrade');
+    return true;
+  }
+  if (String(req.headers['sec-websocket-version'] || '') !== '13') {
+    httpReject(socket, 426, 'Unsupported WebSocket Version', { 'Sec-WebSocket-Version': '13' });
+    return true;
+  }
+  const key = req.headers['sec-websocket-key'];
+  if (!isValidSecWebSocketKey(key)) {
+    httpReject(socket, 400, 'Invalid Sec-WebSocket-Key');
+    return true;
+  }
+
+  const settings = getCodexSettings();
+  if (!settings.websocketEnabled) {
+    httpReject(socket, 403, 'Responses WebSocket disabled');
+    return true;
+  }
+  if (!validateApiKey(extractToken(req))) {
+    httpReject(socket, 401, 'Unauthorized');
+    return true;
+  }
+  if (!isAuthenticated()) {
+    httpReject(socket, 503, 'No active accounts');
+    return true;
+  }
+
+  const turnState = normalizeTurnState(req.headers['x-codex-turn-state']);
+  const responseHeaders = [
+    'HTTP/1.1 101 Switching Protocols',
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    `Sec-WebSocket-Accept: ${acceptKey(key)}`,
+    `x-codex-turn-state: ${turnState}`,
+    '\r\n',
+  ];
+  socket.write(responseHeaders.join('\r\n'));
+
+  const headers = { ...req.headers, 'x-codex-turn-state': turnState };
+  const apiKey = extractToken(req);
+  const context = {
+    apiKey,
+    callerKey: callerKeyFromRequest(req, apiKey, null),
+    headers,
+  };
+  const state = {
+    buffer: Buffer.alloc(0),
+    busy: Promise.resolve(),
+    fragmented: null,
+    closing: false,
+    partialTimer: null,
+  };
+
+  const handlePayload = (opcode, data) => {
+    if (state.closing) return;
+    const payload = normalizeSocketPayload(opcode, data);
+    if (payload === null) return;
+    if (payload === undefined) {
+      sendErrorEvent(socket, 400, errorPayload('Invalid JSON'));
+      return;
+    }
+    state.busy = state.busy
+      .then(() => {
+        if (state.closing) return undefined;
+        return handleResponseCreate(socket, req, payload, context);
+      })
+      .catch((e) => {
+        if (state.closing) return;
+        log.error(`Responses WS error: ${e.message}`);
+        sendErrorEvent(socket, 500, errorPayload(e.message, 'server_error'));
+      });
+  };
+
+  let processChunk;
+  const closeSocket = (code = 1000, reason = '') => {
+    if (state.closing) return;
+    stopReading();
+    sendClose(socket, code, reason);
+  };
+  const refreshPartialTimeout = () => {
+    if (state.partialTimer) {
+      clearTimeout(state.partialTimer);
+      state.partialTimer = null;
+    }
+    if (state.closing || (!state.buffer.length && !state.fragmented)) return;
+    state.partialTimer = setTimeout(() => {
+      log.warn('Responses WS partial frame timeout');
+      closeSocket(1002, 'Protocol error');
+    }, WS_PARTIAL_TIMEOUT_MS);
+    try { state.partialTimer.unref?.(); } catch {}
+  };
+  const stopReading = () => {
+    state.closing = true;
+    if (state.partialTimer) {
+      clearTimeout(state.partialTimer);
+      state.partialTimer = null;
+    }
+    try { socket.setTimeout?.(0); } catch {}
+    state.buffer = Buffer.alloc(0);
+    state.fragmented = null;
+    if (processChunk) socket.removeListener('data', processChunk);
+  };
+
+  const handleFrame = (frame) => {
+    if (state.closing) return undefined;
+    if (frame.opcode === 0x8) return closeSocket();
+    if (frame.opcode === 0x9) { sendFrame(socket, 0xA, frame.payload); return undefined; }
+    if (frame.opcode === 0xA) return undefined;
+
+    if (frame.opcode === 0x0) {
+      if (!state.fragmented) throw new WebSocketProtocolError('Unexpected continuation frame');
+      state.fragmented.size += frame.payload.length;
+      if (state.fragmented.size > MAX_WS_MESSAGE_BYTES) {
+        throw new WebSocketProtocolError('WebSocket message too large', 1009);
+      }
+      state.fragmented.fragments += 1;
+      if (state.fragmented.fragments > MAX_WS_FRAGMENTS) {
+        throw new WebSocketProtocolError('WebSocket message has too many fragments', 1002);
+      }
+      state.fragmented.chunks.push(frame.payload);
+      if (frame.fin) {
+        const complete = Buffer.concat(state.fragmented.chunks);
+        const opcode = state.fragmented.opcode;
+        state.fragmented = null;
+        handlePayload(opcode, complete);
+      }
+      return undefined;
+    }
+
+    if (frame.opcode !== 0x1 && frame.opcode !== 0x2) return undefined;
+    if (state.fragmented) throw new WebSocketProtocolError('New data frame before fragmented message completed');
+    if (!frame.fin) {
+      state.fragmented = { opcode: frame.opcode, chunks: [frame.payload], size: frame.payload.length, fragments: 1 };
+      return undefined;
+    }
+    handlePayload(frame.opcode, frame.payload);
+    return undefined;
+  };
+
+  processChunk = (chunk) => {
+    if (state.closing) return;
+    try {
+      for (const frame of parseFrames(state, chunk, { requireMasked: true })) {
+        handleFrame(frame);
+      }
+      refreshPartialTimeout();
+    } catch (e) {
+      log.warn(`Responses WS parse error: ${e.message}`);
+      const reason = e.closeCode === 1009
+        ? 'Message too big'
+        : e.closeCode === 1007
+          ? 'Invalid payload data'
+          : 'Protocol error';
+      closeSocket(e.closeCode || 1002, reason);
+    }
+  };
+
+  socket.on('data', processChunk);
+  if (head && head.length) processChunk(Buffer.from(head));
+  socket.setTimeout?.(WS_IDLE_TIMEOUT_MS, () => {
+    log.warn('Responses WS idle timeout');
+    closeSocket(1000, 'Idle timeout');
+  });
+  socket.on('close', stopReading);
+  socket.on('error', () => {});
+  return true;
+}
+
+export const _test = {
+  normalizeResponseCreatePayload,
+  parseFrames,
+  sendFrame,
+  setHandleResponsesForTest(fn) { handleResponsesImpl = fn || handleResponses; },
+  resetHandleResponsesForTest() { handleResponsesImpl = handleResponses; },
+  clearResponseOwnersForTest() { _responseOwners.clear(); },
+  rememberResponseOwner,
+  getResponseOwner,
+};

--- a/test/codex-sticky-ws.test.js
+++ b/test/codex-sticky-ws.test.js
@@ -1,0 +1,629 @@
+import test, { afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'windsurfapi-codex-'));
+
+const sticky = await import('../src/sticky-sessions.js');
+const runtime = await import('../src/runtime-config.js');
+const ws = await import('../src/ws-responses.js');
+const auth = await import('../src/auth.js');
+const configModule = await import('../src/config.js');
+
+const originalApiKey = configModule.config.apiKey;
+const originalLogInfo = configModule.log.info;
+const createdAccountIds = [];
+
+afterEach(() => {
+  configModule.config.apiKey = originalApiKey;
+  configModule.log.info = originalLogInfo;
+  ws._test.resetHandleResponsesForTest();
+  ws._test.clearResponseOwnersForTest();
+  auth.configureBindHost('0.0.0.0');
+  while (createdAccountIds.length) auth.removeAccount(createdAccountIds.pop());
+});
+
+class FakeSocket extends EventEmitter {
+  constructor() {
+    super();
+    this.writes = [];
+    this.ended = false;
+    this.destroyed = false;
+    this.timeoutMs = null;
+    this.timeoutCb = null;
+  }
+
+  write(chunk) {
+    this.writes.push(Buffer.isBuffer(chunk) ? Buffer.from(chunk) : Buffer.from(String(chunk)));
+    return true;
+  }
+
+  end() {
+    this.ended = true;
+    this.emit('close');
+  }
+
+  destroy() {
+    this.destroyed = true;
+    this.emit('close');
+  }
+
+  setTimeout(ms, cb) {
+    this.timeoutMs = ms;
+    this.timeoutCb = cb;
+    return this;
+  }
+}
+
+function enableWebSocketAuth() {
+  configModule.config.apiKey = 'ws-test-secret';
+  auth.configureBindHost('0.0.0.0');
+  const account = auth.addAccountByKey(`ws-account-${Date.now()}-${Math.random()}`, 'ws-test');
+  createdAccountIds.push(account.id);
+}
+
+function upgradeReq(headers = {}) {
+  return {
+    method: 'GET',
+    url: '/backend-api/codex/responses',
+    headers: {
+      authorization: 'Bearer ws-test-secret',
+      connection: 'keep-alive, Upgrade',
+      upgrade: 'websocket',
+      'sec-websocket-version': '13',
+      'sec-websocket-key': 'dGhlIHNhbXBsZSBub25jZQ==',
+      ...headers,
+    },
+    socket: { remoteAddress: '127.0.0.1' },
+    connection: { remoteAddress: '127.0.0.1' },
+  };
+}
+
+function maskedClientFrame(payload, { opcode = 0x1, fin = true } = {}) {
+  const body = Buffer.isBuffer(payload) ? payload : Buffer.from(String(payload));
+  const mask = Buffer.from([1, 2, 3, 4]);
+  let header;
+  if (body.length < 126) {
+    header = Buffer.from([(fin ? 0x80 : 0) | opcode, 0x80 | body.length]);
+  } else {
+    header = Buffer.alloc(4);
+    header[0] = (fin ? 0x80 : 0) | opcode;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(body.length, 2);
+  }
+  const masked = Buffer.from(body);
+  for (let i = 0; i < masked.length; i++) masked[i] ^= mask[i % 4];
+  return Buffer.concat([header, mask, masked]);
+}
+
+function maskedLengthOnlyFrame(len, { opcode = 0x1 } = {}) {
+  const mask = Buffer.from([1, 2, 3, 4]);
+  if (len <= 0xffff) {
+    const header = Buffer.alloc(4);
+    header[0] = 0x80 | opcode;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(len, 2);
+    return Buffer.concat([header, mask]);
+  }
+  const header = Buffer.alloc(10);
+  header[0] = 0x80 | opcode;
+  header[1] = 0x80 | 127;
+  header.writeBigUInt64BE(BigInt(len), 2);
+  return Buffer.concat([header, mask]);
+}
+
+function decodeServerTextFrame(frame) {
+  let offset = 2;
+  let len = frame[1] & 0x7f;
+  if (len === 126) {
+    len = frame.readUInt16BE(offset);
+    offset += 2;
+  } else if (len === 127) {
+    len = Number(frame.readBigUInt64BE(offset));
+    offset += 8;
+  }
+  return frame.subarray(offset, offset + len).toString('utf8');
+}
+
+async function waitForWrites(socket, count) {
+  for (let i = 0; i < 50; i++) {
+    if (socket.writes.length >= count) return;
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+  assert.fail(`expected ${count} socket writes, got ${socket.writes.length}`);
+}
+
+function decodeCloseFrame(frame) {
+  assert.equal(frame[0] & 0x0f, 0x8);
+  let offset = 2;
+  let len = frame[1] & 0x7f;
+  if (len === 126) {
+    len = frame.readUInt16BE(offset);
+    offset += 2;
+  }
+  const payload = frame.subarray(offset, offset + len);
+  return {
+    code: payload.length >= 2 ? payload.readUInt16BE(0) : null,
+    reason: payload.subarray(2).toString('utf8'),
+  };
+}
+
+test('Codex sticky context prefers turn-state headers in auto mode', () => {
+  runtime.setCodexSettings({
+    stickySessionsEnabled: true,
+    stickySessionMode: 'auto',
+    derivePromptCacheKey: true,
+    promptCacheMaxAgeSeconds: 1800,
+  });
+  const ctx = sticky.buildStickyContext(
+    { model: 'gpt-5.4', input: 'hello', prompt_cache_key: 'pc-1' },
+    { 'x-codex-turn-state': 'turn-abc' },
+    'api:test',
+  );
+  assert.equal(ctx.kind, 'codex_session');
+  assert.equal(ctx.key, 'turn-abc');
+});
+
+test('Codex sticky store preserves prompt-cache mapping during fallback', () => {
+  sticky.clearStickySessions();
+  runtime.setCodexSettings({
+    stickySessionsEnabled: true,
+    stickySessionMode: 'prompt_cache',
+    derivePromptCacheKey: false,
+    reallocateSticky: false,
+  });
+  const ctx = sticky.buildStickyContext({ model: 'gpt-5.4', input: 'hello', prompt_cache_key: 'pc-2' }, {}, 'api:test');
+  assert.ok(ctx);
+  assert.equal(sticky.getStickyAccountId(ctx), null);
+  assert.equal(sticky.bindStickyAccount(ctx, 'acct-a'), true);
+  assert.equal(sticky.getStickyAccountId(ctx), 'acct-a');
+  assert.equal(sticky.shouldPreserveStickyFallback(ctx, 'acct-a', 'acct-b'), true);
+  assert.equal(sticky.bindStickyAccount(ctx, 'acct-b', { preserveExisting: true }), false);
+  assert.equal(sticky.getStickyAccountId(ctx), 'acct-a');
+});
+
+test('Responses WebSocket accepts response.create wrapper and forces streaming', () => {
+  const normalized = ws._test.normalizeResponseCreatePayload({
+    type: 'response.create',
+    response: {
+      model: 'gpt-5.4',
+      input: 'hello',
+      stream: false,
+    },
+  });
+  assert.deepEqual(normalized, {
+    model: 'gpt-5.4',
+    input: 'hello',
+    stream: true,
+  });
+  assert.equal(ws._test.normalizeResponseCreatePayload({ model: 'gpt-5.4', input: 'raw' }), null);
+});
+
+test('Responses WebSocket performs a real 101 upgrade and processes initial head bytes', () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+
+  const handled = ws.handleResponsesWebSocketUpgrade(
+    upgradeReq({ 'x-codex-turn-state': 'turn-existing' }),
+    socket,
+    maskedClientFrame('{not-json'),
+  );
+
+  assert.equal(handled, true);
+  const handshake = socket.writes[0].toString('utf8');
+  assert.match(handshake, /^HTTP\/1\.1 101 Switching Protocols/);
+  assert.match(handshake, /Upgrade: websocket/i);
+  assert.match(handshake, /Connection: Upgrade/i);
+  assert.match(handshake, /Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK\+xOo=/);
+  assert.match(handshake, /x-codex-turn-state: turn-existing/);
+
+  const errorFrame = JSON.parse(decodeServerTextFrame(socket.writes[1]));
+  assert.equal(errorFrame.type, 'error');
+  assert.equal(errorFrame.status, 400);
+  assert.equal(errorFrame.error.type, 'invalid_request_error');
+});
+
+test('Responses WebSocket rejects raw no-type payloads with status errors', async () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+  let called = false;
+  ws._test.setHandleResponsesForTest(async () => {
+    called = true;
+    return { status: 200, body: {} };
+  });
+
+  ws.handleResponsesWebSocketUpgrade(
+    upgradeReq(),
+    socket,
+    maskedClientFrame(JSON.stringify({ model: 'gpt-5.4', input: 'raw' })),
+  );
+  await waitForWrites(socket, 2);
+
+  const errorFrame = JSON.parse(decodeServerTextFrame(socket.writes[1]));
+  assert.equal(called, false);
+  assert.equal(errorFrame.type, 'error');
+  assert.equal(errorFrame.status, 400);
+  assert.equal(errorFrame.error.type, 'invalid_request_error');
+});
+
+test('Responses WebSocket processes sequential response.create messages on one socket', async () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+  const calls = [];
+  const logs = [];
+  configModule.log.info = (line) => logs.push(String(line));
+  ws._test.setHandleResponsesForTest(async (body, { context }) => {
+    calls.push(body.input);
+    context.__selectedAccountId = 'acct-seq';
+    const id = `resp_seq_${calls.length}`;
+    return {
+      status: 200,
+      stream: true,
+      context,
+      async handler(res) {
+        res.write(`data: ${JSON.stringify({
+          type: 'response.completed',
+          response: {
+            id,
+            model: body.model,
+            usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+          },
+        })}\n\n`);
+        res.end();
+      },
+    };
+  });
+
+  ws.handleResponsesWebSocketUpgrade(upgradeReq(), socket, Buffer.alloc(0));
+  socket.emit('data', maskedClientFrame(JSON.stringify({ type: 'response.create', response: { model: 'gpt-5.4', input: 'one' } })));
+  socket.emit('data', maskedClientFrame(JSON.stringify({ type: 'response.create', response: { model: 'gpt-5.4', input: 'two' } })));
+  await waitForWrites(socket, 3);
+
+  assert.deepEqual(calls, ['one', 'two']);
+  const first = JSON.parse(decodeServerTextFrame(socket.writes[1]));
+  const second = JSON.parse(decodeServerTextFrame(socket.writes[2]));
+  assert.equal(first.response.id, 'resp_seq_1');
+  assert.equal(second.response.id, 'resp_seq_2');
+  const requestLogs = logs
+    .filter(line => line.includes('ResponsesWS '))
+    .map(line => JSON.parse(line.slice(line.indexOf('{'))));
+  assert.equal(requestLogs.length, 2);
+  assert.equal(requestLogs[0].transport, 'websocket');
+  assert.equal(requestLogs[0].status, 200);
+  assert.deepEqual(requestLogs[0].usage, { input_tokens: 1, output_tokens: 2, total_tokens: 3 });
+});
+
+test('Responses WebSocket pins previous_response_id follow-ups to the original account', async () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+  const contexts = [];
+  ws._test.setHandleResponsesForTest(async (body, { context }) => {
+    contexts.push({ preferredAccountId: context.preferredAccountId, requirePreferredAccount: context.requirePreferredAccount });
+    context.__selectedAccountId = context.preferredAccountId || 'acct-original';
+    const id = body.previous_response_id ? 'resp_followup' : 'resp_original';
+    return {
+      status: 200,
+      stream: true,
+      context,
+      async handler(res) {
+        res.write(`data: ${JSON.stringify({ type: 'response.completed', response: { id, model: body.model } })}\n\n`);
+        res.end();
+      },
+    };
+  });
+
+  ws.handleResponsesWebSocketUpgrade(upgradeReq(), socket, Buffer.alloc(0));
+  socket.emit('data', maskedClientFrame(JSON.stringify({ type: 'response.create', response: { model: 'gpt-5.4', input: 'one' } })));
+  await waitForWrites(socket, 2);
+  socket.emit('data', maskedClientFrame(JSON.stringify({
+    type: 'response.create',
+    response: { model: 'gpt-5.4', input: 'two', previous_response_id: 'resp_original' },
+  })));
+  await waitForWrites(socket, 3);
+
+  assert.deepEqual(contexts[0], { preferredAccountId: undefined, requirePreferredAccount: undefined });
+  assert.deepEqual(contexts[1], { preferredAccountId: 'acct-original', requirePreferredAccount: true });
+  const followup = JSON.parse(decodeServerTextFrame(socket.writes[2]));
+  assert.equal(followup.response.id, 'resp_followup');
+});
+
+test('Responses WebSocket rejects unknown previous_response_id with status', async () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+  let called = false;
+  ws._test.setHandleResponsesForTest(async () => {
+    called = true;
+    return { status: 200, body: {} };
+  });
+
+  ws.handleResponsesWebSocketUpgrade(
+    upgradeReq(),
+    socket,
+    maskedClientFrame(JSON.stringify({
+      type: 'response.create',
+      response: { model: 'gpt-5.4', input: 'two', previous_response_id: 'resp_missing' },
+    })),
+  );
+  await waitForWrites(socket, 2);
+
+  const errorFrame = JSON.parse(decodeServerTextFrame(socket.writes[1]));
+  assert.equal(called, false);
+  assert.equal(errorFrame.type, 'error');
+  assert.equal(errorFrame.status, 409);
+  assert.equal(errorFrame.error.code, 'previous_response_not_found');
+});
+
+test('Responses WebSocket surfaces unavailable previous response owner as status error', async () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+  ws._test.setHandleResponsesForTest(async (body, { context }) => {
+    if (body.previous_response_id) {
+      return {
+        status: 409,
+        context,
+        body: {
+          error: {
+            message: 'Previous response owner account is unavailable; retry later.',
+            type: 'previous_response_unavailable',
+          },
+        },
+      };
+    }
+    context.__selectedAccountId = 'acct-original';
+    return {
+      status: 200,
+      stream: true,
+      context,
+      async handler(res) {
+        res.write(`data: ${JSON.stringify({ type: 'response.completed', response: { id: 'resp_original', model: body.model } })}\n\n`);
+        res.end();
+      },
+    };
+  });
+
+  ws.handleResponsesWebSocketUpgrade(upgradeReq(), socket, Buffer.alloc(0));
+  socket.emit('data', maskedClientFrame(JSON.stringify({ type: 'response.create', response: { model: 'gpt-5.4', input: 'one' } })));
+  await waitForWrites(socket, 2);
+  socket.emit('data', maskedClientFrame(JSON.stringify({
+    type: 'response.create',
+    response: { model: 'gpt-5.4', input: 'two', previous_response_id: 'resp_original' },
+  })));
+  await waitForWrites(socket, 3);
+
+  const errorFrame = JSON.parse(decodeServerTextFrame(socket.writes[2]));
+  assert.equal(errorFrame.type, 'error');
+  assert.equal(errorFrame.status, 409);
+  assert.equal(errorFrame.error.type, 'previous_response_unavailable');
+});
+
+test('Responses WebSocket emits response.failed when stream ends without completion', async () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+  const logs = [];
+  configModule.log.info = (line) => logs.push(String(line));
+  ws._test.setHandleResponsesForTest(async (body, { context }) => {
+    context.__selectedAccountId = 'acct-incomplete';
+    return {
+      status: 200,
+      stream: true,
+      context,
+      async handler(res) {
+        res.write(`data: ${JSON.stringify({
+          type: 'response.created',
+          response: {
+            id: 'resp_incomplete',
+            model: body.model,
+            created_at: 123,
+          },
+        })}\n\n`);
+        res.end();
+      },
+    };
+  });
+
+  ws.handleResponsesWebSocketUpgrade(
+    upgradeReq(),
+    socket,
+    maskedClientFrame(JSON.stringify({ type: 'response.create', response: { model: 'gpt-5.4', input: 'one' } })),
+  );
+  await waitForWrites(socket, 3);
+
+  const failed = JSON.parse(decodeServerTextFrame(socket.writes[2]));
+  assert.equal(failed.type, 'response.failed');
+  assert.equal(failed.response.id, 'resp_incomplete');
+  assert.equal(failed.response.error.code, 'stream_incomplete');
+  assert.match(failed.response.error.message, /before response\.completed/);
+  const requestLog = logs
+    .filter(line => line.includes('ResponsesWS '))
+    .map(line => JSON.parse(line.slice(line.indexOf('{'))))[0];
+  assert.equal(requestLog.status, 502);
+  assert.equal(requestLog.error, 'Response stream ended before response.completed');
+});
+
+test('Responses WebSocket emits response.failed when a started stream throws', async () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+  ws._test.setHandleResponsesForTest(async (body, { context }) => {
+    context.__selectedAccountId = 'acct-throw';
+    return {
+      status: 200,
+      stream: true,
+      context,
+      async handler(res) {
+        res.write(`data: ${JSON.stringify({
+          type: 'response.created',
+          response: { id: 'resp_throw', model: body.model },
+        })}\n\n`);
+        throw new Error('upstream dropped');
+      },
+    };
+  });
+
+  ws.handleResponsesWebSocketUpgrade(
+    upgradeReq(),
+    socket,
+    maskedClientFrame(JSON.stringify({ type: 'response.create', response: { model: 'gpt-5.4', input: 'one' } })),
+  );
+  await waitForWrites(socket, 3);
+
+  const failed = JSON.parse(decodeServerTextFrame(socket.writes[2]));
+  assert.equal(failed.type, 'response.failed');
+  assert.equal(failed.response.id, 'resp_throw');
+  assert.equal(failed.response.error.code, 'stream_error');
+  assert.equal(failed.response.error.message, 'upstream dropped');
+});
+
+test('Responses WebSocket sanitizes reflected turn-state handshake headers', () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+
+  ws.handleResponsesWebSocketUpgrade(
+    upgradeReq({ 'x-codex-turn-state': 'turn-good\r\nx-injected: yes' }),
+    socket,
+    Buffer.alloc(0),
+  );
+
+  const handshake = socket.writes[0].toString('utf8');
+  assert.doesNotMatch(handshake, /x-injected/i);
+  assert.doesNotMatch(handshake, /turn-good\r\n/);
+  assert.match(handshake, /x-codex-turn-state: turn_[a-f0-9]{32}/);
+});
+
+test('Responses WebSocket closes oversized frames with 1009', () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+
+  ws.handleResponsesWebSocketUpgrade(
+    upgradeReq(),
+    socket,
+    maskedLengthOnlyFrame(16 * 1024 * 1024 + 1),
+  );
+
+  const close = decodeCloseFrame(socket.writes[1]);
+  assert.equal(close.code, 1009);
+});
+
+test('Responses WebSocket closes invalid UTF-8 text frames with 1007', () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+
+  ws.handleResponsesWebSocketUpgrade(
+    upgradeReq(),
+    socket,
+    maskedClientFrame(Buffer.from([0xff]), { opcode: 0x1 }),
+  );
+
+  const close = decodeCloseFrame(socket.writes[1]);
+  assert.equal(close.code, 1007);
+  assert.equal(close.reason, 'Invalid payload data');
+});
+
+test('Responses WebSocket rejects reserved control opcodes', () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+
+  ws.handleResponsesWebSocketUpgrade(
+    upgradeReq(),
+    socket,
+    maskedClientFrame(Buffer.alloc(0), { opcode: 0xB }),
+  );
+
+  const close = decodeCloseFrame(socket.writes[1]);
+  assert.equal(close.code, 1002);
+});
+
+test('Responses WebSocket closes messages with too many fragments', () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+
+  ws.handleResponsesWebSocketUpgrade(
+    upgradeReq(),
+    socket,
+    maskedClientFrame('{', { opcode: 0x1, fin: false }),
+  );
+  for (let i = 0; i < 4096 && !socket.ended; i++) {
+    socket.emit('data', maskedClientFrame('', { opcode: 0x0, fin: false }));
+  }
+
+  const close = decodeCloseFrame(socket.writes[1]);
+  assert.equal(close.code, 1002);
+});
+
+test('Responses WebSocket rejects non-canonical Sec-WebSocket-Key', () => {
+  enableWebSocketAuth();
+  const socket = new FakeSocket();
+
+  ws.handleResponsesWebSocketUpgrade(
+    upgradeReq({ 'sec-websocket-key': 'dGhlIHNhbXBsZSBub25jZQ==\n' }),
+    socket,
+    Buffer.alloc(0),
+  );
+
+  assert.match(socket.writes[0].toString('utf8'), /^HTTP\/1\.1 400 Invalid Sec-WebSocket-Key/);
+});
+
+test('Responses WebSocket installs and honors an idle timeout', () => {
+  enableWebSocketAuth();
+  runtime.setCodexSettings({ websocketEnabled: true });
+  const socket = new FakeSocket();
+
+  ws.handleResponsesWebSocketUpgrade(upgradeReq(), socket, Buffer.alloc(0));
+
+  assert.equal(socket.timeoutMs, 5 * 60 * 1000);
+  socket.timeoutCb();
+  const close = decodeCloseFrame(socket.writes[1]);
+  assert.equal(close.code, 1000);
+  assert.equal(close.reason, 'Idle timeout');
+});
+
+test('Responses WebSocket version rejection advertises supported version', () => {
+  enableWebSocketAuth();
+  const socket = new FakeSocket();
+
+  ws.handleResponsesWebSocketUpgrade(
+    upgradeReq({ 'sec-websocket-version': '12' }),
+    socket,
+    Buffer.alloc(0),
+  );
+
+  const response = socket.writes[0].toString('utf8');
+  assert.match(response, /^HTTP\/1\.1 426 Unsupported WebSocket Version/);
+  assert.match(response, /Sec-WebSocket-Version: 13/i);
+});
+
+test('Responses WebSocket rejects non-WebSocket HTTP before pretending to stream', () => {
+  enableWebSocketAuth();
+  const socket = new FakeSocket();
+  const req = upgradeReq({ connection: 'keep-alive', upgrade: '' });
+
+  const handled = ws.handleResponsesWebSocketUpgrade(req, socket, Buffer.alloc(0));
+
+  assert.equal(handled, true);
+  assert.match(socket.writes[0].toString('utf8'), /^HTTP\/1\.1 400 Invalid WebSocket upgrade/);
+  assert.equal(socket.destroyed, true);
+});
+
+test('nginx forwards WebSocket upgrade headers to the Node server', () => {
+  const conf = readFileSync(new URL('../nginx.conf', import.meta.url), 'utf8');
+  assert.match(conf, /map\s+\$http_upgrade\s+\$connection_upgrade/);
+  assert.match(conf, /proxy_set_header\s+Upgrade\s+\$http_upgrade;/);
+  assert.match(conf, /proxy_set_header\s+Connection\s+\$connection_upgrade;/);
+  assert.match(conf, /location\s+~\s+\^\/\(v1\/\(ws\/\)\?responses\|backend-api\/codex\/responses\)\$/);
+  assert.match(conf, /location\s+~[\s\S]+proxy_read_timeout\s+3600s;/);
+});

--- a/test/responses.test.js
+++ b/test/responses.test.js
@@ -349,6 +349,28 @@ describe('handleResponses streaming', () => {
     assert.equal(forwarded.tools[0].__response_tool.type, 'web_search');
   });
 
+  it('returns chat handler context metadata for downstream transports', async () => {
+    const result = await handleResponses({
+      model: 'claude-sonnet-4.6',
+      input: 'Hello',
+      stream: false,
+    }, {
+      async handleChatCompletions(body, context) {
+        context.__selectedAccountId = 'acct-context';
+        return {
+          status: 200,
+          body: {
+            id: 'c', object: 'chat.completion', created: 1, model: body.model,
+            choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+          },
+        };
+      },
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(result.context.__selectedAccountId, 'acct-context');
+  });
+
   it('emits the Responses text event sequence and response.completed', async () => {
     const result = await handleResponses({ model: 'claude-sonnet-4.6', input: 'Hello', stream: true }, {
       async handleChatCompletions(body) {


### PR DESCRIPTION
## 改了什么 / What changed

Adds Codex-compatible Responses WebSocket handling for `/v1/responses`, `/v1/ws/responses`, and `/backend-api/codex/responses`, with durable sticky routing and dashboard/runtime controls.

Also hardens the websocket stream lifecycle so a started stream that ends or throws before `response.completed` emits a terminal `response.failed` event instead of leaving Codex clients waiting.

## 为什么 / Why

Codex-style clients expect real WebSocket upgrade support, turn-state affinity, sequential `response.create` handling, and terminal response events. This aligns WindsurfAPI behavior with the codex-lb websocket contract while keeping the upstream Windsurf path on the existing Responses/SSE adapter.

## 测试 / Testing

- `node --test /tmp/windsurfapi-pr/test/codex-sticky-ws.test.js /tmp/windsurfapi-pr/test/responses.test.js`

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies (project is zero-dep)
- [x] 涉及 LS binary 协议改动时 在 PR 描述里注明字段号来源 / If touching LS protocol, document field-number source in the PR description
- [x] 涉及 dashboard UI 用 App.confirm / App.prompt 不用浏览器原生 alert/confirm / Uses App.confirm / App.prompt, not native dialogs (if dashboard)
