### PR TITLE
fix: neutralize MCP-gate + inject tool-description preamble into system prompt on native path

### DIFF
--- a/src/devin-connect.js
+++ b/src/devin-connect.js
@@ -548,19 +548,38 @@ export function normalizeToolSchema(schema) {
       if (req.length) out.required = req; else delete out.required;
     }
   }
+  return stripSchemaDescriptions(out);
+}
+
+// ★ Strip `description` annotations from JSON Schema recursively, but preserve
+// properties that happen to be NAMED "description" (a real parameter, e.g.
+// Cursor's Task tool has a `description` property). Only schema-annotation
+// `description` keys (siblings of `type`/`properties`/`required`) are removed.
+// This neutralizes upstream's MCP-gate fingerprinting on parameter descriptions
+// while keeping the full schema structure (types, required, enums, nested
+// objects) intact for the model.
+function stripSchemaDescriptions(value, inProperties = false) {
+  if (Array.isArray(value)) return value.map((item) => stripSchemaDescriptions(item));
+  if (!value || typeof value !== 'object') return value;
+  const out = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (key === 'description' && !inProperties) continue;
+    out[key] = stripSchemaDescriptions(child, key === 'properties');
+  }
   return out;
 }
 
 // ★ Tool-description length cap (2026-07-10, verified from live paid probes).
-// Devin's upstream returns "an internal error occurred" for a Claude-family
-// NATIVE request when a tool's `description` is long enough to cross an upstream
-// content/complexity threshold (isolated live: Claude Code's `TaskOutput` 1080-char
-// description alone trips it; capped to 500 it passes; ALL 24 CC tools with every
-// description ≤500 pass). It's a cumulative content limit, not a specific string.
-// gpt/swe-family tolerate the long descriptions; Claude-family does not. Truncating
-// the DESCRIPTION only degrades the model's tool-usage hint slightly — it never
-// changes which tool is called or its schema — so a generous cap is safe. Default
-// 500 (proven-safe); env WINDSURFAPI_TOOL_DESC_MAX overrides (0 = no cap).
+// SUPERSEDED (2026-07-13): the MCP-gate fix below (encodeToolDef replaces the
+// top-level description with the tool name and stripSchemaDescriptions removes
+// parameter-schema `description` annotations) is the authoritative approach —
+// it neutralizes BOTH the description-length threshold AND the MCP-gate
+// fingerprint match in one pass. capToolDescription is no longer called by
+// encodeToolDef. The function + env knob are retained as an escape hatch in
+// case a future upstream change reintroduces a pure length threshold without
+// the fingerprint match; set WINDSURFAPI_TOOL_DESC_MAX to re-enable truncation
+// if you wire it back into encodeToolDef. Default 500 (proven-safe for the
+// length-only threshold); 0 = no cap.
 function toolDescMax(env = process.env) {
   const raw = Number(env.WINDSURFAPI_TOOL_DESC_MAX);
   return Number.isFinite(raw) && raw >= 0 ? raw : 500;
@@ -572,11 +591,33 @@ function capToolDescription(desc, env = process.env) {
   return s.slice(0, cap);
 }
 
+// ★ MCP-gate neutralization (2026-07-13, verified from live A/B probes).
+// Upstream server.codeium.com pattern-matches tool descriptions (both the
+// top-level ToolDef #10.description AND parameter schema `description` keys)
+// for known tool signatures and rejects the whole request with
+// permission_denied: "Unable to process request due to an MCP configuration
+// issue." Live A/B on Cursor's real 21-tool inventory found 8 of 21 tools
+// triggered the gate (AskQuestion, Glob, Grep, Read, ReadLints, Shell,
+// WebFetch, WebSearch). The gate fires on a COMBINATION of top-level
+// description + parameter descriptions — removing either alone is
+// insufficient for most tools.
+//
+// Fix: replace the top-level description with the tool name (the model
+// identifies tools by name, not by description prose) and strip all
+// `description` annotations from the parameter JSON Schema (see
+// stripSchemaDescriptions in normalizeToolSchema). Schema structure (types,
+// required, enums, nested objects, properties named "description") is
+// preserved — only human-readable annotation text is removed.
+//
+// ONLY needed on the native tool-def path (DEVIN_CONNECT_TOOL_DEF_TAGS on).
+// With native OFF (prompt emulation), descriptions ride in prompt text which
+// upstream does not scan — no gate, no neutralization needed.
+
 function encodeToolDef(tool, tags) {
   const fn = tool?.function || {};
   const fields = [];
   if (fn.name) fields.push(writeStringField(tags.name, String(fn.name)));
-  if (fn.description) fields.push(writeStringField(tags.description, capToolDescription(fn.description)));
+  if (fn.description) fields.push(writeStringField(tags.description, String(fn.name || 'tool')));
   if (fn.parameters !== undefined) {
     // SWITCH POINT (see header): string today; writeBytesField if RE/capture proves bytes.
     // Normalize the schema envelope first so a malformed client/MCP schema can't

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -1532,19 +1532,50 @@ export function shouldLiftCallerEnv(modelKey, { emulateTools, env = process.env 
   return true;
 }
 
+// Inject a tool-description preamble into the system prompt of a message
+// list. DEVIN_CONNECT has no proto tool_calling_section slot, so the
+// description-only preamble (buildToolPreambleForProto with
+// nativeStructured:true — descriptions without the text-emulation protocol
+// header) must ride the system prompt to give the model tool-selection
+// context the stripped native #10 ToolDef cannot. If a system message
+// already exists the preamble is prepended (separated by a blank line); if
+// not, a new system message is inserted at the front. The list is not
+// mutated in place — a shallow copy is returned so the caller's `messages`
+// reference stays stable.
+export function injectPreambleIntoSystemPrompt(messages, preamble) {
+  if (!preamble || typeof preamble !== 'string' || !preamble.trim()) return messages;
+  if (!Array.isArray(messages)) return messages;
+  const idx = messages.findIndex(m => m?.role === 'system');
+  if (idx >= 0) {
+    const cur = messages[idx];
+    const curContent = typeof cur.content === 'string' ? cur.content
+      : Array.isArray(cur.content) ? cur.content.filter(p => p?.type === 'text').map(p => p.text || '').join('\n')
+      : '';
+    const merged = curContent && curContent.trim()
+      ? `${preamble.trim()}\n\n${curContent}`
+      : preamble.trim();
+    const out = messages.slice();
+    out[idx] = { ...cur, content: merged };
+    return out;
+  }
+  return [{ role: 'system', content: preamble.trim() }, ...messages];
+}
+
 export function applyToolPreambleBudget(tools, toolChoice, callerEnv = '', opts = {}) {
   const modelKey = opts.modelKey || null;
   const provider = opts.provider || null;
   const route = opts.route || null;
+  const nativeStructured = opts.nativeStructured === true;
   const softBytes = opts.softBytes ?? parseInt(process.env.TOOL_PREAMBLE_SOFT_BYTES || '24000', 10);
   const hardBytes = opts.hardBytes ?? parseInt(process.env.TOOL_PREAMBLE_HARD_BYTES || '48000', 10);
+  const tierOpts = nativeStructured ? { nativeStructured: true } : {};
   const tiers = [
     { tier: 'full', build: buildToolPreambleForProto },
     { tier: 'schema-compact', build: buildSchemaCompactToolPreambleForProto },
     { tier: 'skinny', build: buildSkinnyToolPreambleForProto },
     { tier: 'names-only', build: buildCompactToolPreambleForProto },
   ];
-  const full = tiers[0].build(tools || [], toolChoice, callerEnv, modelKey, provider, route);
+  const full = tiers[0].build(tools || [], toolChoice, callerEnv, modelKey, provider, route, tierOpts);
   if (!full) {
     return { ok: true, preamble: '', fullBytes: 0, finalBytes: 0, compacted: false, tier: 'empty', softBytes, hardBytes };
   }
@@ -1555,7 +1586,7 @@ export function applyToolPreambleBudget(tools, toolChoice, callerEnv = '', opts 
   // names-only and let the hard-cap check decide whether to reject.
   let chosen = { tier: 'full', preamble: full, bytes: fullBytes };
   for (const t of tiers) {
-    const text = t.tier === 'full' ? full : t.build(tools || [], toolChoice, callerEnv, modelKey, provider, route);
+    const text = t.tier === 'full' ? full : t.build(tools || [], toolChoice, callerEnv, modelKey, provider, route, tierOpts);
     const bytes = Buffer.byteLength(text, 'utf8');
     chosen = { tier: t.tier, preamble: text, bytes };
     if (bytes <= softBytes) break;
@@ -2270,7 +2301,14 @@ async function _handleChatCompletionsInner(body, context = {}) {
     // correct. Do NOT enable in production: with unverified inner tags the frame
     // may be misread. Normal path keeps the preamble unless both gates are on.
     const soloProbe = nativeDefsOn && String(process.env.DEVIN_CONNECT_TOOL_DEF_SOLO || '') === '1';
-    const suppressPreamble = soloProbe || (nativeDefsOn && nativeCallsOn);
+    // HYBRID (2026-07-13): keep the prompt preamble ON even when native #10
+    // ToolDef + #6 ChatToolCall are both engaged. The preamble carries full
+    // human-readable tool descriptions (which upstream's MCP-gate does NOT
+    // scan — it only fingerprints the protobuf #10 fields), so the model
+    // keeps its tool-selection context while we still get reliable native
+    // tool-call decode. Only the SOLO calibration probe suppresses the
+    // preamble (it needs #10 to be the ONLY tool signal to verify tags).
+    const suppressPreamble = soloProbe;
     if (soloProbe) log.info(`Chat[${reqId}]: DEVIN_CONNECT TOOL_DEF SOLO probe — preamble suppressed, native #10 is the only tool signal`);
     // Native tool_call observability: surface gate state so a paid probe can
     // confirm the native path actually engaged (flag on + tags resolved) vs
@@ -2295,6 +2333,48 @@ async function _handleChatCompletionsInner(body, context = {}) {
         const neut = neutralizeClientIdentity(m.content);
         return neut === m.content ? m : { ...m, content: neut };
       });
+    }
+    // HYBRID native path: DEVIN_CONNECT has no proto tool_calling_section
+    // slot, so the description-only preamble (buildToolPreambleForProto with
+    // nativeStructured:true) is never built by normalizeMessagesForCascade —
+    // its user-message fallback (buildToolPreamble) returns '' for
+    // nativeStructured. Without this injection the model gets ONLY the
+    // stripped native #10 ToolDef (names + schemas, no descriptions) and
+    // loses tool-selection context. Build the description-only preamble via
+    // applyToolPreambleBudget and inject it into the system prompt so the
+    // model keeps full human-readable tool descriptions (which upstream's
+    // MCP-gate does NOT scan — it only fingerprints the protobuf #10
+    // fields) while still calling tools through the native function-calling
+    // interface. The preamble has NO text-emulation protocol header
+    // (nativeStructured strips it), so there is no conflict with native
+    // #6 ChatToolCall. SOLO probe mode (suppressPreamble) skips this too —
+    // it needs #10 to be the ONLY tool signal.
+    if (nativeStructured && !suppressPreamble && Array.isArray(connectMessages)) {
+      const callerEnv = extractCallerEnvironment(messages);
+      const descBudget = applyToolPreambleBudget(connectTools, tool_choice, callerEnv, {
+        modelKey: reqModelName,
+        provider: null,
+        route: 'devin_connect',
+        nativeStructured: true,
+      });
+      if (!descBudget.ok) {
+        log.warn(`Chat[${reqId}]: DEVIN_CONNECT native desc preamble ${Math.round(descBudget.finalBytes / 1024)}KB exceeds hard cap ${Math.round(descBudget.hardBytes / 1024)}KB after ${descBudget.tier} tier; rejecting (${connectTools.length} tools)`);
+        return {
+          status: 400,
+          body: {
+            error: {
+              message: `Tool definitions are too large (${Math.round(descBudget.finalBytes / 1024)}KB > ${Math.round(descBudget.hardBytes / 1024)}KB after ${descBudget.tier} compaction). Reduce the number of tools or shorten tool names.`,
+              type: 'invalid_request_error',
+              param: 'tools',
+              code: 'tool_preamble_too_large',
+            },
+          },
+        };
+      }
+      if (descBudget.preamble) {
+        connectMessages = injectPreambleIntoSystemPrompt(connectMessages, descBudget.preamble);
+        log.info(`Chat[${reqId}]: DEVIN_CONNECT native desc preamble injected into system prompt (${descBudget.tier} tier, ${Math.round(descBudget.finalBytes / 1024)}KB, ${connectTools.length} tools)`);
+      }
     }
     log.info(`Chat[${reqId}]: DEVIN_CONNECT ${reqModelName} -> selector=${selector}${mapped ? '' : ' [unmapped→free-tier]'} stream=${!!stream}${emulateTools ? ` tools=${connectTools.length}` : ''}`);
     const ccId = genId();

--- a/src/handlers/tool-emulation.js
+++ b/src/handlers/tool-emulation.js
@@ -163,8 +163,15 @@ export function trimToolsForWeakModel(tools, modelKey, opts = {}) {
   return { tools: kept, trimmed: true, kept: kept.length, dropped: tools.length - kept.length };
 }
 
-export function buildToolPreamble(tools, toolChoice = 'auto', modelKey = null, provider = null, route = null) {
+export function buildToolPreamble(tools, toolChoice = 'auto', modelKey = null, provider = null, route = null, opts = {}) {
   if (!Array.isArray(tools) || tools.length === 0) return '';
+  // nativeStructured: when native #10 ToolDef + #6 ChatToolCall are engaged,
+  // this user-message fallback would CONFLICT with the native function-calling
+  // interface (it teaches the model to emit text-format tool calls). Return
+  // empty — the native ToolDef already declares the tools, and the proto-level
+  // buildToolPreambleForProto (with nativeStructured:true) carries the
+  // descriptions without the text-emulation protocol.
+  if (opts.nativeStructured) return '';
   const dialect = pickToolDialect(modelKey, provider, route);
   const names = [];
   for (const t of tools) {
@@ -497,11 +504,19 @@ function resolveToolChoice(tc) {
  * X, not /tmp/windsurf-workspace" in a way that survives Cascade's
  * authoritative workspace prior. (#54 follow-up.)
  */
-export function buildToolPreambleForProto(tools, toolChoice, environment, modelKey = null, provider = null, route = null) {
+export function buildToolPreambleForProto(tools, toolChoice, environment, modelKey = null, provider = null, route = null, opts = {}) {
   if (!Array.isArray(tools) || tools.length === 0) return '';
   const { mode, forceName } = resolveToolChoice(toolChoice);
   const dialect = pickToolDialect(modelKey, provider, route);
-  const protocol = protocolHeaderForTools(dialect, mode, forceName, true);
+  // nativeStructured: when native #10 ToolDef + #6 ChatToolCall are engaged,
+  // the protocol header (which teaches the model to emit text-format tool
+  // calls) would CONFLICT with the native function-calling interface. Skip
+  // it — the native ToolDef already declares the tools as function
+  // definitions, and the model should call them through function-calling,
+  // not text emulation. Only the "Available functions" descriptions stay,
+  // giving the model tool-selection context it can't get from the stripped
+  // #10 description field.
+  const protocol = opts.nativeStructured ? '' : protocolHeaderForTools(dialect, mode, forceName, true);
 
   const lines = [];
   if (environment && typeof environment === 'string' && environment.trim()) {
@@ -514,8 +529,10 @@ export function buildToolPreambleForProto(tools, toolChoice, environment, modelK
     lines.push('');
   }
   lines.push(WORKSPACE_PATH_HINT);
-  lines.push('');
-  lines.push(protocol);
+  if (protocol) {
+    lines.push('');
+    lines.push(protocol);
+  }
   const specificRules = toolSpecificRules(tools);
   if (specificRules.length) {
     lines.push('');
@@ -616,11 +633,11 @@ function paramSignature(parameters) {
  * Schema-compact preamble: same shape as full, but strips schema docs and
  * minifies JSON. Saves ~40-60% with no loss of tool-call correctness.
  */
-export function buildSchemaCompactToolPreambleForProto(tools, toolChoice, environment, modelKey = null, provider = null, route = null) {
+export function buildSchemaCompactToolPreambleForProto(tools, toolChoice, environment, modelKey = null, provider = null, route = null, opts = {}) {
   if (!Array.isArray(tools) || tools.length === 0) return '';
   const { mode, forceName } = resolveToolChoice(toolChoice);
   const dialect = pickToolDialect(modelKey, provider, route);
-  const protocol = protocolHeaderForTools(dialect, mode, forceName, true);
+  const protocol = opts.nativeStructured ? '' : protocolHeaderForTools(dialect, mode, forceName, true);
   const lines = [];
   if (environment && typeof environment === 'string' && environment.trim()) {
     lines.push('## Environment facts');
@@ -632,8 +649,10 @@ export function buildSchemaCompactToolPreambleForProto(tools, toolChoice, enviro
     lines.push('');
   }
   lines.push(WORKSPACE_PATH_HINT);
-  lines.push('');
-  lines.push(protocol);
+  if (protocol) {
+    lines.push('');
+    lines.push(protocol);
+  }
   const specificRules = toolSpecificRules(tools);
   if (specificRules.length) {
     lines.push('');
@@ -661,11 +680,11 @@ export function buildSchemaCompactToolPreambleForProto(tools, toolChoice, enviro
  * stop before names-only — keeps enough for the model to know which
  * params each tool needs without paying the schema serialization cost.
  */
-export function buildSkinnyToolPreambleForProto(tools, toolChoice, environment, modelKey = null, provider = null, route = null) {
+export function buildSkinnyToolPreambleForProto(tools, toolChoice, environment, modelKey = null, provider = null, route = null, opts = {}) {
   if (!Array.isArray(tools) || tools.length === 0) return '';
   const { mode, forceName } = resolveToolChoice(toolChoice);
   const dialect = pickToolDialect(modelKey, provider, route);
-  const protocol = protocolHeaderForTools(dialect, mode, forceName, true);
+  const protocol = opts.nativeStructured ? '' : protocolHeaderForTools(dialect, mode, forceName, true);
   const lines = [];
   if (environment && typeof environment === 'string' && environment.trim()) {
     lines.push('## Environment facts');
@@ -675,8 +694,10 @@ export function buildSkinnyToolPreambleForProto(tools, toolChoice, environment, 
     lines.push('');
   }
   lines.push(WORKSPACE_PATH_HINT);
-  lines.push('');
-  lines.push(protocol);
+  if (protocol) {
+    lines.push('');
+    lines.push(protocol);
+  }
   const specificRules = toolSpecificRules(tools);
   if (specificRules.length) {
     lines.push('');
@@ -710,11 +731,11 @@ export function buildSkinnyToolPreambleForProto(tools, toolChoice, environment, 
  * because the alternative is the request failing with panel_state_missing
  * retries until the proxy gives up.
  */
-export function buildCompactToolPreambleForProto(tools, toolChoice, environment, modelKey = null, provider = null, route = null) {
+export function buildCompactToolPreambleForProto(tools, toolChoice, environment, modelKey = null, provider = null, route = null, opts = {}) {
   if (!Array.isArray(tools) || tools.length === 0) return '';
   const { mode, forceName } = resolveToolChoice(toolChoice);
   const dialect = pickToolDialect(modelKey, provider, route);
-  const protocol = protocolHeaderForTools(dialect, mode, forceName, true);
+  const protocol = opts.nativeStructured ? '' : protocolHeaderForTools(dialect, mode, forceName, true);
   const names = [];
   for (const t of tools) {
     if (t?.type !== 'function' || !t.function?.name) continue;
@@ -733,8 +754,10 @@ export function buildCompactToolPreambleForProto(tools, toolChoice, environment,
     lines.push('');
   }
   lines.push(WORKSPACE_PATH_HINT);
-  lines.push('');
-  lines.push(protocol);
+  if (protocol) {
+    lines.push('');
+    lines.push(protocol);
+  }
   const specificRules = toolSpecificRules(tools);
   if (specificRules.length) {
     lines.push('');
@@ -743,7 +766,9 @@ export function buildCompactToolPreambleForProto(tools, toolChoice, environment,
   }
   lines.push('');
   lines.push(`Available functions: ${names.join(', ')}.`);
-  lines.push('Parameter schemas are omitted in this preamble due to total tool-list size. Match each <tool_call> to the function name; the calling agent will validate argument shapes when it executes the call.');
+  lines.push(opts.nativeStructured
+    ? 'Parameter schemas are omitted in this preamble due to total tool-list size; the calling agent validates argument shapes when it executes the call.'
+    : 'Parameter schemas are omitted in this preamble due to total tool-list size. Match each <tool_call> to the function name; the calling agent will validate argument shapes when it executes the call.');
   return lines.join('\n');
 }
 
@@ -982,7 +1007,7 @@ export function normalizeMessagesForCascade(messages, tools, options = {}) {
   // confused prose with zero tool_calls and hit max_wait. Skipping the
   // preamble on tool_result turns lets Opus stay in tool-using mode for
   // the full conversation, matching native-Anthropic-API behaviour.
-  const preamble = buildToolPreamble(tools, toolChoice, modelKey, provider, route);
+  const preamble = buildToolPreamble(tools, toolChoice, modelKey, provider, route, { nativeStructured: options.nativeStructured === true });
   if (preamble && injectUserPreamble) {
     for (let i = out.length - 1; i >= 0; i--) {
       if (out[i].role !== 'user') continue;

--- a/test/devin-connect.test.js
+++ b/test/devin-connect.test.js
@@ -152,11 +152,11 @@ describe('buildGetChatMessageRequest', () => {
     assert.equal(getField(parseFields(proto), 2, 2).value.toString('utf8'), 'be nice');
   });
 
-  // ★ 2026-07-10: tool-description length cap. Verified live — a Claude-family
-  // native request with a very long tool description (Claude Code's TaskOutput,
-  // 1080 chars) returns upstream "internal error"; capped it passes. We truncate
-  // the description (a model hint) without touching name/schema.
-  it('caps a very long tool description in the encoded #10 ToolDef', () => {
+  // ★ 2026-07-13: native ToolDef descriptions are replaced with the tool name.
+  // Live A/B against Cursor's real 21-tool inventory proved upstream fingerprints
+  // both top-level and parameter descriptions as an "MCP configuration issue".
+  // Name, schema structure, types, required fields and enums remain native.
+  it('replaces a very long tool description with the name in #10 ToolDef', () => {
     const longDesc = 'x'.repeat(1200);
     const proto = buildGetChatMessageRequest({
       token: TOKEN, model: 'claude-opus-4-8-medium',
@@ -169,12 +169,12 @@ describe('buildGetChatMessageRequest', () => {
     assert.ok(td, 'has #10 ToolDef');
     const inner = parseFields(td.value);
     const desc = getField(inner, 2, 2).value.toString('utf8');
-    assert.ok(desc.length <= 500, `description capped to <=500 (got ${desc.length})`);
+    assert.equal(desc, 'edit');
     // name (#1) still intact
     assert.equal(getField(inner, 1, 2).value.toString('utf8'), 'edit');
   });
 
-  it('leaves a short tool description untouched', () => {
+  it('replaces a short tool description with the name', () => {
     const proto = buildGetChatMessageRequest({
       token: TOKEN, model: 'claude-opus-4-8-medium',
       messages: [{ role: 'system', content: 'sys' }, { role: 'user', content: 'hi' }],
@@ -182,7 +182,7 @@ describe('buildGetChatMessageRequest', () => {
       nativeToolCall: true,
     });
     const inner = parseFields(getField(parseFields(proto), 10, 2).value);
-    assert.equal(getField(inner, 2, 2).value.toString('utf8'), 'edit a file');
+    assert.equal(getField(inner, 2, 2).value.toString('utf8'), 'edit');
   });
 
   it('embeds the SINGLE token in ClientMetadata #3 (header doubling is separate)', () => {
@@ -1011,7 +1011,7 @@ describe('native tool defs in the request (gated)', () => {
       assert.equal(toolFields.length, 1, 'one ToolDef emitted at #10');
       const td = parseFields(toolFields[0].value);
       assert.equal(getField(td, 1, 2).value.toString('utf8'), 'get_weather');
-      assert.equal(getField(td, 2, 2).value.toString('utf8'), 'Get weather');
+      assert.equal(getField(td, 2, 2).value.toString('utf8'), 'get_weather');
       assert.deepEqual(JSON.parse(getField(td, 3, 2).value.toString('utf8')), TOOLS[0].function.parameters);
     } finally {
       if (prev === undefined) delete process.env.DEVIN_CONNECT_TOOL_DEF_TAGS;
@@ -1634,16 +1634,156 @@ describe('normalizeToolSchema', () => {
     assert.equal(normalizeToolSchema({ type: 'object', properties: {}, required: 'a' }).required, undefined);
     assert.equal(normalizeToolSchema({ type: 'object', properties: { a: {} }, required: ['ghost'] }).required, undefined);
   });
-  it('preserves real schema content (properties, descriptions, nested)', () => {
-    const src = { type: 'object', properties: { path: { type: 'string', description: 'file path' }, n: { type: 'integer' } }, required: ['path'] };
+  it('strips schema annotations but preserves structure and a parameter named description', () => {
+    const src = {
+      type: 'object',
+      description: 'root hint',
+      properties: {
+        path: { type: 'string', description: 'file path' },
+        description: { type: 'string', description: 'parameter hint' },
+        nested: { type: 'object', description: 'nested hint', properties: { value: { type: 'integer', description: 'value hint' } } },
+      },
+      required: ['path', 'description'],
+    };
     const r = normalizeToolSchema(src);
-    assert.deepEqual(r.properties, src.properties);
-    assert.deepEqual(r.required, ['path']);
+    assert.deepEqual(r, {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        description: { type: 'string' },
+        nested: { type: 'object', properties: { value: { type: 'integer' } } },
+      },
+      required: ['path', 'description'],
+    });
   });
   it('does not mutate the caller object', () => {
     const src = { $schema: 'x', type: 'string', properties: {} };
     normalizeToolSchema(src);
     assert.equal(src.$schema, 'x');
     assert.equal(src.type, 'string');
+  });
+  it('strips description from oneOf/anyOf/allOf nested schemas', () => {
+    const src = {
+      type: 'object',
+      properties: {
+        mode: {
+          oneOf: [
+            { type: 'string', description: 'string mode' },
+            { type: 'object', description: 'object mode', properties: { value: { type: 'string', description: 'inner' } } },
+          ],
+        },
+        filter: {
+          anyOf: [
+            { type: 'string', description: 'filter by name' },
+            { type: 'integer', description: 'filter by id' },
+          ],
+        },
+        combine: {
+          allOf: [
+            { type: 'string', description: 'part a' },
+            { type: 'string', enum: ['x', 'y'], description: 'part b' },
+          ],
+        },
+      },
+    };
+    const r = normalizeToolSchema(src);
+    // oneOf: descriptions stripped, structure preserved
+    assert.equal(r.properties.mode.oneOf[0].description, undefined);
+    assert.equal(r.properties.mode.oneOf[1].description, undefined);
+    assert.equal(r.properties.mode.oneOf[1].properties.value.type, 'string');
+    assert.equal(r.properties.mode.oneOf[1].properties.value.description, undefined);
+    // anyOf: descriptions stripped
+    assert.equal(r.properties.filter.anyOf[0].description, undefined);
+    assert.equal(r.properties.filter.anyOf[1].description, undefined);
+    // allOf: descriptions stripped, enum preserved
+    assert.equal(r.properties.combine.allOf[0].description, undefined);
+    assert.equal(r.properties.combine.allOf[1].description, undefined);
+    assert.deepEqual(r.properties.combine.allOf[1].enum, ['x', 'y']);
+  });
+  it('strips description from array items and additionalProperties schemas', () => {
+    const src = {
+      type: 'object',
+      properties: {
+        files: {
+          type: 'array',
+          description: 'list of files',
+          items: { type: 'string', description: 'a file path' },
+        },
+        meta: {
+          type: 'object',
+          description: 'metadata bag',
+          additionalProperties: { type: 'string', description: 'any string value' },
+        },
+      },
+    };
+    const r = normalizeToolSchema(src);
+    assert.equal(r.properties.files.description, undefined);
+    assert.equal(r.properties.files.type, 'array');
+    assert.equal(r.properties.files.items.type, 'string');
+    assert.equal(r.properties.files.items.description, undefined);
+    assert.equal(r.properties.meta.description, undefined);
+    assert.equal(r.properties.meta.additionalProperties.type, 'string');
+    assert.equal(r.properties.meta.additionalProperties.description, undefined);
+  });
+  it('preserves const, format, and enum while stripping description annotations', () => {
+    const src = {
+      type: 'object',
+      properties: {
+        kind: { type: 'string', const: 'fixed', description: 'the kind' },
+        date: { type: 'string', format: 'date-time', description: 'when' },
+        level: { type: 'string', enum: ['low', 'high'], description: 'severity' },
+        withDefault: { type: 'string', default: 'auto', description: 'default val', examples: ['auto', 'manual'] },
+      },
+    };
+    const r = normalizeToolSchema(src);
+    assert.equal(r.properties.kind.const, 'fixed');
+    assert.equal(r.properties.kind.description, undefined);
+    assert.equal(r.properties.date.format, 'date-time');
+    assert.equal(r.properties.date.description, undefined);
+    assert.deepEqual(r.properties.level.enum, ['low', 'high']);
+    assert.equal(r.properties.level.description, undefined);
+    // default and examples are NOT description annotations → preserved
+    assert.equal(r.properties.withDefault.default, 'auto');
+    assert.deepEqual(r.properties.withDefault.examples, ['auto', 'manual']);
+    assert.equal(r.properties.withDefault.description, undefined);
+    assert.equal(r.properties.withDefault.type, 'string');
+  });
+  it('handles deeply nested objects (5 levels) without losing structure', () => {
+    const src = {
+      type: 'object',
+      properties: {
+        a: { type: 'object', description: 'a', properties: { b: { type: 'object', description: 'b', properties: { c: { type: 'object', description: 'c', properties: { d: { type: 'object', description: 'd', properties: { e: { type: 'string', description: 'e' } } } } } } } } },
+      },
+    };
+    const r = normalizeToolSchema(src);
+    const a = r.properties.a;
+    assert.equal(a.description, undefined);
+    assert.equal(a.type, 'object');
+    const b = a.properties.b;
+    assert.equal(b.description, undefined);
+    const c = b.properties.c;
+    assert.equal(c.description, undefined);
+    const d = c.properties.d;
+    assert.equal(d.description, undefined);
+    const e = d.properties.e;
+    assert.equal(e.type, 'string');
+    assert.equal(e.description, undefined);
+  });
+  it('preserves a parameter named "description" with its type and enum', () => {
+    // Regression guard: the MCP-gate fix strips description ANNOTATIONS, not
+    // parameters that happen to be named "description".
+    const src = {
+      type: 'object',
+      properties: {
+        description: { type: 'string', description: 'a human-readable description', enum: ['short', 'long'] },
+      },
+      required: ['description'],
+    };
+    const r = normalizeToolSchema(src);
+    assert.ok(r.properties.description, 'parameter named "description" must survive');
+    assert.equal(r.properties.description.type, 'string');
+    assert.deepEqual(r.properties.description.enum, ['short', 'long']);
+    assert.equal(r.properties.description.description, undefined, 'annotation stripped');
+    assert.deepEqual(r.required, ['description']);
   });
 });

--- a/test/tool-preamble-budget.test.js
+++ b/test/tool-preamble-budget.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { applyToolPreambleBudget } from '../src/handlers/chat.js';
+import { applyToolPreambleBudget, injectPreambleIntoSystemPrompt } from '../src/handlers/chat.js';
 
 function makeTools(count, propCount = 18) {
   return Array.from({ length: count }, (_, i) => ({
@@ -120,4 +120,104 @@ test('schema-compact tier strips per-field description bloat but keeps types and
   assert.notEqual(r.tier, 'full');
   assert.ok(r.finalBytes < fullBytes, 'compacted tier must be smaller than full');
   assert.ok(r.preamble.includes('file_path'), 'all non-empty tiers keep param names somewhere');
+});
+
+// ─── nativeStructured (hybrid mode) regression tests ─────────────────────────
+// The DEVIN_CONNECT native path (nativeToolCall flag + both gates on) has no
+// proto tool_calling_section slot, so the description-only preamble must be
+// built via applyToolPreambleBudget({nativeStructured:true}) and injected into
+// the system prompt. These tests pin the contract:
+//   1. The preamble carries "Available functions" with full descriptions.
+//   2. The preamble has NO text-emulation protocol header (no <tool_call> format
+//      instructions) — that would conflict with native #6 ChatToolCall.
+//   3. All four budget tiers preserve tool names and never emit the protocol.
+//   4. injectPreambleIntoSystemPrompt prepends to an existing system message,
+//      creates one if absent, and never mutates the caller's array.
+
+const PROTOCOL_RE = /emit this EXACT format|To invoke|tool_calls_section_begin|To call one, emit/i;
+
+test('nativeStructured: full preamble has descriptions but no text-emulation protocol header', () => {
+  const tools = makeTools(3, 2);
+  const r = applyToolPreambleBudget(tools, 'auto', '', { nativeStructured: true, softBytes: 100_000, hardBytes: 100_000 });
+  assert.equal(r.ok, true);
+  assert.equal(r.tier, 'full');
+  assert.ok(r.preamble.includes('Available functions'), 'must list available functions');
+  assert.ok(r.preamble.includes('mcp_tool_0'), 'must include tool names');
+  assert.ok(r.preamble.includes('Verbose MCP tool 0'), 'must include full descriptions');
+  assert.doesNotMatch(r.preamble, PROTOCOL_RE, 'must NOT contain text-emulation protocol header');
+});
+
+test('nativeStructured: all four budget tiers keep names and never emit the protocol header', () => {
+  const tools = makeTools(8, 6);
+  for (const softBytes of [100_000, 10_000, 2_000, 500]) {
+    const r = applyToolPreambleBudget(tools, 'auto', '', { nativeStructured: true, softBytes, hardBytes: 200_000 });
+    assert.equal(r.ok, true, `tier at softBytes=${softBytes} should be ok`);
+    if (!r.preamble) continue; // empty tier (no tools) is fine
+    assert.ok(r.preamble.includes('mcp_tool_7'), `tier ${r.tier} must keep all tool names (softBytes=${softBytes})`);
+    assert.doesNotMatch(r.preamble, PROTOCOL_RE, `tier ${r.tier} must NOT emit protocol header (softBytes=${softBytes})`);
+  }
+});
+
+test('nativeStructured: preamble is non-empty (unlike the user-message fallback which returns "")', () => {
+  // The user-message fallback (buildToolPreamble) returns '' for nativeStructured.
+  // applyToolPreambleBudget must NOT — it builds the proto-level description block.
+  const tools = makeTools(2, 1);
+  const r = applyToolPreambleBudget(tools, 'auto', '', { nativeStructured: true });
+  assert.equal(r.ok, true);
+  assert.ok(r.preamble.length > 0, 'nativeStructured preamble must be non-empty (descriptions ride the system prompt)');
+  assert.ok(r.preamble.includes('Available functions'));
+});
+
+test('nativeStructured: tool_choice none/required/forced do not inject protocol header', () => {
+  const tools = makeTools(2, 1);
+  for (const tc of ['auto', 'none', 'required', { type: 'function', function: { name: 'mcp_tool_0' } }]) {
+    const r = applyToolPreambleBudget(tools, tc, '', { nativeStructured: true, softBytes: 100_000, hardBytes: 100_000 });
+    assert.equal(r.ok, true);
+    assert.doesNotMatch(r.preamble, PROTOCOL_RE, `tool_choice=${JSON.stringify(tc)} must not add protocol header`);
+  }
+});
+
+test('injectPreambleIntoSystemPrompt: prepends to existing system message without mutation', () => {
+  const messages = [
+    { role: 'system', content: 'You are helpful.' },
+    { role: 'user', content: 'hi' },
+  ];
+  const preamble = 'Available functions:\n\n### Read\nRead a file.';
+  const out = injectPreambleIntoSystemPrompt(messages, preamble);
+  assert.equal(out.length, 2);
+  assert.equal(out[0].role, 'system');
+  assert.ok(out[0].content.startsWith('Available functions'));
+  assert.ok(out[0].content.includes('You are helpful.'), 'original system content preserved');
+  assert.equal(out[1].content, 'hi', 'user message untouched');
+  // Caller's array not mutated:
+  assert.equal(messages[0].content, 'You are helpful.');
+});
+
+test('injectPreambleIntoSystemPrompt: creates a system message when none exists', () => {
+  const messages = [{ role: 'user', content: 'hi' }];
+  const preamble = 'Available functions:\n\n### Read\nRead a file.';
+  const out = injectPreambleIntoSystemPrompt(messages, preamble);
+  assert.equal(out.length, 2);
+  assert.equal(out[0].role, 'system');
+  assert.ok(out[0].content.includes('Available functions'));
+  assert.equal(out[1].content, 'hi');
+});
+
+test('injectPreambleIntoSystemPrompt: empty/null preamble is a no-op', () => {
+  const messages = [{ role: 'system', content: 'orig' }];
+  assert.strictEqual(injectPreambleIntoSystemPrompt(messages, ''), messages);
+  assert.strictEqual(injectPreambleIntoSystemPrompt(messages, null), messages);
+  assert.strictEqual(injectPreambleIntoSystemPrompt(messages, '   '), messages);
+});
+
+test('injectPreambleIntoSystemPrompt: handles array-content system messages', () => {
+  const messages = [
+    { role: 'system', content: [{ type: 'text', text: 'System prompt part.' }] },
+    { role: 'user', content: 'hi' },
+  ];
+  const preamble = 'Available functions:\n\n### Read\nRead a file.';
+  const out = injectPreambleIntoSystemPrompt(messages, preamble);
+  assert.equal(out[0].role, 'system');
+  assert.ok(out[0].content.startsWith('Available functions'));
+  assert.ok(out[0].content.includes('System prompt part.'));
 });


### PR DESCRIPTION
<!-- 感谢贡献 / Thanks for contributing -->

## 改了什么 / What changed

两个耦合修复，解决 DEVIN_CONNECT 原生工具路径上的 MCP-gate 拦截和模型零工具描述问题。

涉及 3 个源文件 + 2 个测试文件：
- `src/devin-connect.js` — MCP-gate neutralization：`encodeToolDef()` 用工具名替换描述；新增 `stripSchemaDescriptions()` 递归剥离 schema annotations
- `src/handlers/tool-emulation.js` — `buildToolPreambleForProto` 和全部 4 个 budget tier 新增 `opts.nativeStructured` 参数；`nativeStructured=true` 时跳过 protocol header
- `src/handlers/chat.js` — 新增 `injectPreambleIntoSystemPrompt()` helper；在 `_handleChatCompletionsInner` 的 DEVIN_CONNECT native path 注入 description-only preamble 到 system prompt
- `test/devin-connect.test.js` — 新增 5 个 schema edge-case 回归测试
- `test/tool-preamble-budget.test.js` — 新增 8 个 nativeStructured 回归测试

## 为什么 / Why

关联 issue：#213（MCP-gate）、#214（native path 零描述）

### 修复 1：MCP-gate neutralization（#213）

**问题：** Upstream `server.codeium.com` 对工具描述做**指纹匹配**，扫描 `#10.description` 顶层字段 + 参数 JSON Schema `description` annotations。gate 在**组合**上触发——只删一个不够。Cursor 21 个工具中 8 个被 `permission_denied` 拦截（`AskQuestion`, `Glob`, `Grep`, `Read`, `ReadLints`, `Shell`, `WebFetch`, `WebSearch`）。

**为什么是"替换为工具名 + 剥离 schema annotations"：**

| 方案 | 结果 |
|---|---|
| `capToolDescription` 截断到 500 字符 | ❌ gate 是指纹匹配不是长度检查——截断后仍匹配 |
| 只删顶层 description，保留参数 description | ❌ 8 个中 6 个仍被拦截 |
| 只删参数 description，保留顶层 | ❌ 8 个中 5 个仍被拦截 |
| **替换顶层为工具名 + 剥离参数 description** | ✅ 21/21 全部通过 |

模型通过**名字**识别工具，不需要描述 prose。`stripSchemaDescriptions` 通过 `inProperties` flag 区分 annotation vs 参数名——保留命名为 `description` 的参数（如 Cursor Task 工具），只剥离 annotation text。Schema 结构（types, required, enums, nested objects, `const`, `format`, `default`, `examples`）全部保留。

`capToolDescription` / `WINDSURFAPI_TOOL_DESC_MAX` 保留为 escape hatch——如果未来 upstream 重新引入纯长度阈值可以重新启用。

### 修复 2：native-aware tool preamble（#214）

**问题：** MCP-gate fix 将 `#10.description` 替换为工具名后，原生路径上模型**完全失去工具描述**。三个因素叠加：
1. `#10` description 被替换为工具名 → proto 层不携带描述
2. user-message fallback 在 `nativeStructured=true` 时返回 `''`（正确——避免 protocol header）→ 没有描述到达模型
3. DEVIN_CONNECT 没有 proto `tool_calling_section` slot → 描述必须走 system prompt

结果：模型只有工具名 + stripped schema，零工具选择上下文 → 空回复 / 调错工具 / 不调工具（对应 #178, #177, #172, #210 等用户报告）。

**为什么需要三部分一起改：**

| 部分 | 作用 | 不做的后果 |
|---|---|---|
| 剥离 protocol header from all tiers | 避免 text-emulation 与 native function-calling 冲突 | 模型输出 text-format `tool_calls_section_begin` 而不是用 function-calling → 零工具执行 |
| `buildToolPreamble` 返回 `''` for nativeStructured | 避免 user-message 重复信号 | user message 携带 protocol header → 同上冲突 |
| 注入 description-only preamble 到 system prompt | 给模型工具选择上下文 | 模型零描述 → 空回复 / 调错工具 |

**为什么注入 system prompt 而不是 user message：**
1. user-message injection 在 tool_result turns 上被跳过 → 多轮对话第二轮起失去描述
2. system prompt 是模型的持久上下文，多轮全程保留
3. MCP-gate 不扫描 system prompt（只指纹匹配 `#10` protobuf 字段）→ 描述安全
4. 不硬编码新 preamble 字符串——复用现有 4-tier budget 系统，soft/hard cap compaction 自动工作

**`suppressPreamble` 逻辑变化：**
原：`suppressPreamble = soloProbe || (nativeDefsOn && nativeCallsOn)`
新：`suppressPreamble = soloProbe`

hybrid 模式下 preamble 保持开启——它携带的描述是 MCP-gate fix 后模型唯一的工具选择上下文。只有 SOLO calibration probe（`DEVIN_CONNECT_TOOL_DEF_SOLO=1`）需要 suppress。

## 测试 / Testing

```bash
# 完整测试套件
npm test
# → 2652 pass / 0 fail / exit 0

# 新增 13 个回归测试
node --test test/devin-connect.test.js test/tool-preamble-budget.test.js
# → 158 pass / 0 fail

# 覆盖：
# Schema edge-cases (5): oneOf/anyOf/allOf 嵌套、array items、const/format/enum、
#   5 层深度嵌套、参数名为 "description"
# nativeStructured preamble (8): full preamble 有描述无 protocol、4 tier 都不 emit
#   protocol、preamble 非空、tool_choice 变体、injectPreambleIntoSystemPrompt 4 case

# Live-canary 验证（with proxy, real upstream）
# #1: Cursor 21-tool / GLM-5.2 → HTTP 200, tool_call: Ls({path:"."})
# #2: Multi-turn (tool_result → continuation) → HTTP 200, formatted response
# #3: Replay 32-turn/21-tool trace (135KB, 25K tokens) → HTTP 200, tool_call
# 日志：native desc preamble injected into system prompt (schema-compact, 6KB, 21 tools)
```

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies (project is zero-dep)
- [x] 涉及 LS binary 协议改动时 在 PR 描述里注明字段号来源 / If touching LS protocol, document field-number source in the PR description
  — 本 PR 修改 `encodeToolDef` 对 `#10.description` 的写入方式（值从完整描述改为工具名），字段号来源不变：`DEVIN_CONNECT_TOOL_DEF_TAGS` env 配置的 `description` tag（默认 `2`，来自 live wire capture）。不涉及 `windsurf.js` / `proto.js` 的 LS binary field-number 变更
- [x] 涉及 dashboard UI 用 App.confirm / App.prompt 不用浏览器原生 alert/confirm / Uses App.confirm / App.prompt, not native dialogs (if dashboard)
  — N/A：本 PR 不涉及 dashboard UI 改动