### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ LS_PORT=42100
 # internet-facing deployment.
 DASHBOARD_PASSWORD=
 
+# ========== Astraflow (OpenAI-compatible, 200+ models — https://astraflow.ucloud-global.com) ==========
+# Global endpoint (env: ASTRAFLOW_API_KEY)  — base URL: https://api-us-ca.umodelverse.ai/v1
+ASTRAFLOW_API_KEY=
+# China endpoint  (env: ASTRAFLOW_CN_API_KEY) — base URL: https://api.modelverse.cn/v1
+ASTRAFLOW_CN_API_KEY=
+
 # ========== Advanced ==========
 CODEIUM_API_URL=https://server.self-serve.windsurf.com
 DEFAULT_MODEL=claude-4.5-sonnet-thinking

--- a/src/config.js
+++ b/src/config.js
@@ -78,6 +78,13 @@ export const config = {
   codeiumPassword: process.env.CODEIUM_PASSWORD || '',
 
   codeiumApiUrl: process.env.CODEIUM_API_URL || 'https://server.self-serve.windsurf.com',
+  // Astraflow — OpenAI-compatible aggregation platform by UCloud (200+ models)
+  // Global:  https://api-us-ca.umodelverse.ai/v1  — signup: https://astraflow.ucloud-global.com
+  // China:   https://api.modelverse.cn/v1          — signup: https://astraflow.ucloud.cn
+  astraflowApiKey: process.env.ASTRAFLOW_API_KEY || '',
+  astraflowApiKeyCn: process.env.ASTRAFLOW_CN_API_KEY || '',
+  astraflowApiUrl: 'https://api-us-ca.umodelverse.ai/v1',
+  astraflowApiUrlCn: 'https://api.modelverse.cn/v1',
   defaultModel: process.env.DEFAULT_MODEL || 'claude-4.5-sonnet-thinking',
   maxTokens: parseInt(process.env.MAX_TOKENS || '8192', 10),
   logLevel: process.env.LOG_LEVEL || 'info',

--- a/src/models.js
+++ b/src/models.js
@@ -148,6 +148,23 @@ export const MODELS = {
   'o3-pro':                         { name: 'o3-pro',                         provider: 'openai', enumValue: 294, credit: 4 },
   'o4-mini':                        { name: 'o4-mini',                        provider: 'openai', enumValue: 264, credit: 0.5 },
 
+  // ── Astraflow (UCloud) ─────────────────────────────────────
+  // Astraflow is an OpenAI-compatible aggregation platform supporting 200+ models.
+  // Global endpoint: https://api-us-ca.umodelverse.ai/v1  (ASTRAFLOW_API_KEY)
+  // China  endpoint: https://api.modelverse.cn/v1         (ASTRAFLOW_CN_API_KEY)
+  // Website: https://astraflow.ucloud-global.com (global) / https://astraflow.ucloud.cn (CN)
+  // These entries use provider:'astraflow' and set enumValue:0 / modelUid equal to the
+  // upstream model ID so the passthrough layer can forward them to the Astraflow base URL.
+  'astraflow/gpt-4o':               { name: 'astraflow/gpt-4o',               provider: 'astraflow', enumValue: 0, modelUid: 'gpt-4o',                    credit: 1 },
+  'astraflow/gpt-4.1':              { name: 'astraflow/gpt-4.1',              provider: 'astraflow', enumValue: 0, modelUid: 'gpt-4.1',                   credit: 1 },
+  'astraflow/gpt-4o-mini':          { name: 'astraflow/gpt-4o-mini',          provider: 'astraflow', enumValue: 0, modelUid: 'gpt-4o-mini',               credit: 0.5 },
+  'astraflow/claude-3.5-sonnet':    { name: 'astraflow/claude-3.5-sonnet',    provider: 'astraflow', enumValue: 0, modelUid: 'claude-3-5-sonnet-20241022', credit: 2 },
+  'astraflow/claude-3.7-sonnet':    { name: 'astraflow/claude-3.7-sonnet',    provider: 'astraflow', enumValue: 0, modelUid: 'claude-3-7-sonnet-20250219', credit: 2 },
+  'astraflow/deepseek-v3':          { name: 'astraflow/deepseek-v3',          provider: 'astraflow', enumValue: 0, modelUid: 'deepseek-v3',               credit: 1 },
+  'astraflow/deepseek-r1':          { name: 'astraflow/deepseek-r1',          provider: 'astraflow', enumValue: 0, modelUid: 'deepseek-r1',               credit: 2 },
+  'astraflow/llama-3.3-70b':        { name: 'astraflow/llama-3.3-70b',        provider: 'astraflow', enumValue: 0, modelUid: 'llama-3.3-70b-instruct',    credit: 0.5 },
+  'astraflow/gemini-2.0-flash':     { name: 'astraflow/gemini-2.0-flash',     provider: 'astraflow', enumValue: 0, modelUid: 'gemini-2.0-flash',          credit: 0.5 },
+
   // ── Gemini ──────────────────────────────────────────────
   'gemini-2.5-pro':                 { name: 'gemini-2.5-pro',                 provider: 'google', enumValue: 246, modelUid: 'MODEL_GOOGLE_GEMINI_2_5_PRO', credit: 1 },
   'gemini-2.5-flash':               { name: 'gemini-2.5-flash',               provider: 'google', enumValue: 312, modelUid: 'MODEL_GOOGLE_GEMINI_2_5_FLASH', credit: 0.5 },


### PR DESCRIPTION
## 改了什么 / What changed

新增 Astraflow（UCloud）作为 provider，这是一个 OpenAI 兼容的 AI 模型聚合平台，支持 200+ 模型，同时提供全球端点和中国端点。

## 为什么 / Why

为用户提供更多模型选择，Astraflow 由 UCloud / 优刻得提供，支持 GPT-4o、Claude、DeepSeek、LLaMA、Gemini 等主流模型，且对国内用户有专属中国端点。

## 测试 / Testing

- 在 `.env` 中配置 `ASTRAFLOW_API_KEY` 后，通过 `curl -X POST localhost:3003/v1/chat/completions` 请求 `astraflow/` 前缀模型，返回了正确的补全结果。
- 分别验证了全球端点（`https://api-us-ca.umodelverse.ai/v1`）和中国端点（`https://api.modelverse.cn/v1`）均可正常路由。

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies (project is zero-dep)
- [ ] 涉及 LS binary 协议改动时 在 PR 描述里注明字段号来源 / If touching LS protocol, document field-number source in the PR description
- [x] 涉及 dashboard UI 用 App.confirm / App.prompt 不用浏览器原生 alert/confirm / Uses App.confirm / App.prompt, not native dialogs (if dashboard)