### PR TITLE
fix(update): install LS via install-ls sources

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -122,7 +122,7 @@ To pull the latest fixes after deployment, just run one command:
 cd ~/WindsurfAPI && bash update.sh
 ```
 
-`update.sh` does: `git pull` → stops PM2 → kills any residual process on port 3003 → restarts → health check.
+`update.sh` does: `git pull` → updates the LS binary via `install-ls.sh` → stops PM2 → kills any residual process on port 3003 → restarts → health check.
 
 If you are using our public instances (`skiapi.dev`, etc.), you don't need to do anything; we've already pushed the updates.
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ docker compose logs -f
 cd ~/WindsurfAPI && bash update.sh
 ```
 
-`update.sh` 做了：`git pull` → 停 PM2 → kill 3003 端口残留 → 重启 → 健康检查。
+`update.sh` 做了：`git pull` → 通过 `install-ls.sh` 更新 LS binary → 停 PM2 → kill 3003 端口残留 → 重启 → 健康检查。
 
 如果你用的是我们的公网实例（`skiapi.dev` 之类），不用管，我们已经推过了。
 

--- a/install-ls.sh
+++ b/install-ls.sh
@@ -2,7 +2,7 @@
 # Install / update the Windsurf language server binary.
 #
 # Usage:
-#   ./install-ls.sh                        # auto: our release → Exafunction fallback
+#   ./install-ls.sh                        # auto: our release → Windsurf desktop LS release → Exafunction fallback
 #   ./install-ls.sh /path/to/local.bin     # install a local file
 #   ./install-ls.sh --file /path/to.bin    # same as above
 #   ./install-ls.sh --url <direct-url>     # install from a custom URL
@@ -72,7 +72,8 @@ elif [[ $# -ge 2 && "$1" == "--url" ]]; then
   log "Downloading from: $url"
   curl -fL --progress-bar -o "$TMP_TARGET" "$url"
 else
-  # Try our own GitHub release first (newer than Exafunction)
+  # Try our own GitHub release first, then the desktop-extracted LS release,
+  # then the older Exafunction/codeium release as a last resort.
   our_url="${OUR_RELEASE}/${ASSET}"
   log "Trying WindsurfAPI release: $our_url"
   if curl -fL --progress-bar -o "$TMP_TARGET" "$our_url" 2>/dev/null; then

--- a/src/dashboard/api.js
+++ b/src/dashboard/api.js
@@ -986,7 +986,7 @@ export async function handleDashboardApi(method, subpath, body, req, res) {
   // every LS pool entry so requests pick up the new binary on next call.
   // Body: { url?: string } — optional override (e.g. desktop-extracted
   // binary URL); falls back to `install-ls.sh` auto-discovery (our
-  // release → Exafunction).
+  // release → Windsurf desktop LS release → Exafunction).
   if (subpath === '/langserver/update' && method === 'POST') {
     const { spawn } = await import('node:child_process');
     const { fileURLToPath } = await import('node:url');

--- a/src/dashboard/i18n/en.json
+++ b/src/dashboard/i18n/en.json
@@ -655,7 +655,7 @@
     "restartTitle": "Restart Language Server",
     "restartDesc": "In-progress requests will fail. Continue?",
     "updateLsTitle": "Update LS Binary",
-    "updateLsDesc": "Download the latest language_server from the WindsurfAPI / Exafunction GitHub release and restart the LS pool. In-flight requests will fail once.",
+    "updateLsDesc": "Download the latest language_server from the WindsurfAPI / Windsurf desktop LS / Exafunction GitHub release and restart the LS pool. In-flight requests will fail once.",
     "updateLsButton": "Update",
     "restoreDefaultDesc": "restore to default?",
     "clearPoolDesc": "All active Cascade sessions will be cleared. Continue?"

--- a/src/dashboard/i18n/zh-CN.json
+++ b/src/dashboard/i18n/zh-CN.json
@@ -655,7 +655,7 @@
     "restartTitle": "重启 Language Server",
     "restartDesc": "进行中的请求将会失败，确定要继续吗？",
     "updateLsTitle": "更新 LS Binary",
-    "updateLsDesc": "从 WindsurfAPI / Exafunction GitHub release 下载最新 language_server 并重启 LS 池。期间正在进行的请求会失败一次。",
+    "updateLsDesc": "从 WindsurfAPI / Windsurf 桌面 LS / Exafunction GitHub release 下载最新 language_server 并重启 LS 池。期间正在进行的请求会失败一次。",
     "updateLsButton": "更新",
     "restoreDefaultDesc": "恢复到默认？",
     "clearPoolDesc": "当前所有进行中的 Cascade 会话都将被清除，确定继续吗？"

--- a/test/update-script-ls-source.test.js
+++ b/test/update-script-ls-source.test.js
@@ -1,0 +1,41 @@
+// update.sh should use the same language-server download policy as
+// install-ls.sh. It must not drift back to a stale hardcoded asset URL.
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const UPDATE_SH = readFileSync(join(__dirname, '..', 'update.sh'), 'utf8');
+const INSTALL_LS = readFileSync(join(__dirname, '..', 'install-ls.sh'), 'utf8');
+
+describe('update.sh language-server source selection', () => {
+  test('delegates LS updates to install-ls.sh with the configured target path', () => {
+    assert.match(UPDATE_SH, /LS_INSTALL_PATH="\$LS_PATH"\s+bash install-ls\.sh/);
+    assert.doesNotMatch(UPDATE_SH, /RELEASE_URL=/);
+    assert.doesNotMatch(
+      UPDATE_SH,
+      /github\.com\/dwgx\/WindsurfAPI\/releases\/latest\/download\/language_server_linux_x64/,
+      'update.sh must not hardcode the stale WindsurfAPI language-server asset URL'
+    );
+  });
+
+  test('reads LS_BINARY_PATH from .env without GNU grep-only flags', () => {
+    assert.match(UPDATE_SH, /\bawk\b[\s\S]+?\^LS_BINARY_PATH=/);
+    assert.doesNotMatch(
+      UPDATE_SH,
+      /grep[^\n]*\s-[A-Za-z]*P(?:\s|$)/,
+      'update.sh must not require GNU grep -P; macOS ships BSD grep'
+    );
+  });
+
+  test('install-ls.sh knows the fresh Windsurf desktop LS fallback source', () => {
+    assert.match(
+      INSTALL_LS,
+      /WINDSURF_LS_RELEASE=.*CaiJingLong\/windsurf-linux-server-release/,
+      'install-ls.sh should keep the third-party Windsurf desktop LS release source'
+    );
+  });
+});

--- a/test/update-script-ls-source.test.js
+++ b/test/update-script-ls-source.test.js
@@ -23,7 +23,10 @@ describe('update.sh language-server source selection', () => {
   });
 
   test('reads LS_BINARY_PATH from .env without GNU grep-only flags', () => {
-    assert.match(UPDATE_SH, /\bawk\b[\s\S]+?\^LS_BINARY_PATH=/);
+    assert.match(UPDATE_SH, /\bawk\b/);
+    assert.ok(UPDATE_SH.includes('(export[[:space:]]+)?LS_BINARY_PATH'));
+    assert.ok(UPDATE_SH.includes('LS_BINARY_PATH[[:space:]]*=[[:space:]]*'));
+    assert.ok(UPDATE_SH.includes('[[:space:]]+#.*'));
     assert.doesNotMatch(
       UPDATE_SH,
       /grep[^\n]*\s-[A-Za-z]*P(?:\s|$)/,
@@ -34,7 +37,7 @@ describe('update.sh language-server source selection', () => {
   test('install-ls.sh knows the fresh Windsurf desktop LS fallback source', () => {
     assert.match(
       INSTALL_LS,
-      /WINDSURF_LS_RELEASE=.*CaiJingLong\/windsurf-linux-server-release/,
+      /CaiJingLong\/windsurf-linux-server-release/,
       'install-ls.sh should keep the third-party Windsurf desktop LS release source'
     );
   });

--- a/update.sh
+++ b/update.sh
@@ -29,26 +29,21 @@ echo ""
 echo "=== [2/5] Update LS binary ==="
 LS_PATH="${LS_BINARY_PATH:-/opt/windsurf/language_server_linux_x64}"
 if [ -f .env ]; then
-  _lp="$(grep -oP '(?<=LS_BINARY_PATH=).+' .env 2>/dev/null | head -1)"
+  _lp="$(awk '
+    /^LS_BINARY_PATH=/ {
+      sub(/^LS_BINARY_PATH=/, "")
+      print
+      exit
+    }
+  ' .env 2>/dev/null || true)"
   [ -n "$_lp" ] && LS_PATH="$_lp"
 fi
-RELEASE_URL="https://github.com/dwgx/WindsurfAPI/releases/latest/download/language_server_linux_x64"
-if [ -f "$LS_PATH" ]; then
-  LOCAL_SIZE=$(stat --format=%s "$LS_PATH" 2>/dev/null || stat -f%z "$LS_PATH" 2>/dev/null || echo 0)
-  REMOTE_SIZE=$(curl -sI -L "$RELEASE_URL" 2>/dev/null | grep -i content-length | tail -1 | tr -dc '0-9')
-  if [ -n "$REMOTE_SIZE" ] && [ "$REMOTE_SIZE" -gt 0 ] && [ "$LOCAL_SIZE" != "$REMOTE_SIZE" ]; then
-    echo "    LS binary size changed ($LOCAL_SIZE → $REMOTE_SIZE), downloading..."
-    curl -fL --progress-bar -o "$LS_PATH.tmp" "$RELEASE_URL" && mv -f "$LS_PATH.tmp" "$LS_PATH" && chmod +x "$LS_PATH"
-    echo "    LS binary updated"
-  else
-    echo "    LS binary up to date (${LOCAL_SIZE} bytes)"
-  fi
-else
-  echo "    LS binary not found, downloading..."
-  mkdir -p "$(dirname "$LS_PATH")"
-  curl -fL --progress-bar -o "$LS_PATH" "$RELEASE_URL" && chmod +x "$LS_PATH"
-  echo "    LS binary installed"
+if [ ! -f install-ls.sh ]; then
+  echo "    ! install-ls.sh not found; cannot update LS binary"
+  exit 1
 fi
+echo "    Updating via install-ls.sh → $LS_PATH"
+LS_INSTALL_PATH="$LS_PATH" bash install-ls.sh
 
 echo ""
 echo "=== [3/5] Stop service ==="

--- a/update.sh
+++ b/update.sh
@@ -30,9 +30,17 @@ echo "=== [2/5] Update LS binary ==="
 LS_PATH="${LS_BINARY_PATH:-/opt/windsurf/language_server_linux_x64}"
 if [ -f .env ]; then
   _lp="$(awk '
-    /^LS_BINARY_PATH=/ {
-      sub(/^LS_BINARY_PATH=/, "")
-      print
+    /^[[:space:]]*(export[[:space:]]+)?LS_BINARY_PATH[[:space:]]*=/ {
+      sub(/^[[:space:]]*(export[[:space:]]+)?LS_BINARY_PATH[[:space:]]*=[[:space:]]*/, "")
+      if (substr($0, 1, 1) != "\"" && substr($0, 1, 1) != "'\''") {
+        sub(/[[:space:]]+#.*/, "")
+      }
+      sub(/[[:space:]]*$/, "")
+      if ((substr($0, 1, 1) == "\"" && substr($0, length($0), 1) == "\"") ||
+          (substr($0, 1, 1) == "'\''" && substr($0, length($0), 1) == "'\''")) {
+        $0 = substr($0, 2, length($0) - 2)
+      }
+      print $0
       exit
     }
   ' .env 2>/dev/null || true)"


### PR DESCRIPTION
<!-- 感谢贡献 / Thanks for contributing -->

## 改了什么 / What changed

- Route `update.sh` language-server updates through `install-ls.sh` instead of a stale hardcoded WindsurfAPI release URL.
- Align install/update copy with the current fallback chain: WindsurfAPI release → Windsurf desktop LS release → Exafunction fallback.
- Add regression coverage for the release-source fallback and macOS-compatible `.env` parsing.

## 为什么 / Why

`update.sh` still downloaded `language_server_linux_x64` from the old `dwgx/WindsurfAPI` release asset directly, while `install-ls.sh` had already been updated to use the fresh third-party Windsurf desktop LS release fallback. This made one-click updates miss the newer LS source and bypass the atomic install path.

The `.env` parser in `update.sh` also used GNU-only `grep -P`, which fails on macOS BSD grep during local debugging.

## 测试 / Testing

- `bash -n update.sh install-ls.sh`
- `node --test test/update-script-ls-source.test.js test/install-ls-atomic-rename.test.js test/platform-ls-paths.test.js test/langserver-binary-update.test.js test/check-i18n.test.js`

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies (project is zero-dep)
- [x] 涉及 LS binary 协议改动时 在 PR 描述里注明字段号来源 / If touching LS protocol, document field-number source in the PR description (N/A: no LS protocol fields changed)
- [x] 涉及 dashboard UI 用 App.confirm / App.prompt 不用浏览器原生 alert/confirm / Uses App.confirm / App.prompt, not native dialogs (if dashboard) (N/A: copy only, no dashboard dialog flow changed)