### PR TITLE
fix: align language server paths across platforms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,15 @@ CODEIUM_API_KEY=
 CODEIUM_AUTH_TOKEN=
 
 # ========== Language Server ==========
-# Path to language_server_linux_x64 binary
+# Path to the language server binary.
+# Linux x64 default: /opt/windsurf/language_server_linux_x64
+# Linux arm64 default: /opt/windsurf/language_server_linux_arm
+# macOS Apple Silicon default: ~/.windsurf/language_server_macos_arm
+# macOS Intel default: ~/.windsurf/language_server_macos_x64
 LS_BINARY_PATH=/opt/windsurf/language_server_linux_x64
+# Per-proxy language server data root.
+# macOS local runs should use a user-writable directory, e.g. ~/.windsurf/data.
+LS_DATA_DIR=/opt/windsurf/data
 # gRPC port for language server
 LS_PORT=42100
 

--- a/README.en.md
+++ b/README.en.md
@@ -132,9 +132,14 @@ If you are using our public instances (`skiapi.dev`, etc.), you don't need to do
 git clone https://github.com/dwgx/WindsurfAPI.git
 cd WindsurfAPI
 
-# Language Server binary — one-click download + chmod (from Exafunction/codeium releases)
-mkdir -p /opt/windsurf/data/db
+# Language Server binary — auto-detects Linux/macOS, one-click download + chmod
 bash install-ls.sh
+
+# Default install paths:
+#   Linux x64:           /opt/windsurf/language_server_linux_x64
+#   Linux arm64:         /opt/windsurf/language_server_linux_arm
+#   macOS Apple Silicon: $HOME/.windsurf/language_server_macos_arm
+#   macOS Intel:         $HOME/.windsurf/language_server_macos_x64
 
 # Or use a local binary you already have:
 #   bash install-ls.sh /path/to/language_server_linux_x64
@@ -163,9 +168,13 @@ DEFAULT_MODEL=claude-4.5-sonnet-thinking
 MAX_TOKENS=8192
 LOG_LEVEL=info
 LS_BINARY_PATH=/opt/windsurf/language_server_linux_x64
+LS_DATA_DIR=/opt/windsurf/data
 LS_PORT=42100
 DASHBOARD_PASSWORD=
 EOF
+
+# For a local macOS run, use the LS_BINARY_PATH printed by install-ls.sh
+# and set LS_DATA_DIR to a user-writable path such as /Users/you/.windsurf/data.
 
 # Note: Inline comments are supported in .env for unquoted values:
 #   PORT=3003  # Service port
@@ -187,16 +196,16 @@ Open `http://YOUR_IP:3003/dashboard` → Login to get token → Click **Sign in 
 Go to [windsurf.com/show-auth-token](https://windsurf.com/show-auth-token) to copy your token:
 
 ```bash
-curl -X POST http://localhost:3003/auth/login
-  -H "Content-Type: application/json"
+curl -X POST http://localhost:3003/auth/login \
+  -H "Content-Type: application/json" \
   -d '{"token": "YOUR_TOKEN"}'
 ```
 
 **Method 3: Batch**
 
 ```bash
-curl -X POST http://localhost:3003/auth/login
-  -H "Content-Type: application/json"
+curl -X POST http://localhost:3003/auth/login \
+  -H "Content-Type: application/json" \
   -d '{"accounts": [{"token": "t1"}, {"token": "t2"}]}'
 ```
 
@@ -224,9 +233,9 @@ claude                # Use Claude Code as usual
 
 ```bash
 # Raw curl test
-curl http://localhost:3003/v1/messages
-  -H "Authorization: Bearer YOUR_KEY"
-  -H "anthropic-version: 2023-06-01"
+curl http://localhost:3003/v1/messages \
+  -H "Authorization: Bearer YOUR_KEY" \
+  -H "anthropic-version: 2023-06-01" \
   -d '{"model":"claude-opus-4.6","max_tokens":100,"messages":[{"role":"user","content":"Hello"}]}'
 ```
 
@@ -266,7 +275,7 @@ In your client's settings for **Custom OpenAI Compatible**:
 | `LOG_LEVEL` | `info` | debug / info / warn / error |
 | `LS_BINARY_PATH` | `/opt/windsurf/language_server_linux_x64` | Path to the LS binary. |
 | `LS_PORT` | `42100` | LS gRPC port. |
-| `LS_DATA_DIR` | `/opt/windsurf` | Per-proxy LS data directory root. |
+| `LS_DATA_DIR` | Linux: `/opt/windsurf/data`; macOS: `~/.windsurf/data` | Per-proxy LS data directory root. |
 | `DASHBOARD_PASSWORD` | empty | Dashboard password. Leave empty for no password. |
 | `ALLOW_PRIVATE_PROXY_HOSTS` | empty | Set to `1` to allow private/internal IPs (e.g., `192.168.x.x`, `10.x.x.x`) in proxy tests and login. Leave empty to only allow public addresses (default). |
 | `CASCADE_REUSE_STRICT` | `0` | Set to `1` for strict conversation reuse mode (waits for same fingerprint). |

--- a/README.md
+++ b/README.md
@@ -130,9 +130,14 @@ cd ~/WindsurfAPI && bash update.sh
 git clone https://github.com/dwgx/WindsurfAPI.git
 cd WindsurfAPI
 
-# Language Server 二进制 —— 一键下载 + chmod（从 Exafunction/codeium releases）
-mkdir -p /opt/windsurf/data/db
+# Language Server 二进制 —— 自动检测 Linux/macOS，一键下载 + chmod
 bash install-ls.sh
+
+# 默认安装路径：
+#   Linux x64:          /opt/windsurf/language_server_linux_x64
+#   Linux arm64:        /opt/windsurf/language_server_linux_arm
+#   macOS Apple Silicon: $HOME/.windsurf/language_server_macos_arm
+#   macOS Intel:        $HOME/.windsurf/language_server_macos_x64
 
 # 如果想用本地已下好的 binary：
 #   bash install-ls.sh /path/to/language_server_linux_x64
@@ -160,9 +165,13 @@ DEFAULT_MODEL=claude-4.5-sonnet-thinking
 MAX_TOKENS=8192
 LOG_LEVEL=info
 LS_BINARY_PATH=/opt/windsurf/language_server_linux_x64
+LS_DATA_DIR=/opt/windsurf/data
 LS_PORT=42100
 DASHBOARD_PASSWORD=
 EOF
+
+# macOS 本地部署时，使用 install-ls.sh 打印的 LS_BINARY_PATH，
+# 并把 LS_DATA_DIR 设到用户可写目录，例如 /Users/you/.windsurf/data。
 
 node src/index.js
 ```
@@ -256,6 +265,7 @@ curl http://localhost:3003/v1/messages \
 | `MAX_TOKENS` | `8192` | 默认最大回复 token 数 |
 | `LOG_LEVEL` | `info` | debug / info / warn / error |
 | `LS_BINARY_PATH` | `/opt/windsurf/language_server_linux_x64` | LS 二进制位置 |
+| `LS_DATA_DIR` | Linux: `/opt/windsurf/data`；macOS: `~/.windsurf/data` | 每个 proxy 独立的 LS 数据根目录 |
 | `LS_PORT` | `42100` | LS gRPC 端口 |
 | `DASHBOARD_PASSWORD` | 空 | 后台密码 留空不设密码 |
 | `ALLOW_PRIVATE_PROXY_HOSTS` | 空 | 设为 `1` 允许在代理测试和登录时使用内网 IP（如 `192.168.x.x`、`10.x.x.x`）。默认留空仅允许公网地址 |

--- a/install-ls.sh
+++ b/install-ls.sh
@@ -30,7 +30,7 @@ case "$os" in
       aarch64|arm64) ASSET='language_server_linux_arm' ;;
       *) err "Unsupported Linux arch: $arch"; exit 1 ;;
     esac
-    DEFAULT_PATH='/opt/windsurf/language_server_linux_x64'
+    DEFAULT_PATH="/opt/windsurf/${ASSET}"
     ;;
   Darwin)
     case "$arch" in
@@ -38,7 +38,7 @@ case "$os" in
       arm64)         ASSET='language_server_macos_arm' ;;
       *) err "Unsupported macOS arch: $arch"; exit 1 ;;
     esac
-    DEFAULT_PATH="$HOME/.windsurf/language_server_macos_${arch}"
+    DEFAULT_PATH="$HOME/.windsurf/${ASSET}"
     ;;
   *)
     err "Unsupported OS: $os (only Linux and macOS are supported)"

--- a/setup.sh
+++ b/setup.sh
@@ -3,13 +3,25 @@ set -e
 
 echo "=== WindsurfAPI Setup ==="
 
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+case "$OS:$ARCH" in
+  Darwin:arm64)   LS_PATH="$HOME/.windsurf/language_server_macos_arm"; LS_DATA_DIR="$HOME/.windsurf/data" ;;
+  Darwin:x86_64)  LS_PATH="$HOME/.windsurf/language_server_macos_x64"; LS_DATA_DIR="$HOME/.windsurf/data" ;;
+  Linux:x86_64|Linux:amd64)
+                  LS_PATH="/opt/windsurf/language_server_linux_x64"; LS_DATA_DIR="/opt/windsurf/data" ;;
+  Linux:aarch64|Linux:arm64)
+                  LS_PATH="/opt/windsurf/language_server_linux_arm"; LS_DATA_DIR="/opt/windsurf/data" ;;
+  *)              LS_PATH="/opt/windsurf/language_server_linux_x64"; LS_DATA_DIR="/opt/windsurf/data" ;;
+esac
+
 # Create directories
 echo "[1/4] Creating directories..."
-mkdir -p /opt/windsurf/data/db
+mkdir -p "$(dirname "$LS_PATH")"
+mkdir -p "$LS_DATA_DIR/db"
 mkdir -p /tmp/windsurf-workspace
 
 # Check LS binary
-LS_PATH="/opt/windsurf/language_server_linux_x64"
 if [ -f "$LS_PATH" ]; then
   chmod +x "$LS_PATH"
   echo "[2/4] Language Server found at $LS_PATH"
@@ -22,14 +34,15 @@ fi
 # Generate .env if not exists
 if [ ! -f .env ]; then
   echo "[3/4] Generating .env..."
-  cat > .env << 'ENVEOF'
+  cat > .env << ENVEOF
 PORT=3003
 API_KEY=
 DATA_DIR=
 DEFAULT_MODEL=claude-4.5-sonnet-thinking
 MAX_TOKENS=8192
 LOG_LEVEL=info
-LS_BINARY_PATH=/opt/windsurf/language_server_linux_x64
+LS_BINARY_PATH=$LS_PATH
+LS_DATA_DIR=$LS_DATA_DIR
 LS_PORT=42100
 DASHBOARD_PASSWORD=
 ALLOW_PRIVATE_PROXY_HOSTS=

--- a/src/config.js
+++ b/src/config.js
@@ -53,6 +53,15 @@ try {
   mkdirSync(dataDir, { recursive: true });
 } catch {}
 
+export function defaultLsBinaryPath(platform = process.platform, arch = process.arch, home = process.env.HOME) {
+  if (platform === 'darwin') {
+    const name = arch === 'arm64' ? 'language_server_macos_arm' : 'language_server_macos_x64';
+    return `${home}/.windsurf/${name}`;
+  }
+  const name = arch === 'arm64' ? 'language_server_linux_arm' : 'language_server_linux_x64';
+  return `/opt/windsurf/${name}`;
+}
+
 export const config = {
   port: parseInt(process.env.PORT || '3003', 10),
   // Bind host. Defaults to all interfaces. Set HOST=127.0.0.1 (or BIND_HOST=)
@@ -74,11 +83,7 @@ export const config = {
   logLevel: process.env.LOG_LEVEL || 'info',
 
   // Language server
-  lsBinaryPath: process.env.LS_BINARY_PATH || (
-    process.platform === 'darwin'
-      ? `${process.env.HOME}/.windsurf/language_server_macos_${process.arch === 'arm64' ? 'arm' : 'x64'}`
-      : '/opt/windsurf/language_server_linux_x64'
-  ),
+  lsBinaryPath: process.env.LS_BINARY_PATH || defaultLsBinaryPath(),
   lsPort: parseInt(process.env.LS_PORT || '42100', 10),
 
   // Dashboard

--- a/src/langserver.js
+++ b/src/langserver.js
@@ -22,7 +22,7 @@ const DEFAULT_BINARY = '/opt/windsurf/language_server_linux_x64';
 const DEFAULT_PORT = 42100;
 const DEFAULT_CSRF = 'windsurf-api-csrf-fixed-token';
 const DEFAULT_API_URL = 'https://server.self-serve.windsurf.com';
-const DEFAULT_DATA_ROOT = '/opt/windsurf/data';
+const DEFAULT_LINUX_DATA_ROOT = '/opt/windsurf/data';
 
 // Pool: key -> { process, port, csrfToken, proxy, startedAt, ready }
 const _pool = new Map();
@@ -112,10 +112,16 @@ function proxyKey(proxy) {
   return key;
 }
 
+export function defaultLsDataRoot(platform = process.platform, home = process.env.HOME) {
+  return platform === 'darwin'
+    ? resolve(home || '.', '.windsurf', 'data')
+    : DEFAULT_LINUX_DATA_ROOT;
+}
+
 function dataDirForKey(key) {
   const root = process.env.LS_DATA_DIR
     ? resolve(process.cwd(), process.env.LS_DATA_DIR)
-    : DEFAULT_DATA_ROOT;
+    : defaultLsDataRoot();
   return `${root}/${key}`;
 }
 

--- a/test/platform-ls-paths.test.js
+++ b/test/platform-ls-paths.test.js
@@ -1,0 +1,47 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { defaultLsBinaryPath } from '../src/config.js';
+import { defaultLsDataRoot } from '../src/langserver.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INSTALL_LS = readFileSync(join(__dirname, '..', 'install-ls.sh'), 'utf8');
+const SETUP = readFileSync(join(__dirname, '..', 'setup.sh'), 'utf8');
+
+describe('platform-specific language server paths', () => {
+  test('runtime defaults match install-ls.sh defaults', () => {
+    assert.equal(
+      defaultLsBinaryPath('darwin', 'arm64', '/Users/alice'),
+      '/Users/alice/.windsurf/language_server_macos_arm'
+    );
+    assert.equal(
+      defaultLsBinaryPath('darwin', 'x64', '/Users/alice'),
+      '/Users/alice/.windsurf/language_server_macos_x64'
+    );
+    assert.equal(
+      defaultLsBinaryPath('linux', 'x64', '/home/alice'),
+      '/opt/windsurf/language_server_linux_x64'
+    );
+    assert.equal(
+      defaultLsBinaryPath('linux', 'arm64', '/home/alice'),
+      '/opt/windsurf/language_server_linux_arm'
+    );
+
+    assert.match(INSTALL_LS, /DEFAULT_PATH="\$HOME\/\.windsurf\/\$\{ASSET\}"/);
+    assert.match(INSTALL_LS, /DEFAULT_PATH="\/opt\/windsurf\/\$\{ASSET\}"/);
+  });
+
+  test('macOS language server data defaults to a user-writable directory', () => {
+    assert.equal(defaultLsDataRoot('darwin', '/Users/alice'), '/Users/alice/.windsurf/data');
+    assert.equal(defaultLsDataRoot('linux', '/home/alice'), '/opt/windsurf/data');
+  });
+
+  test('setup.sh writes platform-specific LS_BINARY_PATH and LS_DATA_DIR', () => {
+    assert.match(SETUP, /Darwin:arm64\).*LS_PATH="\$HOME\/\.windsurf\/language_server_macos_arm"/s);
+    assert.match(SETUP, /Linux:aarch64\|Linux:arm64\).*LS_PATH="\/opt\/windsurf\/language_server_linux_arm"/s);
+    assert.match(SETUP, /LS_BINARY_PATH=\$LS_PATH/);
+    assert.match(SETUP, /LS_DATA_DIR=\$LS_DATA_DIR/);
+  });
+});


### PR DESCRIPTION
## 改了什么 / What changed

Align Language Server binary/data paths across install-ls.sh, setup.sh, runtime defaults, and docs.

## 为什么 / Why

Manual local setup on macOS could install the LS binary into one path while the runtime looked for another path. The default LS data directory also pointed at /opt/windsurf, which is not writable for normal macOS local runs.

This keeps Linux defaults unchanged while making macOS local setup use user-writable ~/.windsurf paths.

Also fixes a few README.en.md curl examples that were missing line-continuation backslashes.

## 测试 / Testing

- git diff --check
- bash -n setup.sh && bash -n install-ls.sh
- node --test test/platform-ls-paths.test.js test/install-ls-atomic-rename.test.js test/langserver-binary-update.test.js

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies (project is zero-dep)
- [ ] 涉及 LS binary 协议改动时 在 PR 描述里注明字段号来源 / If touching LS protocol, document field-number source in the PR description
- [ ] 涉及 dashboard UI 用 App.confirm / App.prompt 不用浏览器原生 alert/confirm / Uses App.confirm / App.prompt, not native dialogs (if dashboard)
