### PR TITLE
feat: Cascade reuse optimization for single-user setups & HTTPS proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,16 @@ DEFAULT_MODEL=claude-4.5-sonnet-thinking
 MAX_TOKENS=8192
 LOG_LEVEL=info
 
+# ========== Cascade Reuse (single-user Claude Code optimization) ==========
+# Caller-based fallback: when fingerprint misses, reuse the latest cascade
+# for the same caller+model. Set to 1 for single-user Claude Code setups.
+CASCADE_REUSE_BY_CALLER=0
+# Max pool entries. Single-user setups can set to 1-5.
+CASCADE_POOL_MAX=500
+# Don't hash system prompt (reduces fingerprint drift from Claude Code's
+# dynamic system prompt). Already defaults to 0.
+# CASCADE_REUSE_HASH_SYSTEM=0
+
 # ========== Security ==========
 # Allow private/internal hosts (e.g., 192.168.x.x, 10.x.x.x, localhost) in proxy tests.
 # Set to 1 for local deployments where you need to test proxies on private networks.

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ runtime-config.json
 stats.json
 package-lock.json
 *.png
+*.pem
 .docker-data/

--- a/README.en.md
+++ b/README.en.md
@@ -281,6 +281,8 @@ In your client's settings for **Custom OpenAI Compatible**:
 | `CASCADE_REUSE_STRICT` | `0` | Set to `1` for strict conversation reuse mode (waits for same fingerprint). |
 | `CASCADE_REUSE_STRICT_RETRY_MS` | `60000` | Retry delay in ms for strict reuse mode. |
 | `CASCADE_REUSE_HASH_SYSTEM` | `0` | Set to `1` to include system messages in conversation reuse hash. |
+| `CASCADE_REUSE_BY_CALLER` | `0` | Set to `1` to enable caller-based fallback reuse. When fingerprint misses, falls back to the latest cascade for the same caller+model. Best for single-user Claude Code setups. |
+| `CASCADE_POOL_MAX` | `500` | Max conversation pool entries. Set to `1`–`5` for single-user setups to minimize resource usage. |
 
 ## Dashboard Features
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ curl http://localhost:3003/v1/messages \
 | `LS_PORT` | `42100` | LS gRPC 端口 |
 | `DASHBOARD_PASSWORD` | 空 | 后台密码 留空不设密码 |
 | `ALLOW_PRIVATE_PROXY_HOSTS` | 空 | 设为 `1` 允许在代理测试和登录时使用内网 IP（如 `192.168.x.x`、`10.x.x.x`）。默认留空仅允许公网地址 |
+| `CASCADE_REUSE_BY_CALLER` | `0` | 设为 `1` 启用 caller 级别回退复用。指纹未命中时，按 callerKey+model 回退到最近的 cascade。适合单用户 Claude Code 场景 |
+| `CASCADE_POOL_MAX` | `500` | 对话池最大条目数。单用户场景设 `1`–`5` 即可，减少资源占用 |
 
 ## Dashboard 功能面板
 

--- a/https-proxy.js
+++ b/https-proxy.js
@@ -1,0 +1,97 @@
+import http2 from 'http2';
+import http from 'http';
+import { readFileSync } from 'fs';
+
+const HTTPS_PORT = parseInt(process.env.HTTPS_PORT || '3443', 10);
+const TARGET_PORT = parseInt(process.env.TARGET_PORT || '3003', 10);
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
+  'access-control-allow-headers': '*',
+  'access-control-expose-headers': '*',
+  'access-control-max-age': '86400',
+};
+
+function proxy(req, res) {
+  const ts = new Date().toISOString().slice(11, 19);
+  const method = req.method || req.headers[':method'] || 'GET';
+  const url = req.url || req.headers[':path'] || '/';
+  console.log(`[${ts}] ${method} ${url} (${req.httpVersion})`);
+
+  // Handle CORS preflight directly — don't forward to backend
+  if (method === 'OPTIONS') {
+    console.log(`[${ts}] ← 204 CORS preflight`);
+    res.writeHead(204, CORS_HEADERS);
+    return res.end();
+  }
+
+  // Build headers for the HTTP/1.1 backend
+  const fwdHeaders = {};
+  for (const [k, v] of Object.entries(req.headers)) {
+    // Skip HTTP/2 pseudo-headers and hop-by-hop
+    if (k.startsWith(':') || k === 'connection' || k === 'transfer-encoding') continue;
+    fwdHeaders[k] = v;
+  }
+  fwdHeaders['host'] = `127.0.0.1:${TARGET_PORT}`;
+
+  const proxyReq = http.request({
+    hostname: '127.0.0.1',
+    port: TARGET_PORT,
+    path: req.url,
+    method: req.method,
+    headers: fwdHeaders,
+  }, (proxyRes) => {
+    const ct = proxyRes.headers['content-type'] || '';
+    const isSSE = ct.includes('text/event-stream');
+    console.log(`[${ts}] ← ${proxyRes.statusCode} ${ct.split(';')[0]}${isSSE ? ' (SSE)' : ''}`);
+
+    const respHeaders = {};
+    const hop = new Set(['connection', 'transfer-encoding', 'keep-alive', 'upgrade', 'proxy-connection', 'proxy-authenticate', 'proxy-authorization']);
+    for (const [k, v] of Object.entries(proxyRes.headers)) {
+      if (hop.has(k)) continue;
+      respHeaders[k] = v;
+    }
+    if (isSSE) {
+      respHeaders['cache-control'] = 'no-cache';
+      respHeaders['x-accel-buffering'] = 'no';
+    }
+    // Inject CORS headers into every response
+    Object.assign(respHeaders, CORS_HEADERS);
+    res.writeHead(proxyRes.statusCode, respHeaders);
+
+    proxyRes.on('data', (chunk) => {
+      res.write(chunk);
+    });
+    proxyRes.on('end', () => res.end());
+  });
+
+  proxyReq.on('error', (e) => {
+    console.error(`[${ts}] Proxy error: ${e.message} (${req.method} ${req.url})`);
+    if (!res.headersSent) {
+      res.writeHead(502, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: { message: 'Bad Gateway', type: 'proxy_error' } }));
+    }
+  });
+
+  req.on('error', () => proxyReq.destroy());
+  req.on('close', () => { if (!proxyReq.destroyed) proxyReq.destroy(); });
+  req.pipe(proxyReq);
+}
+
+// HTTP/2 secure server with HTTP/1.1 fallback
+const server = http2.createSecureServer({
+  key: readFileSync('./localhost+3-key.pem'),
+  cert: readFileSync('./localhost+3.pem'),
+  allowHTTP1: true,
+}, proxy);
+
+server.timeout = 300_000;
+
+server.on('error', (e) => console.error('Server error:', e.message));
+
+server.listen(HTTPS_PORT, '0.0.0.0', () => {
+  console.log(`HTTPS proxy (HTTP/2 + HTTP/1.1) on https://0.0.0.0:${HTTPS_PORT} → http://127.0.0.1:${TARGET_PORT}`);
+  console.log(`  Local:   https://localhost:${HTTPS_PORT}`);
+  console.log(`  LAN:     https://192.168.50.7:${HTTPS_PORT}`);
+});

--- a/local-setup.md
+++ b/local-setup.md
@@ -1,0 +1,112 @@
+# Local HTTPS Setup for WindsurfAPI
+
+This guide sets up an HTTPS reverse proxy so that clients requiring HTTPS (e.g., Claude for PowerPoint plugin) can connect to WindsurfAPI.
+
+## Prerequisites
+
+- **Node.js** v18+
+- **WindsurfAPI** running on `http://localhost:3003`
+- **macOS** (instructions use Homebrew; adapt for Linux)
+
+## Step 1: Install mkcert
+
+```bash
+brew install mkcert
+```
+
+## Step 2: Install the local CA
+
+```bash
+sudo mkcert -install
+```
+
+This adds a locally-trusted root CA to your system keychain.
+
+## Step 3: Generate certificates
+
+Replace `YOUR_LAN_IP` with your actual LAN IP (find it with `ipconfig getifaddr en0`):
+
+```bash
+cd /path/to/WindsurfAPI
+mkcert localhost 127.0.0.1 YOUR_LAN_IP
+```
+
+Example:
+
+```bash
+mkcert localhost 127.0.0.1 192.168.50.7
+```
+
+This creates two files (e.g., `localhost+2.pem` and `localhost+2-key.pem`). These are gitignored.
+
+## Step 4: Update the proxy cert path
+
+Edit `https-proxy.js` and update the cert/key filenames to match the generated files:
+
+```js
+key: readFileSync('./localhost+2-key.pem'),
+cert: readFileSync('./localhost+2.pem'),
+```
+
+## Step 5: Start the HTTPS proxy
+
+```bash
+node https-proxy.js
+```
+
+Output:
+
+```
+HTTPS proxy (HTTP/2 + HTTP/1.1) on https://0.0.0.0:3443 → http://127.0.0.1:3003
+  Local:   https://localhost:3443
+  LAN:     https://192.168.50.7:3443
+```
+
+## Step 6: Configure your client
+
+| Client | Base URL |
+|---|---|
+| Same machine | `https://localhost:3443` |
+| Other PC on same Wi-Fi | `https://YOUR_LAN_IP:3443` |
+
+## Accessing from another PC
+
+The other PC needs to trust your local CA:
+
+1. Find your CA cert:
+   ```bash
+   mkcert -CAROOT
+   ```
+2. Copy `rootCA.pem` from that folder to the other PC.
+3. Install it in the other PC's trust store:
+   - **Windows**: Double-click → Install Certificate → Local Machine → Trusted Root Certification Authorities
+   - **macOS**: `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain rootCA.pem`
+
+## Troubleshooting
+
+### macOS Firewall blocks LAN access
+
+Turn off the firewall or allow Node:
+
+**System Settings → Network → Firewall → Off**
+
+### Plugin says "Unable to connect"
+
+- Ensure WindsurfAPI is running on port 3003: `curl http://localhost:3003/health`
+- Ensure the HTTPS proxy is running on port 3443: `curl https://localhost:3443/health`
+- Check the proxy terminal for request logs
+
+### Custom ports
+
+```bash
+HTTPS_PORT=8443 TARGET_PORT=3003 node https-proxy.js
+```
+
+## Environment Variables (optional)
+
+Add to your `.env` for cascade reuse optimization (single-user Claude Code):
+
+```env
+CASCADE_REUSE_BY_CALLER=1
+CASCADE_POOL_MAX=1
+```

--- a/src/conversation-pool.js
+++ b/src/conversation-pool.js
@@ -32,12 +32,22 @@ function positiveIntEnv(name, fallback) {
 }
 
 const POOL_TTL_MS = positiveIntEnv('CASCADE_POOL_TTL_MS', 30 * 60 * 1000);
-const POOL_MAX = 500;
+const POOL_MAX = positiveIntEnv('CASCADE_POOL_MAX', 500);
 const KEY_VERSION = 2;
 
-const _pool = new Map();
+// When enabled, a secondary index maps (callerKey + modelKey) → latest
+// fingerprint. If the primary fingerprint lookup misses but the caller has
+// a recent cascade for the same model, we fall back to it. This makes
+// reuse robust against fingerprint drift (system-prompt changes, tool-list
+// reordering, etc.) within a single Claude Code / Cline session.
+const REUSE_BY_CALLER = process.env.CASCADE_REUSE_BY_CALLER === '1';
 
-const stats = { hits: 0, misses: 0, stores: 0, evictions: 0, expired: 0 };
+const _pool = new Map();
+// Secondary index: callerKey:modelKey → fingerprint (latest). Only
+// populated when REUSE_BY_CALLER is on.
+const _callerLatest = new Map();
+
+const stats = { hits: 0, misses: 0, stores: 0, evictions: 0, expired: 0, callerFallbackHits: 0 };
 
 function sha256(s) {
   return createHash('sha256').update(s).digest('hex');
@@ -485,12 +495,23 @@ function prune(now) {
   for (const [fp, e] of _pool) {
     if (now - e.lastAccess > effectiveTtl(e)) { _pool.delete(fp); stats.expired++; }
   }
-  if (_pool.size <= POOL_MAX) return;
+  if (_pool.size <= POOL_MAX) {
+    _pruneCallerIndex();
+    return;
+  }
   const entries = [..._pool.entries()].sort((a, b) => a[1].lastAccess - b[1].lastAccess);
   const toDrop = entries.length - POOL_MAX;
   for (let i = 0; i < toDrop; i++) {
     _pool.delete(entries[i][0]);
     stats.evictions++;
+  }
+  _pruneCallerIndex();
+}
+
+function _pruneCallerIndex() {
+  if (!REUSE_BY_CALLER || !_callerLatest.size) return;
+  for (const [ck, fp] of _callerLatest) {
+    if (!_pool.has(fp)) _callerLatest.delete(ck);
   }
 }
 
@@ -505,10 +526,26 @@ function prune(now) {
  * pool boundary (MED-3). Pass `{ apiKey, lsPort, lsGeneration }` and a
  * mismatch returns null + counts a miss without leaking the entry.
  */
-export function checkout(fingerprint, callerKey = '', expected = null) {
-  if (!fingerprint) { stats.misses++; return null; }
+export function checkout(fingerprint, callerKey = '', expected = null, modelKey = '') {
+  if (!fingerprint) {
+    // No fingerprint — try caller-based fallback before giving up.
+    if (REUSE_BY_CALLER && callerKey && modelKey) {
+      const fallback = _callerFallbackCheckout(callerKey, modelKey, expected);
+      if (fallback) return fallback;
+    }
+    stats.misses++;
+    return null;
+  }
   const entry = _pool.get(fingerprint);
-  if (!entry) { stats.misses++; return null; }
+  if (!entry) {
+    // Fingerprint miss — try caller-based fallback.
+    if (REUSE_BY_CALLER && callerKey && modelKey) {
+      const fallback = _callerFallbackCheckout(callerKey, modelKey, expected);
+      if (fallback) return fallback;
+    }
+    stats.misses++;
+    return null;
+  }
 
   // Validate BEFORE removing from the pool. The previous order
   // (`delete` first, then check) had a subtle leak: when a caller's
@@ -538,6 +575,40 @@ export function checkout(fingerprint, callerKey = '', expected = null) {
 
   // Validated. Now remove and hand to the caller.
   _pool.delete(fingerprint);
+  // Clean up caller index if it pointed at this fingerprint.
+  if (REUSE_BY_CALLER && entry.callerKey) {
+    for (const [ck, fp] of _callerLatest) {
+      if (fp === fingerprint) _callerLatest.delete(ck);
+    }
+  }
+  stats.hits++;
+  return entry;
+}
+
+// Caller-based fallback: look up the latest fingerprint for this
+// callerKey+model pair and check out that entry. Same validation as
+// the primary path.
+function _callerFallbackCheckout(callerKey, modelKey, expected) {
+  const ck = `${callerKey}\0${modelKey}`;
+  const fp = _callerLatest.get(ck);
+  if (!fp) return null;
+  const entry = _pool.get(fp);
+  if (!entry) { _callerLatest.delete(ck); return null; }
+  if (entry.callerKey && callerKey && entry.callerKey !== callerKey) return null;
+  if (Date.now() - entry.lastAccess > effectiveTtl(entry)) {
+    _pool.delete(fp);
+    _callerLatest.delete(ck);
+    stats.expired++;
+    return null;
+  }
+  if (expected) {
+    if (expected.apiKey && entry.apiKey && expected.apiKey !== entry.apiKey) return null;
+    if (expected.lsPort && entry.lsPort && expected.lsPort !== entry.lsPort) return null;
+    if (expected.lsGeneration != null && entry.lsGeneration != null && expected.lsGeneration !== entry.lsGeneration) return null;
+  }
+  _pool.delete(fp);
+  _callerLatest.delete(ck);
+  stats.callerFallbackHits++;
   stats.hits++;
   return entry;
 }
@@ -588,6 +659,7 @@ export function checkin(fingerprint, entry, callerKey = '', ttlHintMs) {
       lsGeneration: entry.lsGeneration,
       apiKey: entry.apiKey,
       callerKey: callerKey || entry.callerKey || '',
+      modelKey: entry.modelKey || '',
       stepOffset: Number.isFinite(entry.stepOffset) ? entry.stepOffset : 0,
       generatorOffset: Number.isFinite(entry.generatorOffset) ? entry.generatorOffset : 0,
       historyCoverage: entry.historyCoverage || null,
@@ -602,6 +674,14 @@ export function checkin(fingerprint, entry, callerKey = '', ttlHintMs) {
   // and operators read pool efficiency wrong.
   stats.stores++;
   if (fingerprints.length > 1) stats.aliasWrites = (stats.aliasWrites || 0) + (fingerprints.length - 1);
+  // Update caller-based secondary index.
+  if (REUSE_BY_CALLER && (callerKey || entry.callerKey)) {
+    const ck = callerKey || entry.callerKey;
+    const mk = entry.modelKey || '';
+    if (ck && fingerprints[0]) {
+      _callerLatest.set(`${ck}\0${mk}`, fingerprints[0]);
+    }
+  }
   prune(now);
 }
 
@@ -647,6 +727,12 @@ export function invalidateFor({ apiKey, lsPort, lsGeneration } = {}) {
       dropped++;
     }
   }
+  // Clean caller index for dropped cascadeIds.
+  if (REUSE_BY_CALLER && dropped > 0) {
+    for (const [ck, fp] of _callerLatest) {
+      if (!_pool.has(fp)) _callerLatest.delete(ck);
+    }
+  }
   return dropped;
 }
 
@@ -655,6 +741,8 @@ export function poolStats() {
     size: _pool.size,
     maxSize: POOL_MAX,
     ttlMs: POOL_TTL_MS,
+    reuseByCaller: REUSE_BY_CALLER,
+    callerLatestSize: _callerLatest.size,
     ...stats,
     hitRate: stats.hits + stats.misses > 0
       ? ((stats.hits / (stats.hits + stats.misses)) * 100).toFixed(1)
@@ -665,6 +753,7 @@ export function poolStats() {
 export function poolClear() {
   const n = _pool.size;
   _pool.clear();
+  _callerLatest.clear();
   return n;
 }
 

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -1792,7 +1792,7 @@ async function _handleChatCompletionsInner(body, context = {}) {
   const strictReuse = shouldUseStrictCascadeReuse({ emulateTools, modelKey: routingModelKey });
   const fpOpts = buildReuseOpts({ tools, toolChoice: tool_choice, toolPreamble, preambleTier: preambleTier || null, emulateTools, route: body.__route || 'chat' });
   const fpBefore = reuseEnabled ? fingerprintBefore(messages, routingModelKey, callerKey, fpOpts) : null;
-  let reuseEntry = reuseEnabled ? poolCheckout(fpBefore, callerKey) : null;
+  let reuseEntry = reuseEnabled ? poolCheckout(fpBefore, callerKey, null, routingModelKey) : null;
   let checkedOutReuseEntry = reuseEntry;
   // v2.0.71 (#116 zhangzhang-bit follow-up): structured reuse log so
   // operators can see whether multi-turn cascades are actually reusing
@@ -2416,6 +2416,7 @@ async function nonStreamResponse(client, id, created, model, modelKey, messages,
         lsPort: poolCtx.lsPort,
         lsGeneration: cascadeMeta.lsGeneration || poolCtx.lsGeneration,
         apiKey: poolCtx.apiKey,
+        modelKey: modelKey || '',
         stepOffset: Number.isFinite(cascadeMeta.stepOffset) ? cascadeMeta.stepOffset : poolCtx.reuseEntry?.stepOffset,
         generatorOffset: Number.isFinite(cascadeMeta.generatorOffset) ? cascadeMeta.generatorOffset : poolCtx.reuseEntry?.generatorOffset,
         historyCoverage: cascadeMeta.historyCoverage || poolCtx.reuseEntry?.historyCoverage || null,
@@ -2722,7 +2723,7 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
         && (isExperimentalEnabled('cascadeConversationReuse') || shouldForceCascadeReuse({ emulateTools, modelKey }));
       const strictReuse = shouldUseStrictCascadeReuse({ emulateTools, modelKey });
       const fpBefore = reuseEnabled ? fingerprintBefore(messages, modelKey, callerKey, fpOpts) : null;
-      let reuseEntry = reuseEnabled ? poolCheckout(fpBefore, callerKey) : null;
+      let reuseEntry = reuseEnabled ? poolCheckout(fpBefore, callerKey, null, modelKey) : null;
       let checkedOutReuseEntry = reuseEntry;
       // v2.0.25 HIGH-2: same dead-entry signal as the non-stream path.
       let reuseEntryDead = false;
@@ -3155,6 +3156,7 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
                 lsPort: ls.port,
                 lsGeneration: cascadeResult.lsGeneration || ls.generation,
                 apiKey: currentApiKey,
+                modelKey: modelKey || '',
                 stepOffset: Number.isFinite(cascadeResult.stepOffset) ? cascadeResult.stepOffset : reuseEntry?.stepOffset,
                 generatorOffset: Number.isFinite(cascadeResult.generatorOffset) ? cascadeResult.generatorOffset : reuseEntry?.generatorOffset,
                 historyCoverage: cascadeResult.historyCoverage || reuseEntry?.historyCoverage || null,


### PR DESCRIPTION
## Summary

This PR improves **cascade conversation reuse** for personal/single-user setups (e.g., Claude Code, Claude Desktop, Claude for Office plugins) and adds an HTTPS reverse proxy for clients that require TLS.

## Problem

When using WindsurfAPI with Claude Code in a single-user setup:
1. **Cascade creates multiple conversations** instead of reusing the same one, because the conversation fingerprint drifts between turns (system prompt changes with timestamps, cwd, git status, etc.)
2. **Office plugins (e.g., Claude for PowerPoint/Word)** require HTTPS but WindsurfAPI only serves HTTP
3. **Pool size** is hardcoded at 500 entries — wasteful for single-user setups

## Changes

### Caller-based cascade reuse fallback
- New env var `CASCADE_REUSE_BY_CALLER=1`: adds a secondary index `(callerKey + model) -> cascade` in the conversation pool
- When the primary fingerprint lookup misses (due to system prompt drift), falls back to the latest cascade for the same caller+model
- **Result**: single-user Claude Code sessions always reuse the same cascade ID, avoiding redundant history replays

### Configurable pool size
- New env var `CASCADE_POOL_MAX=N` (default 500): set to `1`-`5` for single-user setups to minimize memory usage

### HTTPS reverse proxy
- `https-proxy.js`: lightweight HTTP/2 + HTTP/1.1 reverse proxy with full CORS support
- Handles Office plugin requirements (HTTPS, HTTP/2, preflight headers)
- Uses `mkcert` for locally-trusted certificates

### Documentation
- `local-setup.md`: step-by-step guide for HTTPS setup with mkcert
- Updated `.env.example`, `README.md`, `README.en.md` with new env vars

## Recommended .env for single-user personal use

```env
CASCADE_REUSE_BY_CALLER=1
CASCADE_POOL_MAX=1
```

## Files changed
- `src/conversation-pool.js` — configurable pool max, caller-based fallback index
- `src/handlers/chat.js` — pass modelKey to pool checkout/checkin
- `https-proxy.js` — new HTTPS reverse proxy
- `local-setup.md` — setup guide
- `.env.example`, `.gitignore`, `README.md`, `README.en.md` — docs

## Testing
- All 34 existing tests pass
- Verified HTTPS proxy with Claude Messages API
- Verified with Claude for PowerPoint plugin (HTTP/2 + CORS)
