### PR TITLE
fix(chat): don't penalize accounts or fail over on client disconnect (stream replay / re-login / non-stream)

### DIFF
--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -1815,6 +1815,14 @@ function connectFailoverMax(env = process.env) {
   return Number.isFinite(raw) && raw >= 0 ? raw : 2;
 }
 
+// True when an error is an AbortError (client disconnect / server shutdown).
+// Tests look at both name and code because Node's AbortController sets `name`
+// on errors it throws, while fetch/undici sometimes only sets `code: 'ABORT_ERR'`.
+function isAbortError(err) {
+  if (!err) return false;
+  return err.name === 'AbortError' || err.code === 'ABORT_ERR' || /aborted/i.test(err.message);
+}
+
 // Pair with acquireConnectAccount on every exit path. Records billing/stats and
 // returns the account to the pool. `err` null ⇒ success.
 export function finalizeConnectAccount(acct, { model, startTime, err }) {
@@ -1834,7 +1842,7 @@ export function finalizeConnectAccount(acct, { model, startTime, err }) {
   if (err) {
     // A client-side abort (caller disconnected) is not an account fault — just
     // release without penalizing the account's error budget.
-    const aborted = err.name === 'AbortError' || err.code === 'ABORT_ERR';
+    const aborted = isAbortError(err);
     if (aborted) { /* no penalty */ }
     // MODEL_BLOCKED is a tier/entitlement wall (free account asked for a paid
     // selector → upstream "/upgrade"), NOT an account-health problem. Penalizing
@@ -2681,6 +2689,13 @@ async function _handleChatCompletionsInner(body, context = {}) {
               finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: null });
               return { kind: 'ok' };
             } catch (err) {
+              // Client or server-level abort: the caller is gone (or the process
+              // is shutting down). Don't penalize the account, don't log a scary
+              // ERROR, and don't burn quota on more retries/failover.
+              if (abortController.signal.aborted || isAbortError(err)) {
+                finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: isAbortError(err) ? err : Object.assign(new Error('client disconnected'), { name: 'AbortError' }) });
+                return { kind: 'abort' };
+              }
               // Transient blip (5xx / ECONNRESET / server "unavailable") BEFORE
               // any byte hit the wire: the non-stream path already retries these
               // (devin-connect-openai.js maxRetries), but the stream path didn't,
@@ -2688,6 +2703,13 @@ async function _handleChatCompletionsInner(body, context = {}) {
               // client. Replay once on the SAME token while !emitted — replaying
               // after bytes are out would duplicate content, so it's gated.
               if (isConnectRetryable(err) && a && !emitted) {
+                // Don't start a replay if the client disconnected while we were
+                // catching the first error — writing to a dead socket is pointless
+                // and can leave the handler stuck.
+                if (abortController.signal.aborted) {
+                  finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: Object.assign(new Error('client disconnected'), { name: 'AbortError' }) });
+                  return { kind: 'abort' };
+                }
                 log.info(`Chat[${reqId}]: DEVIN_CONNECT stream transient error (${err.code || err.status}); replaying once on same token`);
                 bumpConnect('transient_replays');
                 try {
@@ -2697,6 +2719,13 @@ async function _handleChatCompletionsInner(body, context = {}) {
                   finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: null });
                   return { kind: 'ok' };
                 } catch (retryErr) {
+                  // If the client hung up during the replay, stop immediately rather
+                  // than falling through to the generic error handling which would
+                  // log an ERROR and possibly try to write to a dead socket.
+                  if (abortController.signal.aborted || isAbortError(retryErr)) {
+                    finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: isAbortError(retryErr) ? retryErr : Object.assign(new Error('client disconnected'), { name: 'AbortError' }) });
+                    return { kind: 'abort' };
+                  }
                   // Retry failed too — fall through to the normal handling below
                   // (which may still recover an UNAUTHORIZED via re-login, or
                   // surface the error). Reassign so the branches below see it.
@@ -2720,6 +2749,11 @@ async function _handleChatCompletionsInner(body, context = {}) {
                     finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: null });
                     return { kind: 'ok' };
                   } catch (retryErr) {
+                    // Client disconnected while re-login was in flight — stop cleanly.
+                    if (abortController.signal.aborted || isAbortError(retryErr)) {
+                      finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: isAbortError(retryErr) ? retryErr : Object.assign(new Error('client disconnected'), { name: 'AbortError' }) });
+                      return { kind: 'abort' };
+                    }
                     // Fresh token still UNAUTHORIZED ⇒ entitlement wall, not a dead
                     // session (see non-stream path). Reclassify as MODEL_BLOCKED so
                     // we surface a clean error instead of storming re-login +
@@ -2770,6 +2804,10 @@ async function _handleChatCompletionsInner(body, context = {}) {
               if (acct) triedKeys.push(acct.apiKey);
               const r = await attemptStream(acct);
               if (r.kind === 'ok') break;
+              if (r.kind === 'abort') {
+                log.info(`Chat[${reqId}]: DEVIN_CONNECT stream aborted (client gone) — not failing over`);
+                break;
+              }
               // Re-check after the (awaited) attempt: the client may have hung up
               // while the upstream call was in flight. Bail before failing over.
               if (abortController.signal.aborted) {
@@ -2803,7 +2841,9 @@ async function _handleChatCompletionsInner(body, context = {}) {
               bumpConnect('failover_hops');
               acct = next;
             }
-            if (!res.writableEnded) { res.write('data: [DONE]\n\n'); res.end(); }
+            // If the client already disconnected, don't try to write to a dead
+            // socket — that can leave the handler stuck on a closed connection.
+            if (!abortController.signal.aborted && !res.writableEnded) { res.write('data: [DONE]\n\n'); res.end(); }
           } finally {
             unregisterSse();
             stopHeartbeat();
@@ -2821,6 +2861,11 @@ async function _handleChatCompletionsInner(body, context = {}) {
         finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: null });
         return { kind: 'ok', out };
       } catch (err) {
+        // Client or server-level abort: don't penalize the account or log ERROR.
+        if ((context.signal?.aborted) || isAbortError(err)) {
+          finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: isAbortError(err) ? err : Object.assign(new Error('client disconnected'), { name: 'AbortError' }) });
+          return { kind: 'abort' };
+        }
         if (err.code === 'UNAUTHORIZED' && a) {
           // No force — see the streaming path: honor the 60s cooldown so a
           // mass token-death event recovers each account once instead of
@@ -2833,6 +2878,11 @@ async function _handleChatCompletionsInner(body, context = {}) {
               finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: null });
               return { kind: 'ok', out };
             } catch (retryErr) {
+              // Client aborted during the re-login retry.
+              if ((context.signal?.aborted) || isAbortError(retryErr)) {
+                finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: isAbortError(retryErr) ? retryErr : Object.assign(new Error('client disconnected'), { name: 'AbortError' }) });
+                return { kind: 'abort' };
+              }
               // The re-login above minted a verifiably-fresh token (windsurfLogin
               // succeeded), so a SECOND UNAUTHORIZED on that brand-new token cannot
               // be a dead session — the account simply lacks entitlement for this
@@ -2860,6 +2910,11 @@ async function _handleChatCompletionsInner(body, context = {}) {
     };
     let acct = ccAcct;
     for (let hops = 0; ; hops++) {
+      if (context.signal?.aborted) {
+        if (acct) releaseAccountById(acct.id);
+        log.info(`Chat[${reqId}]: DEVIN_CONNECT non-stream aborted (client gone) — not failing over`);
+        return { status: 499, body: { error: { message: 'Client closed request', type: 'client_disconnect', code: 'client_disconnect' } } };
+      }
       if (acct) triedKeys.push(acct.apiKey);
       const r = await attempt(acct);
       if (r.kind === 'ok') {
@@ -2872,6 +2927,12 @@ async function _handleChatCompletionsInner(body, context = {}) {
         // K8: per-account lifetime spend (non-stream connect path).
         try { recordAccountSpend(acct ? currentApiKeyForId(acct.id, acct.apiKey) : null, r.out?.body?.usage); } catch {}
         return r.out;
+      }
+      if (r.kind === 'abort') {
+        log.info(`Chat[${reqId}]: DEVIN_CONNECT non-stream aborted (client gone) — not failing over`);
+        // Return a 499 Client Closed Request; if the response socket is already
+        // gone the route handler will drop it harmlessly.
+        return { status: 499, body: { error: { message: 'Client closed request', type: 'client_disconnect', code: 'client_disconnect' } } };
       }
       if (r.kind === 'error') {
         // R1: QUOTA_EXHAUSTED / RATE_LIMITED are ACCOUNT dry-wells — the offending

--- a/test/devin-connect-stream-lifecycle.test.js
+++ b/test/devin-connect-stream-lifecycle.test.js
@@ -105,6 +105,41 @@ describe('DEVIN_CONNECT stream — client disconnect stops account-hopping', () 
     assert.ok(!frames.some(f => f !== '[DONE]' && f.error), 'no error frame emitted to the gone client');
   });
 
+  it('aborts cleanly during same-token transient replay when client disconnects', async () => {
+    const a = seed('replay-abort');
+    const b = seed('replay-abort-2');
+    let res;
+    const seen = [];
+    let call = 0;
+    __setConnectDeps({
+      streamChatCompletion: async (params) => {
+        seen.push(params.token);
+        if (call++ === 0) {
+          // First upstream call fails with a retryable ECONNRESET, triggering
+          // the same-token replay in attemptStream.
+          throw Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+        }
+        // Replay is in flight when the client disconnects, causing an abort.
+        res.disconnect();
+        throw Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+      },
+    });
+
+    const result = await handleChatCompletions(
+      { model: 'swe-1-6-slow', stream: true, messages: [{ role: 'user', content: 'hi' }] },
+      { callerKey: '' },
+    );
+    res = fakeRes();
+    await result.handler(res);
+
+    assert.equal(seen.length, 2, 'replayed once on the same token, then stopped');
+    assert.equal(seen[0], seen[1], 'same-token replay used identical token');
+    assert.ok(!seen.includes(b.apiKey), 'never hopped to second account');
+    const frames = parseFrames(res.body);
+    assert.ok(!frames.some(f => f !== '[DONE]' && f.error), 'no error frame emitted to the gone client');
+    assert.ok(!frames.includes('[DONE]'), 'no [DONE] written to a disconnected socket');
+  });
+
   it('aborts on a server-level context.signal and does NOT fail over', async () => {
     const a = seed('sig-1');
     const b = seed('sig-2');


### PR DESCRIPTION
## 中文 TL;DR
客户端中途断开时，原来可能给账号记错误、继续 failover（把配额打到已断的 socket）、
往关闭的流里写数据。本 PR 把已有的 abort 处理扩展到 same-token replay / re-login /
非流式路径：不惩罚账号、不 failover、不写死 socket，非流式返回 499。

## Summary
Hardening. Extends the existing "client disconnect stops account-hopping" behavior
to the paths it didn't yet cover. Complements #221 (both reduce needless upstream
load on the DEVIN_CONNECT path).

## Fix
- `isAbortError(err)` (name / code / message) unifies abort detection.
- Stream attempt + transient-replay + re-login-retry catches → `{ kind: 'abort' }`,
  finalize with an AbortError (no error-budget penalty), break the failover loop.
- `[DONE]` guarded by `!signal.aborted && !res.writableEnded` (no write to a dead socket).
- Non-stream: pre-attempt + `abort` result → `499` `client_disconnect`.

## Test plan
- [x] `test/devin-connect-stream-lifecycle.test.js` +1: same-token replay + disconnect →
      replays once, no account hop, no `[DONE]`, no error frame to the gone client
- [x] Full suite: `npm test` → **2762 pass / 0 fail**

Branch is on current `master` (`v3.5.0`), applies cleanly.
