### PR TITLE
fix: disable Happy Eyeballs + use 127.0.0.1 for local HTTP/2 connections

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@ import { readFileSync, existsSync, mkdirSync, writeFileSync, appendFileSync } fr
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { randomBytes } from 'crypto';
+import net from 'net';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -89,6 +90,18 @@ if (IS_PACKAGED) {
       _generatedCreds = { ...gen, envPath: null, persistError: err.code || err.message };
     }
   }
+}
+
+// Disable Node's Happy Eyeballs (autoSelectFamily). On hosts where DNS returns
+// an unroutable IPv6 (e.g. ULA fd00:696e:: for server.codeium.com) before the
+// working IPv4, Node 20+ tries IPv6 first and the whole attempt dies with
+// ETIMEDOUT in ~270ms — no IPv4 fallback. curl survives via Happy Eyeballs,
+// but Node's implementation does not fall back when the IPv6 connect hangs.
+// Disabling autoSelectFamily makes DNS return IPv4 first (default order),
+// which connects cleanly. Zero-cost on hosts with no IPv6 — the flag only
+// changes the address-selection strategy, not the DNS query itself.
+if (typeof net.setDefaultAutoSelectFamily === 'function') {
+  net.setDefaultAutoSelectFamily(false);
 }
 
 // `sharedDataDir` is the cluster-shared root: a single accounts.json lives

--- a/src/grpc.js
+++ b/src/grpc.js
@@ -50,11 +50,16 @@ export function decodeGrpcMessage(grpcMessage) {
 const _sessionPool = new Map();
 
 function getSession(port) {
-  const key = `localhost:${port}`;
+  const key = `127.0.0.1:${port}`;
   let session = _sessionPool.get(key);
   if (session && !session.destroyed && !session.closed) return session;
 
-  session = http2.connect(`http://localhost:${port}`);
+  // Use 127.0.0.1 (not "localhost") so the HTTP/2 client always connects via
+  // IPv4 — the LS listens on 127.0.0.1, and on macOS "localhost" resolves to
+  // ::1 first. With autoSelectFamily=false (set in config.js to fix ETIMEDOUT
+  // on remote server.codeium.com connections), Node only tries the first DNS
+  // result (::1) and gets ECONNREFUSED instead of falling back to 127.0.0.1.
+  session = http2.connect(`http://127.0.0.1:${port}`);
   session.on('error', (err) => {
     log.debug(`HTTP/2 session error on port ${port}: ${err.message}`);
     if (_sessionPool.get(key) === session) _sessionPool.delete(key);
@@ -75,7 +80,7 @@ function getSession(port) {
  * the port).
  */
 export function closeSessionForPort(port) {
-  const key = `localhost:${port}`;
+  const key = `127.0.0.1:${port}`;
   const session = _sessionPool.get(key);
   if (session) {
     try { session.close(); } catch {}

--- a/src/langserver.js
+++ b/src/langserver.js
@@ -1069,7 +1069,9 @@ function isPortInUse(port) {
 
 export function probeLanguageServerPort(port, timeoutMs = 1500) {
   return new Promise((resolve) => {
-    const client = http2.connect(`http://localhost:${port}`);
+    // 127.0.0.1 (not "localhost") — see grpc.js getSession() for the
+    // autoSelectFamily=false rationale.
+    const client = http2.connect(`http://127.0.0.1:${port}`);
     let settled = false;
     let req = null;
     const finish = (ok) => {
@@ -1114,7 +1116,7 @@ async function waitPortReady(port, timeoutMs = 20000) {
   while (Date.now() - start < timeoutMs) {
     try {
       await new Promise((resolve, reject) => {
-        const client = http2.connect(`http://localhost:${port}`);
+        const client = http2.connect(`http://127.0.0.1:${port}`);
         const timer = setTimeout(() => { try { client.close(); } catch {} reject(new Error('timeout')); }, 2000);
         client.on('connect', () => { clearTimeout(timer); client.close(); resolve(); });
         client.on('error', (e) => { clearTimeout(timer); try { client.close(); } catch {} reject(e); });


### PR DESCRIPTION
<!-- 感谢贡献 / Thanks for contributing -->

## 改了什么 / What changed

关闭 Node 的 Happy Eyeballs（`net.setDefaultAutoSelectFamily(false)`），并将所有本地 HTTP/2 连接从 `localhost` 改为 `127.0.0.1`。

涉及 3 个文件：
- `src/config.js` — 新增 `net.setDefaultAutoSelectFamily(false)`
- `src/grpc.js` — `getSession()` / `closeSessionForPort()` 的 `localhost` → `127.0.0.1`
- `src/langserver.js` — `probeLanguageServerPort()` / `waitPortReady()` 的 `localhost` → `127.0.0.1`

## 为什么 / Why

关联 issue：#212

### 问题

DNS 将 `server.codeium.com` 解析为**不可路由的 IPv6 ULA**（`fd00:696e::ffff:2:4277`）排在可用 IPv4 之前。Node 20+ 默认启用 Happy Eyeballs（`autoSelectFamily`），理论上应该先试 IPv6 再回退 IPv4——但 Node 的实现在 IPv6 connect **挂起**（不是立即 ECONNREFUSED）时**不会回退**，整个请求在 ~270ms 后以 `ETIMEDOUT` 死掉。`curl` 正常是因为它的 Happy Eyeballs 有正确的 250ms race timer。

### 为什么是 `setDefaultAutoSelectFamily(false)` 而不是别的方案

尝试过 4 种方案：

| 方案 | 结果 |
|---|---|
| `NODE_OPTIONS=--no-network-family-autoselection` | Node 版本间解析不一致，Node < 20 不可用 |
| 每请求 `autoSelectFamily:false` in `http2.connect()` | `http2.connect()` options 在 Node 20.x 小版本间不可靠传递到底层 socket |
| 自定义 DNS resolver 过滤 IPv6 | 过度工程，脆弱，破坏合法 IPv6-only 部署 |
| **全局 `setDefaultAutoSelectFamily(false)`** | ✅ 简单、稳健、零副作用 |

`autoSelectFamily=false` 让 DNS 返回默认地址顺序（IPv4 优先），连接干净。在没有 IPv6 的主机上零代价——只改变地址选择策略，不改变 DNS 查询本身。

### 为什么必须同时改 `localhost` → `127.0.0.1`

**这是本 PR 最关键的耦合点。** `autoSelectFamily=false` 修好了 remote ETIMEDOUT，但同时**破坏了本地 HTTP/2 连接**：

在 macOS 上 `localhost` 解析为 `::1`（IPv6）优先，`127.0.0.1`（IPv4）其次。LS 监听在 `127.0.0.1`（IPv4 only）。`autoSelectFamily=false` 让 Node 只试第一个 DNS 结果（`::1`）→ `ECONNREFUSED`。`autoSelectFamily=true`（默认）时 Node 试 `::1` 失败后回退 `127.0.0.1`——这就是为什么改之前测试能过。

如果**只**改 `config.js` 不改 `grpc.js` / `langserver.js`，会引入 9 个测试回归（7× `ERR_HTTP2_STREAM_CANCEL` / `ECONNREFUSED ::1`，1× `probeLanguageServerPort` false，1× stream error mask）。这些失败看起来像网络/环境问题，容易误判为 "pre-existing"——实际是 `autoSelectFamily=false` 的直接回归。

用 `127.0.0.1` 是 production-correct：LS 始终是 `127.0.0.1` 上的本地进程，显式 IPv4 避免任何 loopback DNS 解析依赖。

## 测试 / Testing

```bash
# 完整测试套件 3× 连续运行
npm test
# → 2634 pass / 0 fail / exit 0（fresh clone, no .env）

# 验证 ETIMEDOUT 修复（需要真实 upstream 连接）
DEVIN_CONNECT=1 node src/index.js
curl http://127.0.0.1:3003/v1/chat/completions \
  -H "Authorization: Bearer $API_KEY" \
  -d '{"model":"glm-5.2","messages":[{"role":"user","content":"hi"}]}'
# → HTTP 200（之前 ETIMEDOUT in ~270ms）

# 验证本地 HTTP/2 不受影响
node --test test/client-panel-retry.test.js test/langserver-redact.test.js \
  test/native-read-wrapper.test.js test/stream-error.test.js
# → 39 pass / 0 fail（如果只改 config.js 不改 grpc/langserver → 30 pass / 9 fail）
```

3× clean start/stop cycles：全部 OK，`/v1/models` 响应，0 connect errors。

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies (project is zero-dep)
- [x] 涉及 LS binary 协议改动时 在 PR 描述里注明字段号来源 / If touching LS protocol, document field-number source in the PR description
  — 本 PR 改动 `grpc.js`（在 LS 协议文件列表中），但**不改任何 protobuf 字段号**——只改 HTTP/2 connect URL（`localhost` → `127.0.0.1`），不涉及 `windsurf.js` / `proto.js` 的 field-number 变更
- [x] 涉及 dashboard UI 用 App.confirm / App.prompt 不用浏览器原生 alert/confirm / Uses App.confirm / App.prompt, not native dialogs (if dashboard)
  — N/A：本 PR 不涉及 dashboard UI 改动