### PR TITLE
fix: return 400 for malformed JSON in dashboard API

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -212,6 +212,7 @@ async function route(req, res) {
     if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
       try { body = JSON.parse(await readBody(req)); } catch (err) {
         if (sendBodyTooLargeIfNeeded(res, err, 'dashboard')) return;
+        return json(res, 400, { ok: false, error: 'Invalid JSON' });
       }
     }
     const subpath = path.slice('/dashboard/api'.length);


### PR DESCRIPTION
Addresses an issue where malformed JSON bodies in /dashboard/api/ endpoints were erroneously treated as empty objects instead of returning a 400 Bad Request error. This ensures consistent error handling for invalid JSON input across all API routes.