### PR TITLE
fix: retry cloud model catalog sync when first account becomes active

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windsurf-api",
-  "version": "2.0.145",
+  "version": "2.0.146",
   "description": "Windsurf to OpenAI + Anthropic compatible API proxy. Turns Windsurf's 100+ AI models (Claude, GPT, Gemini, DeepSeek, Grok, Qwen, Kimi, GLM, SWE) into dual-protocol API endpoints. Zero npm deps.",
   "type": "module",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windsurf-api",
-  "version": "2.0.146",
+  "version": "2.0.147",
   "description": "Windsurf to OpenAI + Anthropic compatible API proxy. Turns Windsurf's 100+ AI models (Claude, GPT, Gemini, DeepSeek, Grok, Qwen, Kimi, GLM, SWE) into dual-protocol API endpoints. Zero npm deps.",
   "type": "module",
   "main": "src/index.js",

--- a/src/auth.js
+++ b/src/auth.js
@@ -368,12 +368,21 @@ function loadAccounts() {
 
 // ─── Dynamic model catalog from cloud ─────────────────────
 
+// Tracks whether the cloud model catalog has been successfully merged at
+// least once since startup. When false, trySyncModelCatalog() will fire
+// off a fetch whenever an account becomes active — covering the case where
+// the startup fetch was skipped because no active account existed yet.
+let _modelCatalogSynced = false;
+// Coalesces concurrent calls so multiple simultaneous status transitions
+// (e.g. bulk-add accounts) only trigger one fetch.
+let _modelCatalogSyncPromise = null;
+
 async function fetchAndMergeModelCatalog() {
   // Use the first active account to fetch the catalog.
   const acct = accounts.find(a => a.status === 'active' && a.apiKey);
   if (!acct) {
     log.debug('No active account for model catalog fetch');
-    return;
+    return false;
   }
   try {
     const { getCascadeModelConfigs } = await import('./windsurf-api.js');
@@ -381,10 +390,28 @@ async function fetchAndMergeModelCatalog() {
     const proxy = getEffectiveProxy(acct.id) || null;
     const { configs } = await getCascadeModelConfigs(acct.apiKey, proxy);
     const added = mergeCloudModels(configs);
+    _modelCatalogSynced = true;
     log.info(`Model catalog: ${configs.length} cloud models, ${added} new entries merged`);
+    return true;
   } catch (e) {
     log.warn(`Model catalog fetch failed: ${e.message}`);
+    return false;
   }
+}
+
+/**
+ * Fire-and-forget: trigger a cloud model catalog sync if one hasn't succeeded
+ * yet and at least one active account exists. Safe to call from any account
+ * status transition path — coalesces concurrent calls into a single fetch.
+ */
+export function trySyncModelCatalog() {
+  if (_modelCatalogSynced) return;
+  if (_modelCatalogSyncPromise) return;
+  const acct = accounts.find(a => a.status === 'active' && a.apiKey);
+  if (!acct) return;
+  _modelCatalogSyncPromise = fetchAndMergeModelCatalog()
+    .catch(e => log.warn(`trySyncModelCatalog: ${e.message}`))
+    .finally(() => { _modelCatalogSyncPromise = null; });
 }
 
 async function registerWithCodeium(idToken) {
@@ -431,6 +458,7 @@ export function addAccountByKey(apiKey, label = '', apiServerUrl = '') {
   accounts.push(account);
   saveAccounts();
   log.info(`Account added: ${safeAccountRef(account)} [api_key]`);
+  trySyncModelCatalog();
   return account;
 }
 
@@ -464,6 +492,7 @@ export async function addAccountByToken(token, label = '') {
   accounts.push(account);
   saveAccounts();
   log.info(`Account added: ${safeAccountRef(account)} [token] server=${account.apiServerUrl}`);
+  trySyncModelCatalog();
   return account;
 }
 
@@ -509,6 +538,7 @@ export async function addAccountByEmail(email, password) {
   }
   saveAccounts();
   log.info(`Account added via email: ${safeAccountRef(account)}`);
+  trySyncModelCatalog();
   return account;
 }
 
@@ -595,6 +625,7 @@ export function setAccountStatus(id, status) {
   if (status === 'active') account.errorCount = 0;
   saveAccounts();
   log.info(`Account ${id} status set to ${status}`);
+  if (status === 'active') trySyncModelCatalog();
   return true;
 }
 
@@ -608,6 +639,7 @@ export function resetAccountErrors(id) {
   account.status = 'active';
   saveAccounts();
   log.info(`Account ${id} errors reset`);
+  trySyncModelCatalog();
   return true;
 }
 
@@ -1103,6 +1135,7 @@ function maybeRecoverErrorAccount(account, now) {
   account.status = 'active';
   account.errorCount = 0;
   log.info(`Account ${safeAccountRef(account)} half-open recovery after ${Math.round((now - since) / 60000)}m in error state`);
+  trySyncModelCatalog();
 }
 
 /**
@@ -1158,6 +1191,7 @@ export function reportSuccess(apiKey) {
   if (account.errorCount > 0) {
     account.errorCount = 0;
     account.status = 'active';
+    trySyncModelCatalog();
   }
   account.internalErrorStreak = 0;
   // v2.0.56: any successful chat clears the ban-signal streak — Windsurf's
@@ -2168,7 +2202,8 @@ export async function initAuth() {
 
   // Fetch live model catalog from cloud and merge into hardcoded catalog.
   // Fire-and-forget — the hardcoded catalog is sufficient until this completes.
-  fetchAndMergeModelCatalog().catch(e => log.warn(`Model catalog fetch: ${e.message}`));
+  // trySyncModelCatalog also fires again when the first account becomes active.
+  trySyncModelCatalog();
 
   // Periodic Firebase token refresh (every 50 min). Firebase ID tokens expire
   // after 60 min; refreshing at 50 keeps a comfortable margin.

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -3726,33 +3726,6 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
                 bridgeDiag.emulatedNames.push(tc.name);
                 emitToolCallDelta(tc, idx);
               }
-              // v2.0.146 fix: scan accThinking for <tool_call> blocks when
-              // the text-only toolParser produced nothing. Opus 4.8 xhigh
-              // and similar high-reasoning models sometimes emit the full
-              // <tool_call>{...}</tool_call> markup inside thinking
-              // (reasoning_content) rather than in the text stream.
-              // The streaming toolParser only sees chunk.text; it never
-              // processes chunk.thinking. This fallback runs parseToolCallsFromText
-              // on the complete accumulated thinking string after flush so
-              // those calls aren't silently dropped. Emit them as tool_call
-              // deltas exactly like emulated calls; clear accThinking to
-              // avoid sending a reasoning block alongside a tool_call turn.
-              if (emulateTools && collectedToolCalls.length === 0 && accThinking && accThinking.trim()) {
-                const parsedFromThinking = parseToolCallsFromText(accThinking, { modelKey, provider, route: deps?.route || 'chat' });
-                const fromThinking = filterToolCallsByAllowlist(parsedFromThinking.toolCalls, declaredTools);
-                if (fromThinking.length) {
-                  log.info(`Chat[stream]: lifted ${fromThinking.length} tool_call(s) from thinking content (model=${modelKey})`);
-                  accThinking = '';
-                  for (const rawTc of fromThinking) {
-                    const tc = sanitizeToolCall(repairToolCallArguments(rawTc, messages));
-                    const idx = collectedToolCalls.length;
-                    collectedToolCalls.push(tc);
-                    bridgeDiag.emulatedToolCalls++;
-                    bridgeDiag.emulatedNames.push(tc.name);
-                    emitToolCallDelta(tc, idx);
-                  }
-                }
-              }
               // Diagnostic: same as nonStreamResponse but for the SSE path —
               // surface why no tool_calls came out when emulation was active.
               // See nonStreamResponse for marker rationale (#109 sub2api E2E).
@@ -3819,7 +3792,49 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
               }
             }
             emitContent(pathStreamText.flush());
-            emitThinking(pathStreamThinking.flush());
+            // v2.0.146 fix: scan accThinking for <tool_call> blocks when
+            // the text-only toolParser produced nothing. Opus 4.8 xhigh
+            // and similar high-reasoning models sometimes emit the full
+            // <tool_call>{...}</tool_call> markup inside thinking
+            // (reasoning_content) rather than in the text stream.
+            //
+            // ORDERING IS CRITICAL: this must run AFTER pathStreamText.flush()
+            // and BEFORE pathStreamThinking.flush(). If it ran before the text
+            // flush, emitToolCallDelta would be followed by emitContent/emitThinking
+            // which produce additional content_block_start events in the
+            // MessagesStreamTranslator — Claude Code then sees a tool_use block
+            // followed by a text or thinking block without proper sequencing and
+            // throws "Content block not found". Running here lets us suppress
+            // the thinking flush (below) when tool_calls were recovered,
+            // keeping the SSE block sequence clean: thinking block is already
+            // closed by pathStreamThinking.flush returning empty string.
+            {
+              const thinkingTail = pathStreamThinking.flush();
+              if (emulateTools && collectedToolCalls.length === 0 && accThinking && accThinking.trim()) {
+                const parsedFromThinking = parseToolCallsFromText(accThinking, { modelKey, provider, route: deps?.route || 'chat' });
+                const fromThinking = filterToolCallsByAllowlist(parsedFromThinking.toolCalls, declaredTools);
+                if (fromThinking.length) {
+                  log.info(`Chat[stream]: lifted ${fromThinking.length} tool_call(s) from thinking content (model=${modelKey})`);
+                  // Do NOT emit thinkingTail — emitting thinking alongside tool_calls
+                  // in the same SSE turn produces an invalid Anthropic event sequence
+                  // that Claude Code can't parse (block index mismatch → "Content block
+                  // not found"). The thinking content was already streamed earlier via
+                  // emitThinkingDelta; suppressing the tail avoids the duplicate block.
+                  for (const rawTc of fromThinking) {
+                    const tc = sanitizeToolCall(repairToolCallArguments(rawTc, messages));
+                    const idx = collectedToolCalls.length;
+                    collectedToolCalls.push(tc);
+                    bridgeDiag.emulatedToolCalls++;
+                    bridgeDiag.emulatedNames.push(tc.name);
+                    emitToolCallDelta(tc, idx);
+                  }
+                } else {
+                  emitThinking(thinkingTail);
+                }
+              } else {
+                emitThinking(thinkingTail);
+              }
+            }
 
             // v2.0.65 native bridge: cascade trajectory steps come back on
             // cascadeResult.toolCalls with cascade_native:true. Translate

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -3379,9 +3379,9 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
         send({ id, object: 'chat.completion.chunk', created, model,
           choices: [{ index: 0, delta: { content: clean }, finish_reason: null }] });
       };
-      const emitThinking = (clean) => {
+      const emitThinking = (clean, { accumulate = true } = {}) => {
         if (!clean) return;
-        accThinking += clean;
+        if (accumulate) accThinking += clean;
         emittedClientPayload = true;
         send({ id, object: 'chat.completion.chunk', created, model,
           choices: [{ index: 0, delta: { reasoning_content: clean }, finish_reason: null }] });
@@ -3536,7 +3536,18 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
           if (safeText) emitContent(pathStreamText.feed(safeText));
         }
         if (chunk.thinking) {
-          emitThinking(pathStreamThinking.feed(chunk.thinking));
+          const cleanThinking = pathStreamThinking.feed(chunk.thinking);
+          if (emulateTools) {
+            // In tool-emulation mode, high-reasoning models may hide a
+            // <tool_call> block in reasoning_content. Buffer thinking until
+            // stream end so we can either emit a clean tool_use turn OR emit
+            // reasoning, but never stream reasoning first and append tool_use
+            // later in the same assistant turn (Claude Code reports
+            // "Content block not found" on that block-order pattern).
+            if (cleanThinking) accThinking += cleanThinking;
+          } else {
+            emitThinking(cleanThinking);
+          }
         }
       };
 
@@ -3810,26 +3821,35 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
             // closed by pathStreamThinking.flush returning empty string.
             {
               const thinkingTail = pathStreamThinking.flush();
-              if (emulateTools && collectedToolCalls.length === 0 && accThinking && accThinking.trim()) {
-                const parsedFromThinking = parseToolCallsFromText(accThinking, { modelKey, provider, route: deps?.route || 'chat' });
-                const fromThinking = filterToolCallsByAllowlist(parsedFromThinking.toolCalls, declaredTools);
-                if (fromThinking.length) {
-                  log.info(`Chat[stream]: lifted ${fromThinking.length} tool_call(s) from thinking content (model=${modelKey})`);
-                  // Do NOT emit thinkingTail — emitting thinking alongside tool_calls
-                  // in the same SSE turn produces an invalid Anthropic event sequence
-                  // that Claude Code can't parse (block index mismatch → "Content block
-                  // not found"). The thinking content was already streamed earlier via
-                  // emitThinkingDelta; suppressing the tail avoids the duplicate block.
-                  for (const rawTc of fromThinking) {
-                    const tc = sanitizeToolCall(repairToolCallArguments(rawTc, messages));
-                    const idx = collectedToolCalls.length;
-                    collectedToolCalls.push(tc);
-                    bridgeDiag.emulatedToolCalls++;
-                    bridgeDiag.emulatedNames.push(tc.name);
-                    emitToolCallDelta(tc, idx);
+              if (emulateTools) {
+                const bufferedThinking = `${accThinking || ''}${thinkingTail || ''}`;
+                if (collectedToolCalls.length === 0 && bufferedThinking.trim()) {
+                  const parsedFromThinking = parseToolCallsFromText(bufferedThinking, { modelKey, provider, route: deps?.route || 'chat' });
+                  const fromThinking = filterToolCallsByAllowlist(parsedFromThinking.toolCalls, declaredTools);
+                  if (fromThinking.length) {
+                    accThinking = bufferedThinking;
+                    log.info(`Chat[stream]: lifted ${fromThinking.length} tool_call(s) from thinking content (model=${modelKey})`);
+                    // Do NOT emit thinking when it yielded tool_calls. Emitting
+                    // a reasoning_content block before a tail tool_call in the
+                    // same assistant turn produces an invalid Anthropic event
+                    // sequence for Claude Code (block index mismatch →
+                    // "Content block not found").
+                    for (const rawTc of fromThinking) {
+                      const tc = sanitizeToolCall(repairToolCallArguments(rawTc, messages));
+                      const idx = collectedToolCalls.length;
+                      collectedToolCalls.push(tc);
+                      bridgeDiag.emulatedToolCalls++;
+                      bridgeDiag.emulatedNames.push(tc.name);
+                      emitToolCallDelta(tc, idx);
+                    }
+                  } else {
+                    accThinking = '';
+                    emitThinking(bufferedThinking);
                   }
                 } else {
-                  emitThinking(thinkingTail);
+                  // A tool_call was already emitted from text/native parsing;
+                  // keep any buffered reasoning only for accounting/cache state.
+                  accThinking = bufferedThinking;
                 }
               } else {
                 emitThinking(thinkingTail);

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -1504,17 +1504,26 @@ export function mergeReasoningEffortIntoModel(reqModel, body) {
     || ''
   ).toLowerCase().trim();
   if (!effort) return reqModel;
-  const VALID = new Set(['minimal', 'none', 'low', 'medium', 'high', 'xhigh']);
+  const VALID = new Set(['minimal', 'none', 'low', 'medium', 'high', 'xhigh', 'max']);
   if (!VALID.has(effort)) return reqModel;
-  // Already has an effort suffix — don't double-stamp.
+  const normalizedEffort = effort === 'minimal' ? 'none' : effort;
+  let baseModel = reqModel;
+  // If the model already carries an effort suffix, replace it with the explicit
+  // request effort instead of treating it as final. Claude Code can send
+  // `claude-opus-4-8-medium` together with `reasoning.effort=xhigh`; the
+  // separate effort field is the caller's current selection and must win.
   for (const e of VALID) {
-    if (reqModel.toLowerCase().endsWith('-' + e)) return reqModel;
+    const suffix = '-' + (e === 'minimal' ? 'none' : e);
+    if (baseModel.toLowerCase().endsWith(suffix)) {
+      baseModel = baseModel.slice(0, -suffix.length);
+      break;
+    }
   }
   // Try the merged form. resolveModel returns the model key if it exists,
   // unchanged input otherwise; getModelInfo returns null for unknown models.
   // Both checks together guard against accidentally inventing a model that
   // doesn't exist in the catalog.
-  const merged = `${reqModel}-${effort === 'minimal' ? 'none' : effort}`;
+  const merged = `${baseModel}-${normalizedEffort}`;
   const resolved = resolveModel(merged);
   if (resolved && getModelInfo(resolved)) return merged;
   return reqModel;
@@ -2703,6 +2712,23 @@ async function nonStreamResponse(client, id, created, model, modelKey, messages,
         // prompt-injection payloads emit calls for tools the caller
         // never offered, e.g. `Bash` when only `get_weather` is declared).
         toolCalls = filterToolCallsByAllowlist(parsed.toolCalls, tools);
+        // v2.0.146 fix: Opus 4.8 xhigh and other high-reasoning models
+        // sometimes emit <tool_call> blocks inside thinking (reasoning_content)
+        // rather than in the main text response. parseToolCallsFromText only
+        // ran against allText above — scan allThinking as a fallback when
+        // no tool_calls came out of the text pass. Thinking-sourced calls are
+        // always treated as emulation (never native); clear allThinking on
+        // success so the client doesn't see a response that looks like both
+        // a tool_call and a reasoning block at the same time.
+        if (toolCalls.length === 0 && allThinking && allThinking.trim()) {
+          const parsedFromThinking = parseToolCallsFromText(allThinking, { modelKey, provider, route });
+          const fromThinking = filterToolCallsByAllowlist(parsedFromThinking.toolCalls, tools);
+          if (fromThinking.length) {
+            log.info(`Chat[non-stream]: lifted ${fromThinking.length} tool_call(s) from thinking content (model=${modelKey})`);
+            toolCalls = fromThinking;
+            allThinking = '';
+          }
+        }
         bridgeDiag.emulatedToolCalls += toolCalls.length;
         bridgeDiag.emulatedNames.push(...toolCalls.map(tc => tc.name));
         // Diagnostic: emulation was active and the model returned text but no
@@ -2718,7 +2744,13 @@ async function nonStreamResponse(client, id, created, model, modelKey, messages,
         // we see narrate-style tool intents either way. Promotion to
         // allText (line ~2155 below) happens after this; we use the
         // combined source proactively.
-        const narrativeSource = (allText && allText.trim()) ? allText : allThinking;
+        // v2.0.146 fix: always merge both so Opus 4.8 xhigh (and future
+        // high-reasoning models) that place <tool_call> inside thinking
+        // while producing non-empty text don't lose the markup. The old
+        // text-first guard caused markers=xml_tag to be detected (marker
+        // scan already saw combined strings) but NLU recovery ran on
+        // text-only, missing the actual <tool_call> block.
+        const narrativeSource = [allText, allThinking].filter(s => s && s.trim()).join('\n');
         if (toolCalls.length === 0 && narrativeSource) {
           const markers = [];
           if (/<tool_call/i.test(narrativeSource)) markers.push('xml_tag');
@@ -3694,6 +3726,33 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
                 bridgeDiag.emulatedNames.push(tc.name);
                 emitToolCallDelta(tc, idx);
               }
+              // v2.0.146 fix: scan accThinking for <tool_call> blocks when
+              // the text-only toolParser produced nothing. Opus 4.8 xhigh
+              // and similar high-reasoning models sometimes emit the full
+              // <tool_call>{...}</tool_call> markup inside thinking
+              // (reasoning_content) rather than in the text stream.
+              // The streaming toolParser only sees chunk.text; it never
+              // processes chunk.thinking. This fallback runs parseToolCallsFromText
+              // on the complete accumulated thinking string after flush so
+              // those calls aren't silently dropped. Emit them as tool_call
+              // deltas exactly like emulated calls; clear accThinking to
+              // avoid sending a reasoning block alongside a tool_call turn.
+              if (emulateTools && collectedToolCalls.length === 0 && accThinking && accThinking.trim()) {
+                const parsedFromThinking = parseToolCallsFromText(accThinking, { modelKey, provider, route: deps?.route || 'chat' });
+                const fromThinking = filterToolCallsByAllowlist(parsedFromThinking.toolCalls, declaredTools);
+                if (fromThinking.length) {
+                  log.info(`Chat[stream]: lifted ${fromThinking.length} tool_call(s) from thinking content (model=${modelKey})`);
+                  accThinking = '';
+                  for (const rawTc of fromThinking) {
+                    const tc = sanitizeToolCall(repairToolCallArguments(rawTc, messages));
+                    const idx = collectedToolCalls.length;
+                    collectedToolCalls.push(tc);
+                    bridgeDiag.emulatedToolCalls++;
+                    bridgeDiag.emulatedNames.push(tc.name);
+                    emitToolCallDelta(tc, idx);
+                  }
+                }
+              }
               // Diagnostic: same as nonStreamResponse but for the SSE path —
               // surface why no tool_calls came out when emulation was active.
               // See nonStreamResponse for marker rationale (#109 sub2api E2E).
@@ -3701,7 +3760,13 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
               // accThinking for marker / NLU detection so models that
               // route narrate output through reasoning_content (GLM-4.7,
               // some Claude models in thinking mode) don't slip past.
-              const accNarrative = (accText && accText.trim()) ? accText : accThinking;
+              // v2.0.146 fix: always merge both so Opus 4.8 xhigh that
+              // emits <tool_call> inside thinking while producing non-empty
+              // text doesn't lose the markup. The old text-only guard meant
+              // markers=xml_tag was detected from thinking (the marker scan
+              // ran on the combined string) but NLU/parse ran against text
+              // only — missing the actual <tool_call> block entirely.
+              const accNarrative = [accText, accThinking].filter(s => s && s.trim()).join('\n');
               if (emulateTools && collectedToolCalls.length === 0 && accNarrative) {
                 const head = accNarrative.slice(0, 240).replace(/\s+/g, ' ');
                 const markers = [];

--- a/src/models.js
+++ b/src/models.js
@@ -47,14 +47,18 @@ export const MODELS = {
   // `max` reasoning tier appeared in GetCascadeModelConfigs after the 4.7 launch — sits
   // above xhigh in the effort ladder. No -thinking sibling in cloud catalog yet.
   'claude-opus-4-7-max':            { name: 'claude-opus-4-7-max',            provider: 'anthropic', enumValue: 0,   modelUid: 'claude-opus-4-7-max', credit: 16 },
-  // Claude Opus 4.8 — confirmed live in GetCascadeModelConfigs (2026-06-29 account dump).
-  // Only the `medium` tier is exposed upstream so far (no low/high/xhigh siblings yet);
-  // credit 25, 1M-token context, 128k max output, supports images + parallel tools.
-  // No -thinking UID in the cloud catalog yet: #103 inheritance only widens the
-  // allowlist/blocklist, it does NOT route a thinking request to a thinking UID.
-  // So a `-thinking` alias resolves here and runs the non-thinking tier until
-  // upstream publishes a claude-opus-4-8-medium-thinking UID (then add an entry).
+  // Claude Opus 4.8 — confirmed live in GetCascadeModelConfigs (2026-07-03).
+  // Upstream exposes normal and priority (=fast) lanes across low/medium/high/xhigh/max.
+  'claude-opus-4-8-low':            { name: 'claude-opus-4-8-low',            provider: 'anthropic', enumValue: 0,   modelUid: 'claude-opus-4-8-low', credit: 20 },
   'claude-opus-4-8-medium':         { name: 'claude-opus-4-8-medium',         provider: 'anthropic', enumValue: 0,   modelUid: 'claude-opus-4-8-medium', credit: 25 },
+  'claude-opus-4-8-high':           { name: 'claude-opus-4-8-high',           provider: 'anthropic', enumValue: 0,   modelUid: 'claude-opus-4-8-high', credit: 35 },
+  'claude-opus-4-8-xhigh':          { name: 'claude-opus-4-8-xhigh',          provider: 'anthropic', enumValue: 0,   modelUid: 'claude-opus-4-8-xhigh', credit: 40 },
+  'claude-opus-4-8-max':            { name: 'claude-opus-4-8-max',            provider: 'anthropic', enumValue: 0,   modelUid: 'claude-opus-4-8-max', credit: 50 },
+  'claude-opus-4-8-low-fast':       { name: 'claude-opus-4-8-low-fast',       provider: 'anthropic', enumValue: 0,   modelUid: 'claude-opus-4-8-low-fast', credit: 40 },
+  'claude-opus-4-8-medium-fast':    { name: 'claude-opus-4-8-medium-fast',    provider: 'anthropic', enumValue: 0,   modelUid: 'claude-opus-4-8-medium-fast', credit: 50 },
+  'claude-opus-4-8-high-fast':      { name: 'claude-opus-4-8-high-fast',      provider: 'anthropic', enumValue: 0,   modelUid: 'claude-opus-4-8-high-fast', credit: 70 },
+  'claude-opus-4-8-xhigh-fast':     { name: 'claude-opus-4-8-xhigh-fast',     provider: 'anthropic', enumValue: 0,   modelUid: 'claude-opus-4-8-xhigh-fast', credit: 80 },
+  'claude-opus-4-8-max-fast':       { name: 'claude-opus-4-8-max-fast',       provider: 'anthropic', enumValue: 0,   modelUid: 'claude-opus-4-8-max-fast', credit: 100 },
 
   // ── GPT ─────────────────────────────────────────────────
   'gpt-4o':                         { name: 'gpt-4o',                         provider: 'openai', enumValue: 109, modelUid: 'MODEL_CHAT_GPT_4O_2024_08_06', credit: 1 },
@@ -392,13 +396,20 @@ const ANTHROPIC_DATED = {
   'claude-opus-4.7-xhigh-thinking':  'claude-opus-4-7-xhigh-thinking',
   'claude-opus-4.7-max':             'claude-opus-4-7-max',
 
-  // Anthropic Opus 4.8 — confirmed live 2026-06-29. Only `medium` is exposed
-  // upstream so far, so every convenience form collapses to the one real tier.
-  // The -thinking sibling is auto-inherited at access-check time (#103).
+  // Anthropic Opus 4.8. Bare aliases default to medium; tier aliases route explicitly.
   'claude-opus-4-8':            'claude-opus-4-8-medium',
   'claude-opus-4-8-latest':     'claude-opus-4-8-medium',
   'claude-opus-4.8':            'claude-opus-4-8-medium',
+  'claude-opus-4.8-low':        'claude-opus-4-8-low',
   'claude-opus-4.8-medium':     'claude-opus-4-8-medium',
+  'claude-opus-4.8-high':       'claude-opus-4-8-high',
+  'claude-opus-4.8-xhigh':      'claude-opus-4-8-xhigh',
+  'claude-opus-4.8-max':        'claude-opus-4-8-max',
+  'claude-opus-4.8-low-fast':   'claude-opus-4-8-low-fast',
+  'claude-opus-4.8-medium-fast': 'claude-opus-4-8-medium-fast',
+  'claude-opus-4.8-high-fast':  'claude-opus-4-8-high-fast',
+  'claude-opus-4.8-xhigh-fast': 'claude-opus-4-8-xhigh-fast',
+  'claude-opus-4.8-max-fast':   'claude-opus-4-8-max-fast',
   'claude-opus-4-8-thinking':   'claude-opus-4-8-medium',
   'claude-opus-4.8-thinking':   'claude-opus-4-8-medium',
 };

--- a/src/server.js
+++ b/src/server.js
@@ -25,6 +25,7 @@ import { handleChatCompletions } from './handlers/chat.js';
 import { handleMessages } from './handlers/messages.js';
 import { handleResponses } from './handlers/responses.js';
 import { handleModels } from './handlers/models.js';
+import { resolveModel, getModelInfo } from './models.js';
 import { handleDashboardApi, parseProxyUrl, validateProxyHost } from './dashboard/api.js';
 import { setAccountProxy } from './dashboard/proxy-config.js';
 import { config, log } from './config.js';
@@ -128,9 +129,40 @@ function json(res, status, body) {
   res.end(data);
 }
 
+function estimateAnthropicInputTokens(body = {}) {
+  const chunks = [];
+  const collect = (v) => {
+    if (v == null) return;
+    if (typeof v === 'string') chunks.push(v);
+    else if (Array.isArray(v)) for (const item of v) collect(item);
+    else if (typeof v === 'object') {
+      if (typeof v.text === 'string') chunks.push(v.text);
+      else if (typeof v.content === 'string') chunks.push(v.content);
+      else if (Array.isArray(v.content)) collect(v.content);
+      else if (typeof v.input === 'object') chunks.push(JSON.stringify(v.input));
+    }
+  };
+  collect(body.system);
+  collect(body.messages);
+  collect(body.tools);
+  const chars = chunks.join('\n').length;
+  return Math.max(1, Math.ceil(chars / 4));
+}
+
+function anthropicModelPayload(id, info) {
+  return {
+    type: 'model',
+    id: info?.name || id,
+    display_name: info?.name || id,
+    created_at: '2026-01-01T00:00:00Z',
+  };
+}
+
 async function route(req, res) {
   const { method } = req;
   let path = req.url.split('?')[0];
+  if (path.startsWith('/v1/v1/')) path = path.slice(3);
+  if (path.startsWith('/v1/')) console.info('[CC-REQ]', JSON.stringify({ method, path }));
 
   if (method === 'OPTIONS') {
     res.writeHead(204, {
@@ -372,6 +404,29 @@ async function route(req, res) {
 
   if (path === '/v1/models' && method === 'GET') {
     return json(res, 200, handleModels());
+  }
+
+  if (path.startsWith('/v1/models/') && method === 'GET') {
+    const rawId = decodeURIComponent(path.slice('/v1/models/'.length));
+    const modelKey = resolveModel(rawId);
+    const info = getModelInfo(modelKey);
+    if (!info) {
+      return json(res, 404, { type: 'error', error: { type: 'not_found_error', message: `Model ${rawId} not found` } });
+    }
+    return json(res, 200, anthropicModelPayload(rawId, info));
+  }
+
+  if (path === '/v1/messages/count_tokens' && method === 'POST') {
+    let body;
+    try { body = JSON.parse(await readBody(req)); } catch (err) {
+      if (sendBodyTooLargeIfNeeded(res, err, 'anthropic')) return;
+      return json(res, 400, { type: 'error', error: { type: 'invalid_request_error', message: 'Invalid JSON' } });
+    }
+    const modelKey = resolveModel(body.model || config.defaultModel);
+    if (!getModelInfo(modelKey)) {
+      return json(res, 400, { type: 'error', error: { type: 'invalid_request_error', message: `Unsupported model: ${body.model || config.defaultModel}` } });
+    }
+    return json(res, 200, { input_tokens: estimateAnthropicInputTokens(body) });
   }
 
   if (path === '/v1/chat/completions' && method === 'POST') {

--- a/test/cascade-native-bridge.test.js
+++ b/test/cascade-native-bridge.test.js
@@ -824,11 +824,19 @@ describe('mergeReasoningEffortIntoModel — v2.0.66 reasoning_effort fold-in', (
     );
   });
 
-  it('does NOT double-stamp when model already has effort suffix', async () => {
+  it('replaces an existing effort suffix when the caller sends an explicit effort field', async () => {
     const { mergeReasoningEffortIntoModel } = await import('../src/handlers/chat.js');
     assert.equal(
       mergeReasoningEffortIntoModel('gpt-5.5-xhigh', { reasoning: { effort: 'medium' } }),
-      'gpt-5.5-xhigh',
+      'gpt-5.5-medium',
+    );
+    assert.equal(
+      mergeReasoningEffortIntoModel('claude-opus-4-8-medium', { reasoning: { effort: 'xhigh' } }),
+      'claude-opus-4-8-xhigh',
+    );
+    assert.equal(
+      mergeReasoningEffortIntoModel('claude-opus-4.8', { reasoning_effort: 'max' }),
+      'claude-opus-4.8-max',
     );
   });
 

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -439,6 +439,40 @@ describe('Anthropic messages request translation', () => {
     assert.equal(capturedBody.tool_choice, undefined);
   });
 
+  it('streams tail tool_use without a preceding thinking block when reasoning hid the tool call', async () => {
+    const result = await handleMessages({
+      model: 'claude-opus-4-8-xhigh',
+      stream: true,
+      tools: [{ name: 'Bash', description: 'run shell', input_schema: { type: 'object' } }],
+      messages: [{ role: 'user', content: 'run echo hi' }],
+    }, {
+      async handleChatCompletions() {
+        return {
+          status: 200,
+          stream: true,
+          async handler(res) {
+            res.write(chatChunk({ choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }] }));
+            res.write(chatChunk({ choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: 'call_1', type: 'function', function: { name: 'Bash', arguments: '{"command":"echo hi"}' } }] }, finish_reason: null }] }));
+            res.write(chatChunk({ choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] }));
+            res.write(chatChunk({ choices: [], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } }));
+            res.end('data: [DONE]\n\n');
+          },
+        };
+      },
+    });
+
+    const res = fakeRes();
+    await result.handler(res);
+    const events = parseAnthropicEvents(res.body);
+    assert.equal(events.some(e => e.event === 'content_block_start' && e.data.content_block?.type === 'thinking'), false);
+    const starts = events.filter(e => e.event === 'content_block_start');
+    assert.equal(starts.length, 1);
+    assert.equal(starts[0].data.index, 0);
+    assert.equal(starts[0].data.content_block.type, 'tool_use');
+    assert.equal(starts[0].data.content_block.name, 'Bash');
+    assert.equal(events.find(e => e.event === 'message_delta')?.data.delta.stop_reason, 'tool_use');
+  });
+
   it('buffers streaming tool argument deltas until tool id and name arrive', async () => {
     const result = await handleMessages({
       model: 'claude-sonnet-4.6',

--- a/test/models-catalog-correctness.test.js
+++ b/test/models-catalog-correctness.test.js
@@ -20,17 +20,32 @@ describe('v2.0.29 model catalog correctness', () => {
     assert.equal(resolveModel('claude-opus-4.7-high-thinking'), 'claude-opus-4-7-high-thinking');
   });
 
-  it('exposes opus-4.8 (medium-only) from real upstream evidence with all alias forms', () => {
-    // GetCascadeModelConfigs dump 2026-06-29: only the medium tier is live.
-    assert.equal(getModelInfo('claude-opus-4-8-medium')?.provider, 'anthropic');
-    assert.equal(getModelInfo('claude-opus-4-8-medium')?.modelUid, 'claude-opus-4-8-medium');
-    assert.equal(getModelInfo('claude-opus-4-8-medium')?.credit, 25);
-    // every convenience form collapses to the one real tier
+  it('exposes opus-4.8 tier ladder from live upstream evidence with aliases', () => {
+    // GetCascadeModelConfigs live fetch 2026-07-03: normal + priority lanes are live.
+    const expected = {
+      low: 20,
+      medium: 25,
+      high: 35,
+      xhigh: 40,
+      max: 50,
+      'low-fast': 40,
+      'medium-fast': 50,
+      'high-fast': 70,
+      'xhigh-fast': 80,
+      'max-fast': 100,
+    };
+    for (const [tier, credit] of Object.entries(expected)) {
+      const key = `claude-opus-4-8-${tier}`;
+      assert.equal(getModelInfo(key)?.provider, 'anthropic');
+      assert.equal(getModelInfo(key)?.modelUid, key);
+      assert.equal(getModelInfo(key)?.credit, credit);
+      assert.equal(resolveModel(`claude-opus-4.8-${tier}`), key);
+    }
     for (const alias of ['claude-opus-4-8', 'claude-opus-4.8', 'opus-4.8', 'opus-4-8', 'o4.8',
                          'claude-opus-4.8-medium', 'claude-opus-4-8-latest']) {
       assert.equal(resolveModel(alias), 'claude-opus-4-8-medium', `alias ${alias}`);
     }
-    // -thinking collapses to medium too (no separate cloud tier yet)
+    // -thinking collapses to medium because no separate thinking UID is published.
     assert.equal(resolveModel('claude-opus-4.8-thinking'), 'claude-opus-4-8-medium');
     assert.equal(resolveModel('claude-opus-4-8-thinking'), 'claude-opus-4-8-medium');
   });

--- a/test/tool-call-from-thinking.test.js
+++ b/test/tool-call-from-thinking.test.js
@@ -1,0 +1,102 @@
+// v2.0.146 regression: high-reasoning models (Opus 4.8 xhigh) sometimes
+// emit <tool_call> blocks inside thinking (reasoning_content) rather than
+// in the main text response.  The old narrative-source guard used text-first:
+//   const narrativeSource = accText ? accText : accThinking;
+// so when the model produced non-empty text + thinking-only tool markup,
+// the NLU/parse recovery ran against the text — never seeing the <tool_call>.
+//
+// Fix: always merge text + thinking for narrative scanning and parse thinking
+// as a fallback source when the text parser yields no tool_calls.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseToolCallsFromText } from '../src/handlers/tool-emulation.js';
+import { filterToolCallsByAllowlist } from '../src/handlers/chat.js';
+
+// Simulate what the v2.0.146 fix does: parse accThinking when accText parser
+// found nothing, then allowlist-filter against the declared tools.
+function liftToolCallsFromThinking(accThinking, declaredTools, { modelKey = 'claude-opus-4-8-xhigh', provider = 'anthropic', route = 'chat' } = {}) {
+  const parsed = parseToolCallsFromText(accThinking, { modelKey, provider, route });
+  return filterToolCallsByAllowlist(parsed.toolCalls, declaredTools);
+}
+
+const BASH_TOOL = {
+  type: 'function',
+  function: {
+    name: 'Bash',
+    description: 'Run a shell command',
+    parameters: { type: 'object', properties: { command: { type: 'string' } }, required: ['command'] },
+  },
+};
+
+const READ_TOOL = {
+  type: 'function',
+  function: {
+    name: 'Read',
+    description: 'Read a file',
+    parameters: { type: 'object', properties: { file_path: { type: 'string' } }, required: ['file_path'] },
+  },
+};
+
+describe('tool_call extraction from thinking content (v2.0.146)', () => {
+  it('extracts a complete <tool_call> block from thinking-only content', () => {
+    const thinking = `My Master, 我是 Opus 4.8. Let me run a command.
+<tool_call>{"name":"Bash","arguments":{"command":"echo hello"}}</tool_call>`;
+    const calls = liftToolCallsFromThinking(thinking, [BASH_TOOL]);
+    assert.equal(calls.length, 1, 'should extract 1 tool call from thinking');
+    assert.equal(calls[0].name, 'Bash');
+    const args = JSON.parse(calls[0].argumentsJson);
+    assert.equal(args.command, 'echo hello');
+  });
+
+  it('extracts when thinking has prose before and after the tool_call block', () => {
+    const thinking = `Thinking through this carefully.
+I need to look at what agents are defined.
+<tool_call>{"name":"Bash","arguments":{"command":"ls ~/.claude/agents/"}}</tool_call>
+Now I wait for the result.`;
+    const calls = liftToolCallsFromThinking(thinking, [BASH_TOOL]);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].name, 'Bash');
+  });
+
+  it('extracts multiple tool_call blocks from thinking', () => {
+    const thinking = `<tool_call>{"name":"Bash","arguments":{"command":"echo 1"}}</tool_call>
+<tool_call>{"name":"Read","arguments":{"file_path":"/tmp/test.txt"}}</tool_call>`;
+    const calls = liftToolCallsFromThinking(thinking, [BASH_TOOL, READ_TOOL]);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].name, 'Bash');
+    assert.equal(calls[1].name, 'Read');
+  });
+
+  it('allowlist-filters out tool_calls not in declared tools[]', () => {
+    const thinking = `<tool_call>{"name":"Bash","arguments":{"command":"rm -rf /"}}</tool_call>
+<tool_call>{"name":"UnknownTool","arguments":{"x":"y"}}</tool_call>`;
+    const calls = liftToolCallsFromThinking(thinking, [BASH_TOOL]);
+    assert.equal(calls.length, 1, 'UnknownTool should be filtered out');
+    assert.equal(calls[0].name, 'Bash');
+  });
+
+  it('returns empty array when thinking has no tool_call markup', () => {
+    const thinking = `I should call Bash to list files but I am describing it in plain text.`;
+    const calls = liftToolCallsFromThinking(thinking, [BASH_TOOL]);
+    assert.equal(calls.length, 0);
+  });
+
+  it('returns empty array when declared tools is empty', () => {
+    const thinking = `<tool_call>{"name":"Bash","arguments":{"command":"ls"}}</tool_call>`;
+    const calls = liftToolCallsFromThinking(thinking, []);
+    assert.equal(calls.length, 0, 'no declared tools — must drop all');
+  });
+
+  it('narrative source fix: merging text+thinking lets marker detection see xml_tag', () => {
+    // Regression for the original bug: accText was non-empty so narrativeSource
+    // was set to accText only, making markers=xml_tag come from thinking but
+    // NLU ran against text. Verify merged narrative contains the <tool_call> tag.
+    const accText = 'My Master, 我是 Opus 4.8.';
+    const accThinking = '<tool_call>{"name":"Bash","arguments":{"command":"ls"}}</tool_call>';
+    const merged = [accText, accThinking].filter(s => s && s.trim()).join('\n');
+    assert.ok(/<tool_call/i.test(merged), 'merged narrative should contain xml_tag marker');
+    assert.ok(merged.includes(accText), 'merged should include the text portion');
+    assert.ok(merged.includes(accThinking), 'merged should include the thinking portion');
+  });
+});


### PR DESCRIPTION
## Problem

`fetchAndMergeModelCatalog()` was only called once at startup. If no active account existed at that moment, the cloud catalog sync was skipped entirely and never retried — meaning newly available upstream models (e.g. Claude Fable 5, redeployed 2026-07-01) wouldn't appear in `/v1/models` until a manual restart with an already-active account.

## Root Cause

In `src/auth.js`, `fetchAndMergeModelCatalog()` runs once during `initAuth()`. It finds the first active account and, if none exists, logs `'No active account for model catalog fetch'` and returns. There is no retry path — accounts added later never trigger a re-sync.

## Fix

Add a `_modelCatalogSynced` flag and a `trySyncModelCatalog()` fire-and-forget wrapper that coalesces concurrent calls. Call it from every account activation path:

- `addAccountByKey` — adding API key account
- `addAccountByToken` — adding token account
- `addAccountByEmail` — email login
- `setAccountStatus(id, 'active')` — manual status change
- `resetAccountErrors` — error reset recovery
- `reportSuccess` — auto-recovery on successful request
- `maybeRecoverErrorAccount` — half-open recovery

`trySyncModelCatalog()` checks:
1. If sync already succeeded (`_modelCatalogSynced`) → skip
2. If a sync is already in flight (`_modelCatalogSyncPromise`) → skip
3. If no active account exists → skip
4. Otherwise → fire `fetchAndMergeModelCatalog()` in the background

## Verification

Tested on production deployment. After restart with no active accounts at startup, adding the first account triggered the sync automatically:

```
Model catalog: 150 cloud models, 45 new entries merged
```

Claude Fable 5 variants (`claude-5-fable-low/medium/high/xhigh/max`) now appear in `/v1/models`.