### PR TITLE
feat(devin-connect): experimental stable session_id from client pair-chain (opt-in, default OFF)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,20 @@ LS_PORT=42100
 # Default 2; set 0 to disable failover (same-account re-login still applies).
 # DEVIN_CONNECT_FAILOVER_MAX=2
 #
+# --- Session continuity (experimental, opt-in, default OFF) ---
+# By default every DEVIN_CONNECT call mints a fresh protobuf session_id (#16),
+# so the upstream velocity limiter sees each turn of one dialog as a brand-new
+# session. With reuse ON, a stable session_id is derived from the conversation's
+# own completed request/response pair chain (never from requestId/IP/timestamp),
+# so a multi-turn dialog rides ONE session_id. Identity survives tool_call_id
+# regeneration, system-prompt drift, and response truncation; parallel dialogs on
+# the same key stay independent. In-memory only (no persistence across restarts).
+# DEVIN_CONNECT_SESSION_REUSE=0
+# State TTL before a dormant dialog's session_id is forgotten. Default 1800000 (30 min).
+# DEVIN_CONNECT_SESSION_TTL_MS=1800000
+# Max tracked dialogs (LRU-evicted). Default 500.
+# DEVIN_CONNECT_SESSION_MAX_STATES=500
+#
 # --- Timeouts ---
 # Idle (no-activity) socket timeout — resets on every byte. Default 120000.
 # DEVIN_CONNECT_IDLE_TIMEOUT_MS=120000

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -58,6 +58,7 @@ import { resolveConnectSelector } from '../devin-connect-models.js';
 import { isRetryable as isConnectRetryable, getToolDefTags, parseToolCallTagMap } from '../devin-connect.js';
 import { isRouterModel, assignModel } from '../devin-connect-catalog.js';
 import { bumpConnect } from '../devin-connect-metrics.js';
+import { resolveSessionId as resolveConnectSessionId, commitAfterResponse as commitConnectSession } from '../session-continuity.js';
 import { newTraceId, traceClientRequest, traceRouting, traceClientResponse, traceEnabled } from '../trace.js';
 import { sanitizeText, sanitizeToolCall, PathSanitizeStream } from '../sanitize.js';
 import { systemFingerprint } from '../system-fingerprint.js';
@@ -2500,6 +2501,19 @@ async function _handleChatCompletionsInner(body, context = {}) {
     }
     const ccAcct = await acquireConnectAccount(context.signal, callerKey, selector);
     const connectParams = { messages: connectMessages, model: selector };
+    // Session continuity (opt-in, DEVIN_CONNECT_SESSION_REUSE, default OFF). Derive
+    // a stable protobuf session_id (#16) from the conversation's completed request/
+    // response pair chain so a multi-turn dialog reuses ONE session_id instead of
+    // minting a fresh randomUUID per call — which the upstream velocity limiter
+    // reads as N brand-new sessions. Resolves BEFORE dispatch on the client's own
+    // history; returns null (⇒ fresh per-request uuid, byte-identical to today) when
+    // the gate is off. Uses connectMessages so the fingerprint reflects exactly what
+    // rides the wire.
+    const connectSessionId = resolveConnectSessionId(callerKey || '', connectMessages);
+    if (connectSessionId) {
+      connectParams.sessionId = connectSessionId;
+      log.info(`Chat[${reqId}]: DEVIN_CONNECT session reuse active → session_id=${connectSessionId}`);
+    }
     if (ccAcct) {
       connectParams.token = ccAcct.apiKey;
       // Stable per-account device fingerprint (opt-in, WINDSURFAPI_STABLE_DEVICE).
@@ -2679,7 +2693,7 @@ async function _handleChatCompletionsInner(body, context = {}) {
               // K8: attribute the spend to THIS account (per-account lifetime total).
               try { recordAccountSpend(a?.apiKey, _sr?.usage); } catch {}
               finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: null });
-              return { kind: 'ok' };
+              return { kind: 'ok', sr: _sr };
             } catch (err) {
               // Transient blip (5xx / ECONNRESET / server "unavailable") BEFORE
               // any byte hit the wire: the non-stream path already retries these
@@ -2695,7 +2709,7 @@ async function _handleChatCompletionsInner(body, context = {}) {
                   try { recordTokenUsage(_sr2?.usage); } catch {}
                   try { recordAccountSpend(a?.apiKey, _sr2?.usage); } catch {}
                   finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: null });
-                  return { kind: 'ok' };
+                  return { kind: 'ok', sr: _sr2 };
                 } catch (retryErr) {
                   // Retry failed too — fall through to the normal handling below
                   // (which may still recover an UNAUTHORIZED via re-login, or
@@ -2718,7 +2732,7 @@ async function _handleChatCompletionsInner(body, context = {}) {
                     try { recordTokenUsage(_sr3?.usage); } catch {}
                     try { recordAccountSpend(currentApiKeyForId(a.id, a.apiKey), _sr3?.usage); } catch {}
                     finalizeConnectAccount(a, { model: reqModelName, startTime: ccStart, err: null });
-                    return { kind: 'ok' };
+                    return { kind: 'ok', sr: _sr3 };
                   } catch (retryErr) {
                     // Fresh token still UNAUTHORIZED ⇒ entitlement wall, not a dead
                     // session (see non-stream path). Reclassify as MODEL_BLOCKED so
@@ -2769,7 +2783,24 @@ async function _handleChatCompletionsInner(body, context = {}) {
               }
               if (acct) triedKeys.push(acct.apiKey);
               const r = await attemptStream(acct);
-              if (r.kind === 'ok') break;
+              if (r.kind === 'ok') {
+                // Session continuity: commit the completed request→response pair
+                // from the streamed result so the next turn resolves to this same
+                // session_id via pair-chain overlap. Gate-checked + best-effort
+                // (no-op when reuse is off). r.sr is threaded from every success
+                // path (initial, transient replay, re-login retry) so the commit
+                // fires even after an upstream wobble — exactly when reuse helps.
+                try {
+                  const tc = r.sr?.toolCalls;
+                  const commitMsgs = [...connectMessages, {
+                    role: 'assistant',
+                    content: r.sr?.content || '',
+                    ...(tc?.length ? { tool_calls: tc.map((t, idx) => ({ id: t.id || `tc_${idx}`, function: { name: t.name, arguments: t.argumentsJson || t.arguments || '' } })) } : {}),
+                  }];
+                  commitConnectSession(callerKey || '', commitMsgs);
+                } catch { /* session commit is best-effort */ }
+                break;
+              }
               // Re-check after the (awaited) attempt: the client may have hung up
               // while the upstream call was in flight. Bail before failing over.
               if (abortController.signal.aborted) {
@@ -2871,6 +2902,19 @@ async function _handleChatCompletionsInner(body, context = {}) {
         try { recordTokenUsage(r.out?.body?.usage); } catch {}
         // K8: per-account lifetime spend (non-stream connect path).
         try { recordAccountSpend(acct ? currentApiKeyForId(acct.id, acct.apiKey) : null, r.out?.body?.usage); } catch {}
+        // Session continuity: commit the completed request→response pair so the
+        // next turn resolves to this session_id via pair-chain overlap. The
+        // response tool_calls already ride the OpenAI function shape here.
+        // Gate-checked + best-effort (no-op when reuse is off).
+        try {
+          const msg = r.out?.body?.choices?.[0]?.message;
+          const commitMsgs = [...connectMessages, {
+            role: 'assistant',
+            content: msg?.content || '',
+            ...(msg?.tool_calls ? { tool_calls: msg.tool_calls } : {}),
+          }];
+          commitConnectSession(callerKey || '', commitMsgs);
+        } catch { /* session commit is best-effort */ }
         return r.out;
       }
       if (r.kind === 'error') {

--- a/src/session-continuity.js
+++ b/src/session-continuity.js
@@ -1,0 +1,600 @@
+/**
+ * Session continuity for DEVIN_CONNECT.
+ *
+ * Derives a stable protobuf session_id (#16) from the conversation's own completed
+ * request/response pair fingerprints, so one multi-turn dialog reuses ONE session_id
+ * instead of minting a fresh uuid per turn (which the upstream velocity limiter reads
+ * as N brand-new sessions). Identity is the client-visible input/output only — never
+ * requestId / session / IP / timestamp / provider signature.
+ *
+ * Architecture:
+ *   1. Canonicalize OpenAI messages → events (role:kind:payload)
+ *   2. Normalize tool linkage (semantic slot matching, not transport IDs)
+ *   3. Split into completed pairs: [input] → [output]
+ *   4. HMAC-hash each pair by scopeId
+ *   5. Resolve by overlap scoring against stored pair windows
+ *   6. Commit after response with idempotency guard
+ *
+ * Edge cases handled:
+ *   - Tool call ID regeneration (retry/combo switch)
+ *   - Orphan tool_result (barrier → blocks resolve)
+ *   - System prompt changes (excluded from identity)
+ *   - Parallel dialogs on same API key (different pair chains)
+ *   - Output drift (client truncates response text)
+ *   - Idempotent commits (same state → same stateId)
+ */
+import crypto from 'crypto';
+
+// ─── Configuration ─────────────────────────────────────────────────────────
+
+const SECRET = crypto.randomBytes(32);
+const DEFAULT_TTL = 30 * 60 * 1000;
+const DEFAULT_MAX_STATES = 500;
+const PAIR_WINDOW_SIZE = 10;
+const CLEANUP_INTERVAL = 5 * 60 * 1000;
+
+function getTtl(env = process.env) {
+  const v = Number(env.DEVIN_CONNECT_SESSION_TTL_MS);
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_TTL;
+}
+
+function getMaxStates(env = process.env) {
+  const v = Number(env.DEVIN_CONNECT_SESSION_MAX_STATES);
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_MAX_STATES;
+}
+
+// ─── State Store ───────────────────────────────────────────────────────────
+
+const statesById = new Map();
+const pairIndex = new Map();       // `${scopeId}:${pairHash}` → Set<stateId>
+const commitIndex = new Map();     // commitKey → stateId
+
+export function isSessionReuseEnabled(env = process.env) {
+  const v = String(env.DEVIN_CONNECT_SESSION_REUSE ?? '').trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+// ─── Canonicalizer ─────────────────────────────────────────────────────────
+
+function deriveScopeId(callerKey) {
+  return crypto.createHmac('sha256', SECRET).update(callerKey || '').digest('hex');
+}
+
+function messageText(msg) {
+  if (typeof msg?.content === 'string') return msg.content;
+  if (Array.isArray(msg?.content)) return msg.content.map((p) => p?.text || '').join('');
+  return '';
+}
+
+function canonicalizeArgs(args) {
+  if (typeof args === 'string') {
+    try { return JSON.stringify(JSON.parse(args)); } catch { return args; }
+  }
+  if (args && typeof args === 'object') return JSON.stringify(args);
+  return '';
+}
+
+/**
+ * Canonicalize OpenAI messages into a normalized event stream.
+ * System/developer messages are EXCLUDED (they don't participate in pair identity).
+ */
+export function canonicalize(messages) {
+  const events = [];
+  for (const msg of (messages || [])) {
+    if (!msg) continue;
+    const role = msg.role || '';
+    if (role === 'system' || role === 'developer') continue;
+
+    if (role === 'tool') {
+      events.push({
+        role: 'tool',
+        kind: 'tool_result',
+        payload: { rawLink: msg.tool_call_id || '', content: messageText(msg) },
+      });
+      continue;
+    }
+
+    const text = messageText(msg);
+    if (text) events.push({ role, kind: 'text', payload: text });
+
+    if (Array.isArray(msg.tool_calls)) {
+      for (const tc of msg.tool_calls) {
+        const name = tc.function?.name || tc.name || '';
+        const args = canonicalizeArgs(tc.function?.arguments ?? tc.arguments);
+        events.push({
+          role,
+          kind: 'tool_call',
+          payload: { name, arguments: args, rawLink: tc.id || '' },
+        });
+      }
+    }
+
+    // Anchor empty assistant turns (no text, no tool_calls) so they still form a pair boundary
+    if (role === 'assistant' && !text && !Array.isArray(msg.tool_calls)) {
+      events.push({ role: 'assistant', kind: 'empty_output', payload: '' });
+    }
+  }
+  return events;
+}
+
+// ─── Tool Linkage Normalizer ───────────────────────────────────────────────
+
+function isAssistantOutput(ev) {
+  return ev.role === 'assistant' && (ev.kind === 'text' || ev.kind === 'tool_call' || ev.kind === 'empty_output');
+}
+
+/**
+ * Normalize tool_call ↔ tool_result linkage by semantic content (name + args + slot),
+ * not by opaque transport IDs. Survives tool_call_id regeneration across retries.
+ */
+export function normalizeToolLinkage(events) {
+  if (!Array.isArray(events)) return [];
+  const rawLinkToDescriptor = new Map();
+  let inRun = false;
+  let batch = -1;
+  let batchSlot = 0;
+  let lastBatchDescriptors = [];
+
+  return events.map((ev) => {
+    if (isAssistantOutput(ev)) {
+      if (!inRun) { inRun = true; batch++; batchSlot = 0; lastBatchDescriptors = []; }
+      if (ev.kind !== 'tool_call') return ev;
+
+      const p = ev.payload || {};
+      const descriptor = { slot: `slot:${batchSlot++}`, name: p.name || '', arguments: p.arguments || '', pending: true };
+      if (p.rawLink) rawLinkToDescriptor.set(p.rawLink, descriptor);
+      lastBatchDescriptors.push(descriptor);
+      return { ...ev, payload: { slot: descriptor.slot, name: descriptor.name, arguments: descriptor.arguments } };
+    }
+
+    inRun = false;
+    if (ev.role === 'tool' && ev.kind === 'tool_result') {
+      const p = ev.payload || {};
+      const rawLink = p.rawLink || '';
+      // Try raw link first
+      let desc = rawLink ? rawLinkToDescriptor.get(rawLink) : null;
+      if (desc && !desc.pending) desc = null; // already consumed
+      // Fallback: name-hint (single pending match by name)
+      if (!desc && p.nameHint) {
+        const matches = lastBatchDescriptors.filter((d) => d.pending && d.name === p.nameHint);
+        if (matches.length === 1) desc = matches[0];
+      }
+      if (!desc) {
+        return { ...ev, payload: { unlinked: true, content: p.content || '' } };
+      }
+      // Consume
+      desc.pending = false;
+      if (rawLink) rawLinkToDescriptor.delete(rawLink);
+      return { ...ev, payload: { slot: desc.slot, name: desc.name, arguments: desc.arguments, content: p.content || '' } };
+    }
+
+    return ev;
+  });
+}
+
+// ─── Barrier Detection ─────────────────────────────────────────────────────
+
+function hasUnlinkedResult(events) {
+  return events.some((ev) => ev.role === 'tool' && ev.kind === 'tool_result' && ev.payload?.unlinked === true);
+}
+
+/**
+ * Analyze history: detect barriers, compute post-barrier pair chain.
+ */
+export function analyzeHistory(events, scopeId) {
+  const normalized = normalizeToolLinkage(events);
+  const { records, trailingInput } = splitWithTrailing(normalized);
+
+  const hasTrailingBarrier = hasUnlinkedResult(trailingInput);
+
+  let lastBarrierIndex = -1;
+  for (let i = 0; i < records.length; i++) {
+    if (hasUnlinkedResult(records[i].input)) lastBarrierIndex = i;
+  }
+
+  const postBarrierRecords = hasTrailingBarrier ? [] : records.slice(lastBarrierIndex + 1);
+  const hashes = postBarrierRecords.map((r) => hashPair(r, scopeId));
+  const canResolve = !hasTrailingBarrier && hashes.length > 0;
+
+  return { records, trailingInput, hasTrailingBarrier, lastBarrierIndex, postBarrierRecords, hashes, canResolve };
+}
+
+function splitWithTrailing(events) {
+  const pairs = [];
+  let input = [];
+  let output = [];
+  let inOutput = false;
+
+  for (const ev of events) {
+    if (isAssistantOutput(ev)) {
+      inOutput = true;
+      output.push(ev);
+    } else {
+      if (inOutput) {
+        pairs.push({ input, output });
+        input = [];
+        output = [];
+        inOutput = false;
+      }
+      input.push(ev);
+    }
+  }
+  if (inOutput && output.length > 0) {
+    pairs.push({ input, output });
+    return { records: pairs, trailingInput: [] };
+  }
+  return { records: pairs, trailingInput: input };
+}
+
+// ─── Pair Hashing ──────────────────────────────────────────────────────────
+
+function stableJson(value) {
+  if (value === undefined) return '';
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return '[' + value.map(stableJson).join(',') + ']';
+  if (typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return '{' + keys.map((k) => JSON.stringify(k) + ':' + stableJson(value[k])).join(',') + '}';
+  }
+  return JSON.stringify(value);
+}
+
+function hashPair(pair, scopeId) {
+  const obj = { version: 'pair-v1', scopeId, input: pair.input, output: pair.output };
+  return crypto.createHmac('sha256', SECRET).update(stableJson(obj)).digest('hex');
+}
+
+/**
+ * Derive a per-dialog "root anchor" key from the dialog's FIRST input turn — the
+ * only identifying signal available before any completed pair exists. This is what
+ * lets the session_id be stable from turn 1: the same first input yields the same
+ * key at resolve time (turn 1, trailing input) and at commit time (turn 1, first
+ * pair's input) and on every later turn (first pair's input). Two dialogs with a
+ * byte-identical opener share this key until they diverge — an unavoidable ceiling
+ * (there is no other signal at turn 1) — and the pair chain then forks them at
+ * commit via the provisional-claim rule. Returns null when even the opener is empty.
+ */
+function rootAnchorKey(scopeId, analysis) {
+  const firstPairInput = analysis.records?.[0]?.input;
+  const firstInput = (Array.isArray(firstPairInput) && firstPairInput.length)
+    ? firstPairInput
+    : analysis.trailingInput;
+  if (!Array.isArray(firstInput) || firstInput.length === 0) return null;
+  const digest = crypto.createHmac('sha256', SECRET)
+    .update(stableJson({ version: 'root-v1', scopeId, input: firstInput }))
+    .digest('hex');
+  return `${scopeId}:root:${digest}`;
+}
+
+/**
+ * Build completed pair hashes for a conversation.
+ */
+export function buildPairHashes(callerKey, messages) {
+  const scopeId = deriveScopeId(callerKey);
+  const events = canonicalize(messages);
+  const analysis = analyzeHistory(events, scopeId);
+  return { scopeId, hashes: analysis.hashes, canResolve: analysis.canResolve };
+}
+
+// ─── Resolver ──────────────────────────────────────────────────────────────
+
+/**
+ * Overlap score: how many of the candidate's hashes appear as a contiguous
+ * subsequence within incoming (anchored at the last stored hash).
+ */
+function overlapScore(incoming, candidateWindow) {
+  if (!candidateWindow.length || !incoming.length) return 0;
+  const lastCand = candidateWindow[candidateWindow.length - 1];
+  let anchor = -1;
+  for (let i = incoming.length - 1; i >= 0; i--) {
+    if (incoming[i] === lastCand) { anchor = i; break; }
+  }
+  if (anchor < 0) return 0;
+  let score = 0;
+  for (let k = 0; k < candidateWindow.length && anchor - k >= 0; k++) {
+    if (incoming[anchor - k] !== candidateWindow[candidateWindow.length - 1 - k]) break;
+    score++;
+  }
+  return score;
+}
+
+/**
+ * Output drift tolerance: when exact hash doesn't match but the input is
+ * identical and the output is a prefix/superset of the stored output.
+ */
+function driftScore(incomingRecords, candidateRecords, incomingHashes, candidateHashes) {
+  if (!Array.isArray(incomingRecords) || !Array.isArray(candidateRecords)) return 0;
+  const max = Math.min(10, incomingRecords.length, candidateRecords.length);
+  let score = 0;
+  for (let k = 1; k <= max; k++) {
+    const iIdx = incomingRecords.length - k;
+    const cIdx = candidateRecords.length - k;
+    // Exact hash match takes priority
+    if (incomingHashes?.[incomingHashes.length - k] === candidateHashes?.[candidateHashes.length - k]) {
+      score = k;
+      continue;
+    }
+    const inc = incomingRecords[iIdx];
+    const cand = candidateRecords[cIdx];
+    if (stableJson(inc?.input) !== stableJson(cand?.input)) break;
+    // Output: check if one is a prefix of the other (text truncation/extension)
+    if (!outputsCompatible(inc?.output, cand?.output)) break;
+    score = k;
+  }
+  return score;
+}
+
+function outputsCompatible(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i]?.role !== b[i]?.role || a[i]?.kind !== b[i]?.kind) return false;
+    const aText = typeof a[i]?.payload === 'string' ? a[i].payload : null;
+    const bText = typeof b[i]?.payload === 'string' ? b[i].payload : null;
+    if (aText !== null || bText !== null) {
+      if (aText === null || bText === null) return false;
+      if (aText === bText) continue;
+      const shorter = aText.length <= bText.length ? aText : bText;
+      const longer = aText.length > bText.length ? aText : bText;
+      if (shorter.length < 24 || shorter.length / Math.max(1, longer.length) < 0.35) return false;
+      if (!longer.includes(shorter)) return false;
+      continue;
+    }
+    if (stableJson(a[i]?.payload) !== stableJson(b[i]?.payload)) return false;
+  }
+  return true;
+}
+
+// ─── Store Operations ──────────────────────────────────────────────────────
+
+function evictState(stateId) {
+  const state = statesById.get(stateId);
+  if (!state) return;
+  for (const ph of state.pairWindow) {
+    const key = `${state.scopeId}:${ph}`;
+    const set = pairIndex.get(key);
+    if (set) { set.delete(stateId); if (set.size === 0) pairIndex.delete(key); }
+  }
+  if (state.rootKey) {
+    const rootSet = pairIndex.get(state.rootKey);
+    if (rootSet) { rootSet.delete(stateId); if (rootSet.size === 0) pairIndex.delete(state.rootKey); }
+  }
+  if (state.commitKey) commitIndex.delete(state.commitKey);
+  statesById.delete(stateId);
+}
+
+function enforceCapacity(env) {
+  const max = getMaxStates(env);
+  if (statesById.size < max) return;
+  let oldest = null; let oldestTs = Infinity;
+  for (const [id, s] of statesById) {
+    if (s.lastSeen < oldestTs) { oldestTs = s.lastSeen; oldest = id; }
+  }
+  if (oldest) evictState(oldest);
+}
+
+function clearExpired(env) {
+  const ttl = getTtl(env);
+  const now = Date.now();
+  for (const [id, s] of statesById) {
+    if (now - s.lastSeen > ttl) evictState(id);
+  }
+}
+
+function indexState(stateId, state) {
+  for (const ph of state.pairWindow) {
+    const k = `${state.scopeId}:${ph}`;
+    if (!pairIndex.has(k)) pairIndex.set(k, new Set());
+    pairIndex.get(k).add(stateId);
+  }
+}
+
+// ─── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a stable session_id for the given conversation.
+ * Called BEFORE upstream dispatch.
+ */
+export function resolveSessionId(callerKey, messages, env = process.env) {
+  if (!isSessionReuseEnabled(env)) return null;
+
+  const scopeId = deriveScopeId(callerKey);
+  const events = canonicalize(messages);
+  const analysis = analyzeHistory(events, scopeId);
+  const { hashes, canResolve, postBarrierRecords } = analysis;
+  const ttl = getTtl(env);
+  const now = Date.now();
+
+  if (!canResolve || hashes.length === 0) {
+    // First turn (no completed pair yet) or a barrier. Anchor the session on the
+    // dialog's first input turn so the id is STABLE FROM TURN 1 — the only signal
+    // that exists before a pair does. Falls back to a shared bucket only when even
+    // the opener is empty. Two dialogs with an identical opener share this id until
+    // they diverge; commitAfterResponse then forks them (provisional-claim rule).
+    const rootKey = rootAnchorKey(scopeId, analysis) || `${scopeId}:__no_pair__`;
+    const existing = pairIndex.get(rootKey);
+    if (existing) {
+      for (const sid of existing) {
+        const state = statesById.get(sid);
+        if (state && now - state.lastSeen < ttl) {
+          state.lastSeen = now;
+          return state.sessionId;
+        }
+        // Expired — evict so it doesn't block future lookups
+        evictState(sid);
+      }
+    }
+    enforceCapacity(env);
+    const sessionId = crypto.randomUUID();
+    const stateId = crypto.randomUUID();
+    const state = { stateId, scopeId, sessionId, pairWindow: [], pairRecords: [], lastSeen: now, commitKey: null, dialogAnchor: null, rootKey };
+    statesById.set(stateId, state);
+    if (!pairIndex.has(rootKey)) pairIndex.set(rootKey, new Set());
+    pairIndex.get(rootKey).add(stateId);
+    return sessionId;
+  }
+
+  // Find best match by iterating ALL incoming hashes as index keys
+  let best = null; let bestScore = 0; let hasTie = false;
+  const seen = new Set();
+  for (let i = hashes.length - 1; i >= 0; i--) {
+    const idxKey = `${scopeId}:${hashes[i]}`;
+    const candidates = pairIndex.get(idxKey);
+    if (!candidates) continue;
+    for (const stateId of candidates) {
+      if (seen.has(stateId)) continue;
+      seen.add(stateId);
+      const state = statesById.get(stateId);
+      if (!state || now - state.lastSeen > ttl) continue;
+      let score = overlapScore(hashes, state.pairWindow);
+      // Drift fallback
+      if (score === 0 && state.pairRecords?.length) {
+        score = driftScore(postBarrierRecords, state.pairRecords, hashes, state.pairWindow);
+      }
+      if (score > bestScore) { bestScore = score; best = state; hasTie = false; }
+      else if (score === bestScore && score > 0) hasTie = true;
+    }
+  }
+
+  if (best && !hasTie) {
+    best.lastSeen = now;
+    const newWindow = hashes.slice(-PAIR_WINDOW_SIZE);
+    // Re-index with new hashes (stateId stored on state object for O(1) access)
+    if (best.stateId) {
+      for (const ph of newWindow) {
+        const k = `${scopeId}:${ph}`;
+        if (!pairIndex.has(k)) pairIndex.set(k, new Set());
+        pairIndex.get(k).add(best.stateId);
+      }
+    }
+    best.pairWindow = newWindow;
+    best.pairRecords = postBarrierRecords.slice(-PAIR_WINDOW_SIZE);
+    return best.sessionId;
+  }
+
+  // No match — create new state
+  clearExpired(env);
+  enforceCapacity(env);
+  const sessionId = crypto.randomUUID();
+  const stateId = crypto.randomUUID();
+  const pairWindow = hashes.slice(-PAIR_WINDOW_SIZE);
+  const dialogAnchor = pairWindow[0]?.slice(0, 16) || null;
+  const state = { stateId, scopeId, sessionId, pairWindow, pairRecords: postBarrierRecords.slice(-PAIR_WINDOW_SIZE), lastSeen: now, commitKey: null, dialogAnchor };
+  statesById.set(stateId, state);
+  indexState(stateId, state);
+  return sessionId;
+}
+
+/**
+ * Commit state after a successful response. Idempotent.
+ * Called AFTER upstream response completes.
+ */
+export function commitAfterResponse(callerKey, messagesWithResponse, env = process.env) {
+  if (!isSessionReuseEnabled(env)) return null;
+
+  const scopeId = deriveScopeId(callerKey);
+  const events = canonicalize(messagesWithResponse);
+  const analysis = analyzeHistory(events, scopeId);
+  const { hashes, postBarrierRecords } = analysis;
+  if (hashes.length === 0) return null;
+
+  const pairWindow = hashes.slice(-PAIR_WINDOW_SIZE);
+  const ttl = getTtl(env);
+  const now = Date.now();
+
+  // Compute commitKey for idempotency
+  const commitKey = crypto.createHmac('sha256', SECRET)
+    .update(JSON.stringify({ scopeId, pairWindow }))
+    .digest('hex');
+
+  const existingId = commitIndex.get(commitKey);
+  if (existingId) {
+    const existing = statesById.get(existingId);
+    if (existing && now - existing.lastSeen < ttl) {
+      existing.lastSeen = now;
+      return existing.sessionId;
+    }
+  }
+
+  // Find existing state to update (by overlap)
+  let target = null;
+  const seen = new Set();
+  for (let i = hashes.length - 1; i >= 0; i--) {
+    const idxKey = `${scopeId}:${hashes[i]}`;
+    const candidates = pairIndex.get(idxKey);
+    if (!candidates) continue;
+    for (const stateId of candidates) {
+      if (seen.has(stateId)) continue;
+      seen.add(stateId);
+      const state = statesById.get(stateId);
+      if (!state || now - state.lastSeen > ttl) continue;
+      const score = overlapScore(hashes, state.pairWindow);
+      if (score > 0) { target = { state, stateId }; break; }
+    }
+    if (target) break;
+  }
+
+  if (target) {
+    // Update existing state
+    target.state.lastSeen = now;
+    target.state.pairWindow = pairWindow;
+    target.state.pairRecords = postBarrierRecords.slice(-PAIR_WINDOW_SIZE);
+    target.state.commitKey = commitKey;
+    commitIndex.set(commitKey, target.stateId);
+    indexState(target.stateId, target.state);
+    return target.state.sessionId;
+  }
+
+  // Turn-1 commit: no pair matched yet, but resolveSessionId already minted a
+  // provisional state under this dialog's root anchor. Claim it so the id chosen
+  // on turn 1 carries into the pair chain (stable from turn 1). Only an UNCLAIMED
+  // provisional (empty pairWindow) is reusable — a second dialog with the same
+  // opener finds this one already claimed and forks into a fresh state below.
+  const rootKey = rootAnchorKey(scopeId, analysis);
+  if (rootKey) {
+    const rootCandidates = pairIndex.get(rootKey);
+    if (rootCandidates) {
+      for (const sid of rootCandidates) {
+        const state = statesById.get(sid);
+        if (!state || now - state.lastSeen > ttl) continue;
+        if (state.pairWindow.length > 0) continue; // already claimed by another dialog
+        state.lastSeen = now;
+        state.pairWindow = pairWindow;
+        state.pairRecords = postBarrierRecords.slice(-PAIR_WINDOW_SIZE);
+        state.commitKey = commitKey;
+        if (!state.dialogAnchor) state.dialogAnchor = pairWindow[0]?.slice(0, 16) || null;
+        commitIndex.set(commitKey, sid);
+        indexState(sid, state);
+        return state.sessionId;
+      }
+    }
+  }
+
+  // Create new state (shouldn't normally happen if resolve was called first)
+  clearExpired(env);
+  enforceCapacity(env);
+  const sessionId = crypto.randomUUID();
+  const stateId = crypto.randomUUID();
+  const dialogAnchor = pairWindow[0]?.slice(0, 16) || null;
+  const state = { stateId, scopeId, sessionId, pairWindow, pairRecords: postBarrierRecords.slice(-PAIR_WINDOW_SIZE), lastSeen: now, commitKey, dialogAnchor };
+  statesById.set(stateId, state);
+  commitIndex.set(commitKey, stateId);
+  indexState(stateId, state);
+  return sessionId;
+}
+
+// ─── Periodic Cleanup ──────────────────────────────────────────────────────
+
+const _cleanupInterval = setInterval(() => clearExpired(), CLEANUP_INTERVAL);
+if (_cleanupInterval.unref) _cleanupInterval.unref();
+
+// ─── Test Helpers ──────────────────────────────────────────────────────────
+
+export function _resetForTests() {
+  statesById.clear();
+  pairIndex.clear();
+  commitIndex.clear();
+}
+
+export function _getStoreSize() {
+  return statesById.size;
+}

--- a/test/session-continuity.test.js
+++ b/test/session-continuity.test.js
@@ -1,0 +1,381 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  resolveSessionId,
+  commitAfterResponse,
+  isSessionReuseEnabled,
+  buildPairHashes,
+  canonicalize,
+  normalizeToolLinkage,
+  analyzeHistory,
+  _resetForTests,
+  _getStoreSize,
+} from '../src/session-continuity.js';
+
+const ENV = { DEVIN_CONNECT_SESSION_REUSE: '1' };
+
+describe('session-continuity: gate', () => {
+  it('isSessionReuseEnabled respects env values', () => {
+    assert.equal(isSessionReuseEnabled({ DEVIN_CONNECT_SESSION_REUSE: '1' }), true);
+    assert.equal(isSessionReuseEnabled({ DEVIN_CONNECT_SESSION_REUSE: 'true' }), true);
+    assert.equal(isSessionReuseEnabled({ DEVIN_CONNECT_SESSION_REUSE: 'YES' }), true);
+    assert.equal(isSessionReuseEnabled({ DEVIN_CONNECT_SESSION_REUSE: 'on' }), true);
+    assert.equal(isSessionReuseEnabled({ DEVIN_CONNECT_SESSION_REUSE: '0' }), false);
+    assert.equal(isSessionReuseEnabled({}), false);
+  });
+
+  it('resolveSessionId returns null when disabled', () => {
+    assert.equal(resolveSessionId('caller', [{ role: 'user', content: 'hi' }], {}), null);
+  });
+});
+
+describe('session-continuity: canonicalization', () => {
+  beforeEach(() => _resetForTests());
+  afterEach(() => _resetForTests());
+
+  it('excludes system and developer messages', () => {
+    const events = canonicalize([
+      { role: 'system', content: 'sys' },
+      { role: 'developer', content: 'dev' },
+      { role: 'user', content: 'hi' },
+    ]);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].role, 'user');
+  });
+
+  it('decomposes tool_calls into individual events', () => {
+    const events = canonicalize([
+      { role: 'assistant', tool_calls: [
+        { id: 'c1', function: { name: 'read', arguments: '{"f":"a.js"}' } },
+        { id: 'c2', function: { name: 'write', arguments: '{}' } },
+      ]},
+    ]);
+    assert.equal(events.length, 2);
+    assert.equal(events[0].kind, 'tool_call');
+    assert.equal(events[0].payload.name, 'read');
+    assert.equal(events[1].payload.name, 'write');
+  });
+
+  it('anchors empty assistant turn as empty_output', () => {
+    const events = canonicalize([{ role: 'assistant', content: '' }]);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].kind, 'empty_output');
+  });
+
+  it('tool results carry rawLink from tool_call_id', () => {
+    const events = canonicalize([{ role: 'tool', tool_call_id: 'call-7', content: 'ok' }]);
+    assert.equal(events[0].payload.rawLink, 'call-7');
+  });
+});
+
+describe('session-continuity: tool linkage normalization', () => {
+  beforeEach(() => _resetForTests());
+  afterEach(() => _resetForTests());
+
+  it('replaces rawLink with semantic slot descriptors', () => {
+    const events = [
+      { role: 'assistant', kind: 'tool_call', payload: { name: 'search', arguments: '{}', rawLink: 'raw-A' } },
+      { role: 'tool', kind: 'tool_result', payload: { rawLink: 'raw-A', content: 'found' } },
+    ];
+    const normalized = normalizeToolLinkage(events);
+    assert.equal(normalized[0].payload.slot, 'slot:0');
+    assert.ok(!('rawLink' in normalized[0].payload));
+    assert.equal(normalized[1].payload.slot, 'slot:0');
+    assert.equal(normalized[1].payload.name, 'search');
+    assert.equal(normalized[1].payload.content, 'found');
+  });
+
+  it('marks orphan tool_result as unlinked', () => {
+    const events = [
+      { role: 'tool', kind: 'tool_result', payload: { rawLink: 'unknown', content: 'x' } },
+    ];
+    const normalized = normalizeToolLinkage(events);
+    assert.deepEqual(normalized[0].payload, { unlinked: true, content: 'x' });
+  });
+
+  it('duplicate result with same rawLink becomes unlinked', () => {
+    const events = [
+      { role: 'assistant', kind: 'tool_call', payload: { name: 'a', arguments: '{}', rawLink: 'dup' } },
+      { role: 'tool', kind: 'tool_result', payload: { rawLink: 'dup', content: 'first' } },
+      { role: 'tool', kind: 'tool_result', payload: { rawLink: 'dup', content: 'second' } },
+    ];
+    const normalized = normalizeToolLinkage(events);
+    assert.equal(normalized[1].payload.slot, 'slot:0');
+    assert.deepEqual(normalized[2].payload, { unlinked: true, content: 'second' });
+  });
+
+  it('different tool_call_ids with same semantics produce identical normalized pairs', () => {
+    const make = (id) => canonicalize([
+      { role: 'user', content: 'do it' },
+      { role: 'assistant', tool_calls: [{ id, function: { name: 'search', arguments: '{"q":"x"}' } }] },
+      { role: 'tool', tool_call_id: id, content: 'result' },
+      { role: 'assistant', content: 'done' },
+    ]);
+    const a = normalizeToolLinkage(make('call-AAA'));
+    const b = normalizeToolLinkage(make('call-ZZZ'));
+    assert.deepEqual(a, b);
+  });
+});
+
+describe('session-continuity: barrier detection', () => {
+  beforeEach(() => _resetForTests());
+  afterEach(() => _resetForTests());
+
+  it('trailing unlinked tool_result blocks resolve', () => {
+    const events = canonicalize([
+      { role: 'user', content: 'search' },
+      { role: 'assistant', tool_calls: [{ id: 'c1', function: { name: 'search', arguments: '{}' } }] },
+      { role: 'tool', tool_call_id: 'c99', content: 'orphan' }, // wrong id → unlinked
+    ]);
+    const { canResolve, hasTrailingBarrier } = analyzeHistory(events, 'scope');
+    assert.equal(hasTrailingBarrier, true);
+    assert.equal(canResolve, false);
+  });
+
+  it('barrier resets the pair chain suffix', () => {
+    const events = canonicalize([
+      { role: 'user', content: 'A' },
+      { role: 'assistant', tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }] },
+      { role: 'tool', tool_call_id: 'c99', content: 'orphan' }, // barrier
+      { role: 'assistant', content: 'recovered' },
+      { role: 'user', content: 'B' },
+      { role: 'assistant', content: 'answer B' },
+    ]);
+    const { hashes, lastBarrierIndex } = analyzeHistory(events, 'scope');
+    assert.ok(lastBarrierIndex >= 0);
+    // Only post-barrier pairs are in hashes
+    assert.ok(hashes.length > 0);
+    assert.ok(hashes.length < 3); // not all pairs
+  });
+});
+
+describe('session-continuity: resolve + commit lifecycle', () => {
+  beforeEach(() => _resetForTests());
+  afterEach(() => _resetForTests());
+
+  it('20 tool iterations remain stable session_id', () => {
+    let messages = [
+      { role: 'system', content: 'You are a coding assistant.' },
+      { role: 'user', content: 'Refactor the auth module for better security' },
+      { role: 'assistant', content: 'Starting analysis.' },
+    ];
+
+    const firstId = resolveSessionId('caller1', messages, ENV);
+    assert.ok(firstId);
+    // Commit after first response
+    commitAfterResponse('caller1', messages, ENV);
+
+    for (let i = 0; i < 20; i++) {
+      messages = [
+        ...messages,
+        { role: 'user', content: `Continue step ${i}` },
+        { role: 'assistant', tool_calls: [{ id: `tc-${i}`, function: { name: `tool_${i}`, arguments: `{"i":${i}}` } }] },
+        { role: 'tool', tool_call_id: `tc-${i}`, content: `result_${i}` },
+        { role: 'assistant', content: `Done step ${i}.` },
+      ];
+      const id = resolveSessionId('caller1', messages, ENV);
+      assert.equal(id, firstId, `iteration ${i}: session_id must remain stable`);
+      commitAfterResponse('caller1', messages, ENV);
+    }
+  });
+
+  it('different conversations get different session_ids', () => {
+    const a = [{ role: 'user', content: 'task A' }, { role: 'assistant', content: 'A' }];
+    const b = [{ role: 'user', content: 'task B' }, { role: 'assistant', content: 'B' }];
+    const idA = resolveSessionId('caller1', a, ENV);
+    const idB = resolveSessionId('caller1', b, ENV);
+    assert.notEqual(idA, idB);
+  });
+
+  it('different callerKeys get different session_ids', () => {
+    const msgs = [{ role: 'user', content: 'hi' }, { role: 'assistant', content: 'hello' }];
+    const id1 = resolveSessionId('caller1', msgs, ENV);
+    const id2 = resolveSessionId('caller2', msgs, ENV);
+    assert.notEqual(id1, id2);
+  });
+
+  it('system prompt changes do not break session identity', () => {
+    const msgs1 = [{ role: 'system', content: 'v1' }, { role: 'user', content: 'hi' }, { role: 'assistant', content: 'hey' }];
+    const msgs2 = [{ role: 'system', content: 'v2 totally different' }, { role: 'user', content: 'hi' }, { role: 'assistant', content: 'hey' }];
+    const id1 = resolveSessionId('caller1', msgs1, ENV);
+    const id2 = resolveSessionId('caller1', msgs2, ENV);
+    assert.equal(id1, id2);
+  });
+
+  it('tool_call_id regeneration does not break session identity', () => {
+    const base = [
+      { role: 'user', content: 'do it' },
+      { role: 'assistant', tool_calls: [{ id: 'orig-id', function: { name: 'search', arguments: '{"q":"x"}' } }] },
+      { role: 'tool', tool_call_id: 'orig-id', content: 'found' },
+      { role: 'assistant', content: 'done' },
+    ];
+    const id1 = resolveSessionId('caller1', base, ENV);
+    commitAfterResponse('caller1', base, ENV);
+
+    const replayed = [
+      { role: 'user', content: 'do it' },
+      { role: 'assistant', tool_calls: [{ id: 'new-id-after-retry', function: { name: 'search', arguments: '{"q":"x"}' } }] },
+      { role: 'tool', tool_call_id: 'new-id-after-retry', content: 'found' },
+      { role: 'assistant', content: 'done' },
+      { role: 'user', content: 'next' },
+    ];
+    const id2 = resolveSessionId('caller1', replayed, ENV);
+    assert.equal(id2, id1, 'regenerated tool_call_id must not break session identity');
+  });
+
+  it('idempotent commit returns same sessionId', () => {
+    const msgs = [{ role: 'user', content: 'hi' }, { role: 'assistant', content: 'hey' }];
+    const id1 = commitAfterResponse('caller1', msgs, ENV);
+    const id2 = commitAfterResponse('caller1', msgs, ENV);
+    assert.equal(id1, id2);
+  });
+
+  it('LRU eviction keeps store bounded', () => {
+    const env = { ...ENV, DEVIN_CONNECT_SESSION_MAX_STATES: '5' };
+    for (let i = 0; i < 10; i++) {
+      const msgs = [{ role: 'user', content: `q${i}` }, { role: 'assistant', content: `a${i}` }];
+      resolveSessionId(`caller-${i}`, msgs, env);
+    }
+    assert.ok(_getStoreSize() <= 6); // 5 + possible no-pair state
+  });
+});
+
+describe('session-continuity: overlap, drift, TTL, pair hashing', () => {
+  beforeEach(() => _resetForTests());
+  afterEach(() => _resetForTests());
+
+  it('buildPairHashes is stable per conversation and scoped per callerKey', () => {
+    const msgs = [
+      { role: 'user', content: 'A1' },
+      { role: 'assistant', content: 'O1' },
+      { role: 'user', content: 'A2' },
+    ];
+    const a = buildPairHashes('caller1', msgs);
+    const b = buildPairHashes('caller1', msgs);
+    assert.deepEqual(a.hashes, b.hashes, 'same caller + history → identical hashes');
+    assert.ok(a.hashes.length === 1 && a.canResolve, 'one completed pair, resolvable');
+    const other = buildPairHashes('caller2', msgs);
+    assert.notDeepEqual(a.hashes, other.hashes, 'different callerKey → different scoped hashes');
+  });
+
+  it('tolerates assistant output drift (client truncates response text) across a 2-pair chain', () => {
+    const full = 'the quick brown fox jumps over the lazy dog and keeps going';
+    // Turn 1 + Turn 2 committed with the FULL second answer.
+    const t1 = [{ role: 'user', content: 'A1' }, { role: 'assistant', content: 'O1' }];
+    resolveSessionId('caller1', t1, ENV);
+    const id = commitAfterResponse('caller1', t1, ENV);
+    const t2 = [...t1, { role: 'user', content: 'A2' }, { role: 'assistant', content: full }];
+    commitAfterResponse('caller1', t2, ENV);
+
+    // Turn 3: the client replays A2's answer TRUNCATED to a prefix, then asks A3.
+    const truncated = 'the quick brown fox jumps over the lazy dog';
+    const t3 = [
+      { role: 'user', content: 'A1' }, { role: 'assistant', content: 'O1' },
+      { role: 'user', content: 'A2' }, { role: 'assistant', content: truncated },
+      { role: 'user', content: 'A3' },
+    ];
+    const resolved = resolveSessionId('caller1', t3, ENV);
+    assert.equal(resolved, id, 'drifted (prefix-truncated) output still resolves the same session');
+  });
+
+  it('a semantically different answer does NOT resolve to the drifted session', () => {
+    const t1 = [{ role: 'user', content: 'A1' }, { role: 'assistant', content: 'O1' }];
+    resolveSessionId('caller1', t1, ENV);
+    commitAfterResponse('caller1', t1, ENV);
+    const t2 = [...t1, { role: 'user', content: 'A2' }, { role: 'assistant', content: 'the original committed answer text' }];
+    commitAfterResponse('caller1', t2, ENV);
+
+    const different = [
+      { role: 'user', content: 'A1' }, { role: 'assistant', content: 'O1' },
+      { role: 'user', content: 'A2' }, { role: 'assistant', content: 'a completely unrelated different answer' },
+      { role: 'user', content: 'A3' },
+    ];
+    const before = _getStoreSize();
+    resolveSessionId('caller1', different, ENV);
+    assert.ok(_getStoreSize() > before, 'a genuinely different answer forks a new session, not a drift match');
+  });
+
+  it('an expired state (TTL) is evicted and yields a fresh session_id', () => {
+    const env = { ...ENV, DEVIN_CONNECT_SESSION_TTL_MS: '1' };
+    const t1 = [{ role: 'user', content: 'A1' }, { role: 'assistant', content: 'O1' }];
+    const id1 = resolveSessionId('caller1', t1, env);
+    commitAfterResponse('caller1', t1, env);
+    const t2 = [...t1, { role: 'user', content: 'A2' }];
+    // Busy-wait past the 1ms TTL so the stored state is stale on the next resolve.
+    const spinUntil = Date.now() + 5;
+    while (Date.now() < spinUntil) { /* let the TTL lapse */ }
+    const id2 = resolveSessionId('caller1', t2, env);
+    assert.notEqual(id2, id1, 'a resolve after the TTL lapses must not reuse the expired session');
+  });
+
+  it('resumes matching only after the last barrier (post-barrier pair resolves)', () => {
+    // History with an orphan tool_result barrier, then a clean post-barrier pair.
+    const history = [
+      { role: 'user', content: 'A' },
+      { role: 'assistant', tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }] },
+      { role: 'tool', tool_call_id: 'c99', content: 'orphan' }, // barrier
+      { role: 'assistant', content: 'recovered' },
+      { role: 'user', content: 'B' },
+      { role: 'assistant', content: 'answer B' },
+    ];
+    const id = resolveSessionId('caller1', history, ENV);
+    commitAfterResponse('caller1', history, ENV);
+    // Next turn keeps the same post-barrier chain and adds a follow-up.
+    const next = [...history, { role: 'user', content: 'C' }];
+    const resolved = resolveSessionId('caller1', next, ENV);
+    assert.equal(resolved, id, 'post-barrier pair chain keeps resolving the same session');
+  });
+});
+
+describe('session-continuity: turn-1 stability (root anchor)', () => {
+  beforeEach(() => _resetForTests());
+  afterEach(() => _resetForTests());
+
+  // Drive resolve → commit → resolve exactly as the handler does, chaining the
+  // real assistant reply into the next turn's history.
+  function turn(caller, historyRef, userText, assistantText) {
+    historyRef.push({ role: 'user', content: userText });
+    const id = resolveSessionId(caller, historyRef, ENV);
+    historyRef.push({ role: 'assistant', content: assistantText });
+    commitAfterResponse(caller, historyRef, ENV);
+    return id;
+  }
+
+  it('session_id is stable FROM TURN 1 (turn1 == turn2 == turn3)', () => {
+    const h = [{ role: 'system', content: 'sys' }];
+    const id1 = turn('c1', h, 'remember X', 'ok');
+    const id2 = turn('c1', h, 'what did I say?', 'X');
+    const id3 = turn('c1', h, 'again?', 'X');
+    assert.equal(id1, id2, 'turn 2 keeps the turn-1 session_id');
+    assert.equal(id2, id3, 'turn 3 stays stable');
+  });
+
+  it('different openers get different session_ids already on turn 1', () => {
+    const idA = resolveSessionId('c1', [{ role: 'user', content: 'opener AAA' }], ENV);
+    const idB = resolveSessionId('c1', [{ role: 'user', content: 'opener BBB' }], ENV);
+    assert.notEqual(idA, idB, 'distinct first messages → distinct ids at turn 1');
+  });
+
+  it('system prompt drift does not change the turn-1 id (system excluded from the anchor)', () => {
+    const id1 = resolveSessionId('c1', [{ role: 'system', content: 'v1' }, { role: 'user', content: 'hi' }], ENV);
+    const id2 = resolveSessionId('c1', [{ role: 'system', content: 'v2 different' }, { role: 'user', content: 'hi' }], ENV);
+    assert.equal(id1, id2, 'same opener under a drifting system prompt keeps one turn-1 id');
+  });
+
+  it('identical-opener dialogs collide on turn 1 then fork at turn 2 (graceful, no independence regression)', () => {
+    // Dialog 1 claims the root anchor.
+    const h1 = [];
+    const d1t1 = turn('c1', h1, 'same opener', 'reply one');
+    const d1t2 = turn('c1', h1, 'continue 1', 'more one');
+    assert.equal(d1t1, d1t2, 'dialog 1 is stable from turn 1');
+
+    // Dialog 2 on the SAME caller with a byte-identical opener: shares the id on
+    // turn 1 (unavoidable — no other signal), but a DIFFERENT turn-1 answer forks
+    // it onto its own id at turn 2 (the root anchor is already claimed by dialog 1).
+    const h2 = [];
+    const d2t1 = turn('c1', h2, 'same opener', 'reply two');
+    assert.equal(d2t1, d1t1, 'turn-1 collision on an identical opener is expected');
+    const d2t2 = turn('c1', h2, 'continue 2', 'more two');
+    assert.notEqual(d2t2, d1t2, 'once diverged, the two dialogs hold independent ids');
+  });
+});


### PR DESCRIPTION
## 中文 TL;DR
实验性、默认关闭。从对话自身的「请求/响应 pair 链」推导稳定 session_id，让一个多轮对话
复用一个 session_id，而不是每轮 randomUUID —— 降低对 upstream velocity limiter 的压力。
关闭时与现状字节一致。身份仅来自客户端可见的输入/输出，绝不用 requestId/IP/时间戳。
已在真实 upstream 上验证：**从第 1 轮就稳定**。

## Summary
Discussed in #222. Self-contained, **opt-in**, experimental. Identity is derived
**only** from client-visible input/output pair fingerprints — never `requestId` /
session / IP / timestamp / provider signature.

## Design (survives real-world drift)
- `tool_call_id` regeneration (retry / combo switch) — matched by semantic slot+name+args
- system-prompt changes — excluded from identity
- response truncation — output-drift tolerance in the resolver
- parallel dialogs on one key — independent pair chains
- orphan `tool_result` — barrier blocks resolve/commit
- **stable from turn 1** — the session is anchored on the dialog's first input turn
  (root anchor), then carried into the pair chain via a provisional-claim rule;
  distinct openers get distinct ids at turn 1, identical openers collide only
  transiently and fork at turn 2

## Safety
- Gate default **OFF** → `resolveSessionId` returns null → fresh per-request uuid (unchanged).
- In-memory only, TTL 30 min, LRU cap 500. Zero npm deps (`node:crypto`).
- Commits are best-effort / try-caught — telemetry never breaks a real request.

## Test plan
- [x] `test/session-continuity.test.js`: **28/28** (gate, multi-format canonicalization,
      tool linkage, barriers, 20-iteration stability, drift, TTL, LRU, turn-1 stability)
- [x] Full suite: `npm test` → **2789 pass / 0 fail**
- [x] **Live smoke, real upstream (`glm-5.2`)**: two 3-turn dialogs → dialog A
      `84e69d07…` ×3, dialog B `e6fcf628…` ×3 — one session_id per dialog for its
      whole life (stable from turn 1), independent across dialogs, all `HTTP 200`,
      zero rate-limit/error. Upstream accepts the reused session_id, dialog intact.

## Note
This is a large but cohesive feature patch behind an off-by-default gate. Whether
reuse measurably lowers `429` frequency over long runs is the open question tracked
in #222; happy to iterate on the direction before merge.
