### PR TITLE
fix(devin-connect,chat): honor the 429 reset window on the streaming path — propagate resetMs + cool account-wide

### DIFF
--- a/src/devin-connect.js
+++ b/src/devin-connect.js
@@ -1831,8 +1831,17 @@ export async function* streamChat({
         // as transient. Best-effort JSON parse; falls back to body+status.
         let upstreamCode = null;
         try { upstreamCode = JSON.parse(body)?.error?.code || null; } catch { /* text body */ }
-        const { code, message } = classifyUpstreamError(body, upstreamCode, res.statusCode);
-        streamError = Object.assign(new Error(message), { code, status: res.statusCode });
+        // Preserve resetMs (audit F3): classifyUpstreamError parses an explicit
+        // reset window (e.g. "Resets in: 3h0m0s" → resetMs) but this path used to
+        // destructure only { code, message }, dropping it — so the handler cooled
+        // the account for a generic burst window instead of the real 3h. Forward
+        // it when present so finalizeConnectAccount can honor the true duration.
+        const classified = classifyUpstreamError(body, upstreamCode, res.statusCode);
+        streamError = Object.assign(new Error(classified.message), {
+          code: classified.code,
+          status: res.statusCode,
+          ...(classified.resetMs != null ? { resetMs: classified.resetMs } : {}),
+        });
         done = true;
         pump();
       });
@@ -1863,9 +1872,13 @@ export async function* streamChat({
             try {
               const parsed = JSON.parse(text);
               if (parsed?.error) {
-                const { code, message } = classifyUpstreamError(
+                const classified = classifyUpstreamError(
                   parsed.error.message || text, parsed.error.code || null, null);
-                streamError = Object.assign(new Error(message), { code, upstream: parsed.error });
+                streamError = Object.assign(new Error(classified.message), {
+                  code: classified.code,
+                  upstream: parsed.error,
+                  ...(classified.resetMs != null ? { resetMs: classified.resetMs } : {}),
+                });
               }
             } catch { /* non-JSON trailer — leave as success */ }
           }

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -1871,16 +1871,19 @@ export function finalizeConnectAccount(acct, { model, startTime, err }) {
     }
     else if (err.code === 'RATE_LIMITED') {
       // Honor an explicit upstream reset window when the classifier parsed one
-      // (e.g. "message rate limit ... Resets in: 3h0m0s" → err.resetMs). A hard
-      // per-model limit is model-scoped, so cool THIS model only and let the pool
-      // prefer another account/model for it, rather than benching the account for
-      // every model. Falls back to an account-wide burst cooldown when no window
-      // was given (generic 429 with no retry-after). F2: that burst duration is
-      // now the `rlBurstMs` tunable (default 300000 = the historical 5min, so
-      // this is byte-identical unless an operator shortens it — see the tunable's
-      // note re: KiroStudio's "bare bursts self-heal in seconds" finding).
+      // (e.g. "message rate limit ... Resets in: 3h0m0s" → err.resetMs). Apply it
+      // ACCOUNT-WIDE (modelKey=null), not model-scoped: acquireConnectAccount
+      // selects the pool via getApiKey(triedKeys, null, ...) with modelKey=null,
+      // and isRateLimitedForModel only consults _modelRateLimits when modelKey is
+      // truthy — so a model-scoped cooldown is structurally invisible to
+      // DEVIN_CONNECT selection and the pool immediately re-picks the account that
+      // just 429'd, ignoring the reset window entirely. rateLimitedUntil is the
+      // only cooldown dimension getApiKey honors with modelKey=null. Falls back to
+      // a burst cooldown when no window was given (generic 429 with no retry-after);
+      // F2: that burst duration is the `rlBurstMs` tunable (default 300000 = the
+      // historical 5min).
       if (Number.isFinite(err.resetMs) && err.resetMs > 0) {
-        markRateLimited(apiKey, err.resetMs, model, 'r');
+        markRateLimited(apiKey, err.resetMs, null, 'r');
       } else {
         markRateLimited(apiKey, getBreakerTunable('rlBurstMs'), null);
       }

--- a/test/devin-connect-pool.test.js
+++ b/test/devin-connect-pool.test.js
@@ -71,7 +71,7 @@ describe('finalizeConnectAccount', () => {
   // F2: a BARE 429 (no upstream reset window) applies an account-wide cooldown of
   // `rlBurstMs`. Default is 15000 (15s) as of 2026-07-12 (429 mitigation on) — the
   // historical value was 300000 (5min). An operator can revert via the tunable. A
-  // 429 WITH a reset window is unaffected (stays model-scoped).
+  // 429 WITH a reset window also cools account-wide, for the real window duration.
   it('F2: bare 429 default cools the account ~15s account-wide', () => {
     const acct = seed('rl-bare-default');
     const t0 = Date.now();
@@ -99,7 +99,7 @@ describe('finalizeConnectAccount', () => {
     }
   });
 
-  it('F2: a 429 WITH a reset window stays model-scoped, ignores rlBurstMs', () => {
+  it('F2: a 429 WITH a reset window cools account-wide for the real window, ignoring rlBurstMs', () => {
     setBreakerTunables({ rlBurstMs: 15000 });
     try {
       const acct = seed('rl-window');
@@ -108,9 +108,13 @@ describe('finalizeConnectAccount', () => {
         { id: acct.id, apiKey: acct.apiKey },
         { model: 'swe-1-6-slow', startTime: t0, err: Object.assign(new Error('resets in 3h'), { code: 'RATE_LIMITED', resetMs: 3 * 60 * 60 * 1000 }) },
       );
-      // reset-window path is model-scoped: no account-wide rateLimitedUntil.
-      assert.ok(!(acct.rateLimitedUntil > t0), 'account-wide cooldown NOT set for a windowed 429');
-      assert.ok((acct._modelRateLimits?.['swe-1-6-slow'] || 0) > t0 + 2 * 60 * 60 * 1000, 'model-scoped cooldown honours the 3h window');
+      // The DEVIN_CONNECT pool selects with modelKey=null (acquireConnectAccount →
+      // getApiKey(triedKeys, null, ...)), and isRateLimitedForModel only consults
+      // _modelRateLimits when modelKey is truthy — so the reset window MUST land on
+      // the account-wide rateLimitedUntil to be visible to selection, not on a
+      // model-scoped cooldown the pool never reads for this path.
+      assert.ok(acct.rateLimitedUntil > t0 + 2 * 60 * 60 * 1000, 'account-wide cooldown honours the 3h window');
+      assert.ok(!(acct._modelRateLimits?.['swe-1-6-slow'] > t0), 'no dead model-scoped cooldown for a path selected with modelKey=null');
     } finally {
       setBreakerTunables({ rlBurstMs: null });
     }

--- a/test/devin-connect.test.js
+++ b/test/devin-connect.test.js
@@ -1854,3 +1854,77 @@ describe('normalizeToolSchema', () => {
     });
   });
 });
+
+describe('streamChat transport resetMs propagation', () => {
+  afterEach(() => __setRequestImpl(null));
+
+  it('attaches resetMs to streamError on a non-200 rate-limit response with a reset window', async () => {
+    __setRequestImpl((_opts, cb) => {
+      const req = { on() { return req; }, setTimeout() { return req; }, write() {}, end() {}, destroy() {} };
+      const res = new EventEmitter();
+      res.statusCode = 429;
+      if (cb) cb(res);
+      queueMicrotask(() => {
+        res.emit('data', Buffer.from('Reached message rate limit for this model. Please try again later. Resets in: 2h30m0s'));
+        res.emit('end');
+      });
+      return req;
+    });
+
+    await assert.rejects(
+      (async () => {
+        for await (const _ of streamChat({
+          messages: [{ role: 'user', content: 'hi' }],
+          model: 'swe-1-7',
+          token: TOKEN,
+        })) { /* drain */ }
+      })(),
+      (err) => {
+        assert.equal(err.code, 'RATE_LIMITED');
+        assert.equal(err.resetMs, (2 * 3600 + 30 * 60) * 1000);
+        return true;
+      },
+    );
+  });
+
+  it('attaches resetMs to streamError on a JSON trailer rate-limit response with a reset window', async () => {
+    __setRequestImpl((_opts, cb) => {
+      const req = { on() { return req; }, setTimeout() { return req; }, write() {}, end() {}, destroy() {} };
+      const res = new EventEmitter();
+      res.statusCode = 200;
+      if (cb) cb(res);
+      queueMicrotask(() => {
+        const trailerJson = JSON.stringify({
+          error: {
+            message: 'Reached message rate limit for this model. Please try again later. Resets in: 1h15m0s',
+            code: 'resource_exhausted',
+          },
+        });
+        const payload = Buffer.from(trailerJson);
+        const trailerFrame = Buffer.alloc(5 + payload.length);
+        trailerFrame[0] = 0x02; // end-of-stream flag
+        trailerFrame.writeUInt32BE(payload.length, 1);
+        payload.copy(trailerFrame, 5);
+
+        res.emit('data', trailerFrame);
+        res.emit('end');
+      });
+      return req;
+    });
+
+    await assert.rejects(
+      (async () => {
+        for await (const _ of streamChat({
+          messages: [{ role: 'user', content: 'hi' }],
+          model: 'swe-1-7',
+          token: TOKEN,
+        })) { /* drain */ }
+      })(),
+      (err) => {
+        assert.equal(err.code, 'RATE_LIMITED');
+        assert.equal(err.resetMs, (1 * 3600 + 15 * 60) * 1000);
+        return true;
+      },
+    );
+  });
+});


### PR DESCRIPTION
## 中文 TL;DR
流式 DEVIN_CONNECT 路径丢了 429 的 reset window，并且把 cooldown 写到账号池读不到的
model 维度上，导致刚被限流的账号被立刻重选、反复打 upstream limiter。本 PR 让 resetMs
一路透传，并按 account-wide 冷却（池选择用 modelKey=null，只认 rateLimitedUntil）。

## Summary
Closes #221. Two links of one chain — a `429` reset window is dropped in transport,
then written to a cooldown dimension the pool never reads. Both must be fixed
together for any observable effect.

## Root cause
- `classifyUpstreamError()` parses `resetMs`, but `streamChat`'s two error paths
  kept only `{ code, message }` → cooldown fell back to the short burst default.
- `acquireConnectAccount` → `getApiKey(triedKeys, null, ...)` selects with
  `modelKey = null`; `isRateLimitedForModel` only reads `_modelRateLimits` when
  `modelKey` is truthy, so a model-scoped cooldown can never gate DEVIN_CONNECT
  selection. `rateLimitedUntil` (account-wide) is the only dimension it honors.

## Fix
- `src/devin-connect.js` (2 points): forward `resetMs` onto `streamError`.
- `src/handlers/chat.js`: `markRateLimited(apiKey, resetMs, null, 'r')`.

## Test plan
- [x] `test/devin-connect.test.js` +2: `resetMs` on non-200 (`2h30m`) & JSON-trailer (`1h15m`) paths
- [x] `test/devin-connect-pool.test.js`: F2 now asserts account-wide `rateLimitedUntil` honors the 3h window
- [x] Full suite: `npm test` → **2763 pass / 0 fail**

Branch is rebased on current `master` (`v3.5.0`), applies cleanly.
