### PR TITLE
fix(responses):fix(responses): support responses-lite additional_tools support responses-lite additional_tools

### DIFF
--- a/src/handlers/responses.js
+++ b/src/handlers/responses.js
@@ -206,7 +206,39 @@ function flattenResponseTool(tool, inheritedNamespace = '') {
 
 function flattenResponseTools(tools = []) {
   if (!Array.isArray(tools)) return [];
-  return tools.flatMap(tool => flattenResponseTool(tool));
+  const flattened = tools.flatMap(tool => flattenResponseTool(tool));
+  const unique = [];
+  const seen = new Map();
+  for (const tool of flattened) {
+    const name = tool.function?.name || tool.name || '';
+    const serialized = JSON.stringify(tool);
+    if (seen.has(name)) {
+      if (seen.get(name) !== serialized) throw new Error(`Ambiguous Responses tool name after flattening: ${name}`);
+      continue;
+    }
+    seen.set(name, serialized);
+    unique.push(tool);
+  }
+  return unique;
+}
+
+function responseLiteClientTool(tool) {
+  if (!tool || typeof tool !== 'object') return null;
+  if (tool.type === 'function' || tool.type === 'custom') return tool;
+  if (tool.type !== 'namespace') return null;
+  const childKey = ['tools', 'children', 'functions', 'items'].find(key => Array.isArray(tool[key]));
+  const children = childKey ? tool[childKey].map(responseLiteClientTool).filter(Boolean) : [];
+  return { ...tool, [childKey || 'tools']: children };
+}
+
+function collectResponseTools(body) {
+  const tools = Array.isArray(body?.tools) ? [...body.tools] : [];
+  if (!Array.isArray(body?.input)) return tools;
+  for (const item of body.input) {
+    if (item?.type !== 'additional_tools' || !Array.isArray(item.tools)) continue;
+    tools.push(...item.tools.map(responseLiteClientTool).filter(Boolean));
+  }
+  return tools;
 }
 
 function responseItemToolName(item) {
@@ -217,11 +249,11 @@ function normalizeResponseToolChoice(toolChoice) {
   if (toolChoice === 'auto' || toolChoice === 'required' || toolChoice === 'none') return toolChoice;
   if (typeof toolChoice !== 'object') return toolChoice;
   if (toolChoice.type === 'web_search' || toolChoice.type === 'tool_search') return 'auto';
-  if (toolChoice.type === 'function' && toolChoice.function?.name) {
+  if (toolChoice.type === 'function' && (toolChoice.function?.name || toolChoice.name)) {
     return {
       type: 'function',
       function: {
-        name: encodeToolName(toolChoice.function.name, toolChoice.function.namespace || toolChoice.namespace || ''),
+        name: encodeToolName(toolChoice.function?.name || toolChoice.name, toolChoice.function?.namespace || toolChoice.namespace || ''),
       },
     };
   }
@@ -300,7 +332,7 @@ export function responsesToChat(body) {
           id: item.call_id || item.id || `call_${randomUUID().slice(0, 8)}`,
           type: 'function',
           function: {
-            name: item.name || item.function?.name || 'unknown',
+            name: responseItemToolName(item),
             arguments: stringifyMaybe(item.arguments ?? item.function?.arguments ?? ''),
           },
         });
@@ -341,6 +373,7 @@ export function responsesToChat(body) {
         flushToolCalls.add({
           id: item.call_id || item.id,
           name: item.name,
+          namespace: item.namespace,
           arguments: JSON.stringify({ input: stringifyMaybe(item.input) }),
         });
       } else if (item.type === 'custom_tool_call_output') {
@@ -355,7 +388,7 @@ export function responsesToChat(body) {
     flushToolCalls.flush();
   }
 
-  const tools = flattenResponseTools(body.tools || []);
+  const tools = flattenResponseTools(collectResponseTools(body));
   const responseFormat = normalizeResponseTextFormat(body.text?.format);
   const forwardedToolChoice = body.tool_choice != null
     ? pruneResponseToolChoice(body.tool_choice, tools)

--- a/test/responses.test.js
+++ b/test/responses.test.js
@@ -139,6 +139,98 @@ describe('responsesToChat', () => {
     });
   });
 
+  it('collects Responses Lite additional_tools without creating a message', () => {
+    const out = responsesToChat({
+      input: [
+        {
+          type: 'additional_tools',
+          role: 'developer',
+          tools: [
+            { type: 'custom', name: 'exec', description: 'Run code.' },
+            { type: 'function', name: 'wait', parameters: { type: 'object', properties: { id: { type: 'string' } } } },
+            { type: 'tool_search', description: 'Deferred tool discovery is not bridged by this adapter.' },
+            {
+              type: 'namespace',
+              name: 'mcp__amazon_ads',
+              tools: [
+                { type: 'function', name: 'query_campaigns', parameters: { type: 'object', properties: { days: { type: 'integer' } } } },
+              ],
+            },
+          ],
+        },
+        { type: 'message', role: 'user', content: 'Run it' },
+      ],
+      tools: [
+        { type: 'function', name: 'top_level', parameters: { type: 'object', properties: {} } },
+      ],
+    });
+    assert.deepEqual(out.messages, [{ role: 'user', content: 'Run it' }]);
+    assert.deepEqual(out.tools.map(tool => tool.function.name), [
+      'top_level',
+      'exec',
+      'wait',
+      'mcp__amazon_ads__query_campaigns',
+    ]);
+    assert.deepEqual(out.tools[1].__response_tool, { type: 'custom', namespace: '', originalName: 'exec' });
+    assert.deepEqual(out.tools[3].__response_tool, { type: 'namespace', namespace: 'mcp__amazon_ads', originalName: 'query_campaigns' });
+  });
+
+  it('deduplicates the same tool mirrored across top-level and additional_tools', () => {
+    const tool = { type: 'function', name: 'wait', parameters: { type: 'object', properties: { id: { type: 'string' } } } };
+    const out = responsesToChat({
+      tools: [tool],
+      input: [{ type: 'additional_tools', tools: [{ ...tool }] }],
+    });
+    assert.deepEqual(out.tools.map(entry => entry.function.name), ['wait']);
+  });
+
+  it('fails closed when flattened Responses tool names collide', () => {
+    assert.throws(() => responsesToChat({
+      tools: [{ type: 'function', name: 'mcp__ads__query', parameters: { type: 'object', properties: {} } }],
+      input: [{
+        type: 'additional_tools',
+        tools: [{
+          type: 'namespace',
+          name: 'mcp__ads',
+          tools: [{ type: 'function', name: 'query', parameters: { type: 'object', properties: { days: { type: 'integer' } } } }],
+        }],
+      }],
+    }), /ambiguous Responses tool name/i);
+  });
+
+  it('normalizes a flat namespaced function tool_choice from Responses Lite', () => {
+    const out = responsesToChat({
+      input: [{
+        type: 'additional_tools',
+        tools: [{
+          type: 'namespace',
+          name: 'mcp__amazon_ads',
+          tools: [{ type: 'function', name: 'query_campaigns', parameters: { type: 'object', properties: {} } }],
+        }],
+      }],
+      tool_choice: { type: 'function', name: 'query_campaigns', namespace: 'mcp__amazon_ads' },
+    });
+    assert.deepEqual(out.tool_choice, {
+      type: 'function',
+      function: { name: 'mcp__amazon_ads__query_campaigns' },
+    });
+  });
+
+  it('encodes namespace metadata on function and custom history items', () => {
+    const out = responsesToChat({
+      input: [
+        { type: 'function_call', call_id: 'call_function', name: 'query_campaigns', namespace: 'mcp__amazon_ads', arguments: '{"days":7}' },
+        { type: 'function_call_output', call_id: 'call_function', output: 'ok' },
+        { type: 'custom_tool_call', call_id: 'call_custom', name: 'raw_query', namespace: 'mcp__amazon_ads', input: 'SELECT 1' },
+        { type: 'custom_tool_call_output', call_id: 'call_custom', output: 'done' },
+      ],
+    });
+    assert.equal(out.messages[0].tool_calls[0].function.name, 'mcp__amazon_ads__query_campaigns');
+    assert.equal(out.messages[2].tool_calls[0].function.name, 'mcp__amazon_ads__raw_query');
+    assert.deepEqual(out.messages[1], { role: 'tool', tool_call_id: 'call_function', content: 'ok' });
+    assert.deepEqual(out.messages[3], { role: 'tool', tool_call_id: 'call_custom', content: 'done' });
+  });
+
   it('maps function_call and function_call_output items to chat tool turns', () => {
     const out = responsesToChat({
       input: [
@@ -287,6 +379,62 @@ describe('chatToResponse', () => {
     assert.equal(response.output[2].type, 'function_call');
     assert.equal(response.output[2].name, 'read_file');
     assert.equal(response.output[2].namespace, 'mcp__desktop_commander');
+  });
+
+  it('round-trips Responses Lite additional_tools metadata', async () => {
+    const result = await handleResponses({
+      model: 'claude-sonnet-4.6',
+      input: [
+        {
+          type: 'additional_tools',
+          tools: [
+            { type: 'custom', name: 'exec', description: 'Run code.' },
+            {
+              type: 'namespace',
+              name: 'mcp__amazon_ads',
+              tools: [{ type: 'function', name: 'query_campaigns', parameters: { type: 'object', properties: {} } }],
+            },
+          ],
+        },
+        { type: 'message', role: 'user', content: 'Run it' },
+      ],
+      tool_choice: { type: 'function', name: 'query_campaigns', namespace: 'mcp__amazon_ads' },
+    }, {
+      async handleChatCompletions(body) {
+        assert.deepEqual(body.messages, [{ role: 'user', content: 'Run it' }]);
+        assert.deepEqual(body.tools.map(tool => tool.function.name), ['exec', 'mcp__amazon_ads__query_campaigns']);
+        assert.deepEqual(body.tool_choice, {
+          type: 'function',
+          function: { name: 'mcp__amazon_ads__query_campaigns' },
+        });
+        return {
+          status: 200,
+          body: {
+            created: 123,
+            model: body.model,
+            choices: [{
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  { id: 'call_exec', type: 'function', function: { name: 'exec', arguments: '{"input":"echo hi"}' } },
+                  { id: 'call_query', type: 'function', function: { name: 'mcp__amazon_ads__query_campaigns', arguments: '{"days":7}' } },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            }],
+          },
+        };
+      },
+    });
+    assert.equal(result.status, 200);
+    assert.equal(result.body.output[0].type, 'custom_tool_call');
+    assert.equal(result.body.output[0].name, 'exec');
+    assert.equal(result.body.output[0].input, 'echo hi');
+    assert.equal(result.body.output[1].type, 'function_call');
+    assert.equal(result.body.output[1].name, 'query_campaigns');
+    assert.equal(result.body.output[1].namespace, 'mcp__amazon_ads');
   });
 
   it('maps non-stream reasoning_content to a reasoning output item', () => {


### PR DESCRIPTION
## 改了什么 / What changed

- 从 Responses Lite `input[].additional_tools` 收集客户端可执行的 function、custom 和 namespace 工具
- 复用现有 Responses 工具扁平化及元数据恢复逻辑
- 支持扁平的 namespaced function `tool_choice`
- 保留 function/custom 历史调用中的 namespace
- 对顶层与 additional_tools 中的相同定义去重
- 对映射到同一扁平名称的不同工具定义返回 400，避免路由到错误工具
- 不处理尚未实现完整生命周期的 deferred `tool_search`

## 为什么 / Why

新版 Codex Responses Lite 会将客户端工具放在：

`input[].type = "additional_tools"`

同时保持顶层 `tools` 为空。

当前实现只读取 `body.tools`，因此 function/custom/namespace 工具会被静默丢弃，模型收到的工具列表为空，表现为无法执行本地工具。

本补丁仅桥接请求中已直接提供的客户端工具，不宣称支持完整的 deferred tool discovery 生命周期。

Related to #178.

## 测试 / Testing

- Responses 专项：32/32
- Responses、Messages、Gemini、Cline、stream-error：207/207
- Release gate：76/76
- 全量：2751/2752
  - 唯一失败是环境相关的既有代理 DNS 用例：本机 DNS 将 `does-not-exist.invalid` 解析到 `198.18.1.87`，触发正确的 `ERR_PROXY_PRIVATE_IP`
  - 本补丁仅修改 `src/handlers/responses.js` 和 `test/responses.test.js`

## Checklist

- [x] 代码风格与现有文件一致
- [x] 没有引入 npm 依赖
- [x] 添加了请求转换、历史调用、tool_choice、去重和冲突回归测试