### PR TITLE
fix(messages): omit empty thinking signature instead of signature: "" (strict clients reject it)

### DIFF
--- a/src/handlers/messages.js
+++ b/src/handlers/messages.js
@@ -749,19 +749,21 @@ export function openAIToAnthropic(result, model, msgId, cachePolicy = null, stop
   const usage = result.usage || {};
   const content = [];
   if (choice?.message?.reasoning_content) {
-    // Anthropic thinking blocks carry an opaque encrypted `signature` that the
-    // *real* Anthropic server decrypts on multi-turn replay. Our upstream
-    // (Devin #9 / Cascade) never emits one, so this is a proxy-synthesized
-    // placeholder — the empty string is the Foxfishc-verified safe fallback
-    // (client SDK accepts it; nothing on our path decrypts/verifies it because
-    // the client only round-trips it and we discard thinking history inbound).
-    // It is NOT a genuine Anthropic signature. If upstream ever supplies a real
-    // signature we forward it (forward-compat for a future thinking/paid model).
-    content.push({
+    // Anthropic thinking blocks may carry an opaque encrypted `signature` that
+    // the *real* Anthropic server decrypts on multi-turn replay. Our upstream
+    // (Devin #9 / Cascade) never emits one, so when it is missing we omit the
+    // field entirely rather than emitting an empty-string placeholder — some
+    // strict clients (e.g. Grok Build's messages backend) reject `signature: ""`
+    // as a missing/invalid value. If upstream ever supplies a real signature we
+    // forward it (forward-compat for a future thinking/paid model).
+    const thinkingBlock = {
       type: 'thinking',
       thinking: choice.message.reasoning_content,
-      signature: choice.message.reasoning_signature || '',
-    });
+    };
+    if (choice.message.reasoning_signature) {
+      thinkingBlock.signature = choice.message.reasoning_signature;
+    }
+    content.push(thinkingBlock);
   }
   if (choice?.message?.tool_calls?.length) {
     if (choice.message.content) content.push({ type: 'text', text: choice.message.content });
@@ -965,11 +967,12 @@ class AnthropicStreamTranslator {
     // abnormal cutoff (network drop / upstream abort / deadline) — see BUG1.
     this.sawTerminalSignal = false;
     this.pendingSseBuf = '';
-    // Anthropic requires a thinking block to close with a `signature_delta`
-    // (before content_block_stop) carrying the encrypted-thinking signature.
-    // Our upstream never produces one, so we emit the empty-string fallback
-    // (proxy-synthesized, NOT a real Anthropic signature). If a future upstream
-    // delta supplies delta.reasoning_signature we round-trip the real value.
+    // Anthropic streams close a thinking block with a `signature_delta` carrying
+    // the encrypted-thinking signature. Our upstream never produces one, so we
+    // keep the pending signature empty and only emit the delta if a real
+    // `delta.reasoning_signature` arrives. An empty-string fallback is omitted
+    // because strict clients (e.g. Grok Build's messages backend) reject
+    // `signature: ""` as an invalid value.
     this.pendingThinkingSignature = '';
   }
 
@@ -1043,15 +1046,17 @@ class AnthropicStreamTranslator {
     if (this.current.type === 'tool_use') {
       this.flushToolArgs(this.toolBufForBlockIndex(this.current.index));
     }
-    // A thinking block must close with a signature_delta BEFORE content_block_stop
+    // A thinking block should close with a signature_delta BEFORE content_block_stop
     // (Anthropic sequence: start → thinking_delta* → signature_delta → stop). Only
-    // thinking blocks get it — never text/tool_use. Empty-string fallback when the
-    // upstream supplied no real signature (see constructor note).
-    if (this.current.type === 'thinking') {
+    // thinking blocks get it — never text/tool_use. We only emit the delta when
+    // the upstream actually provided a real signature; an empty-string fallback
+    // is omitted because strict clients (e.g. Grok Build's messages backend)
+    // reject `signature: ""` as invalid (see constructor note).
+    if (this.current.type === 'thinking' && this.pendingThinkingSignature) {
       this.send('content_block_delta', {
         type: 'content_block_delta',
         index: this.current.index,
-        delta: { type: 'signature_delta', signature: this.pendingThinkingSignature || '' },
+        delta: { type: 'signature_delta', signature: this.pendingThinkingSignature },
       });
       this.pendingThinkingSignature = '';
     }

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -80,10 +80,10 @@ describe('Anthropic messages request translation', () => {
     assert.equal(result.status, 200);
     assert.equal(result.body.content[0].type, 'thinking');
     assert.equal(result.body.content[0].thinking, 'plan');
-    // Anthropic thinking blocks must carry a `signature` field (empty-string
-    // proxy placeholder since upstream supplies none) so the block schema is
-    // spec-complete for the client SDK.
-    assert.equal(result.body.content[0].signature, '');
+    // When the upstream supplies no real reasoning_signature, the `signature` key
+    // is omitted entirely. Strict clients (e.g. Grok Build's messages backend)
+    // reject an empty-string placeholder as invalid.
+    assert.equal(result.body.content[0].signature, undefined);
     assert.equal(result.body.content[1].type, 'text');
     assert.equal(result.body.content[1].text, 'done');
   });
@@ -817,10 +817,11 @@ describe('Anthropic messages request translation', () => {
   });
 
   // Anthropic thinking-block sequence: content_block_start(thinking) →
-  // thinking_delta* → signature_delta → content_block_stop. The proxy emits an
-  // empty-string signature (upstream supplies none) but the event must exist and
-  // land before the block's stop.
-  it('emits exactly one signature_delta before content_block_stop for a streamed thinking block', async () => {
+  // thinking_delta* → [signature_delta] → content_block_stop. The proxy only
+  // emits a signature_delta when the upstream supplied a real reasoning_signature;
+  // otherwise the signature key is omitted so strict clients (e.g. Grok Build's
+  // messages backend) don't fail on an empty-string placeholder.
+  it('does not emit a signature_delta for a streamed thinking block without a real signature', async () => {
     const result = await handleMessages({
       model: 'claude-sonnet-4.6',
       stream: true,
@@ -852,20 +853,16 @@ describe('Anthropic messages request translation', () => {
     const thinkingIdx = thinkingStart.data.index;
 
     const sigDeltas = events.filter(e => e.event === 'content_block_delta' && e.data.delta?.type === 'signature_delta');
-    assert.equal(sigDeltas.length, 1, 'exactly one signature_delta emitted');
-    assert.equal(sigDeltas[0].data.index, thinkingIdx, 'signature_delta targets the thinking block');
-    assert.equal(sigDeltas[0].data.delta.signature, '', 'empty-string placeholder signature');
+    assert.equal(sigDeltas.length, 0, 'no signature_delta emitted without a real signature');
 
-    // Ordering: signature_delta must come AFTER all thinking_delta and BEFORE the
-    // thinking block's content_block_stop.
+    // Ordering: the thinking block's content_block_stop must come after the last
+    // thinking_delta.
     const order = events.map((e, i) => ({ i, e }));
-    const sigPos = order.find(o => o.e.event === 'content_block_delta' && o.e.data.delta?.type === 'signature_delta').i;
     const stopPos = order.find(o => o.e.event === 'content_block_stop' && o.e.data.index === thinkingIdx).i;
     const lastThinkingDeltaPos = Math.max(...order
       .filter(o => o.e.event === 'content_block_delta' && o.e.data.delta?.type === 'thinking_delta' && o.e.data.index === thinkingIdx)
       .map(o => o.i));
-    assert.ok(lastThinkingDeltaPos < sigPos, 'signature_delta comes after all thinking_delta');
-    assert.ok(sigPos < stopPos, 'signature_delta comes before content_block_stop');
+    assert.ok(lastThinkingDeltaPos < stopPos, 'content_block_stop comes after all thinking_delta');
   });
 
   it('does not emit signature_delta for text or tool_use blocks', async () => {


### PR DESCRIPTION
## 中文 TL;DR
上游从不产出 Anthropic thinking signature，代理原来发 signature:""，严格客户端
（如 Grok Build 的 messages 后端）会判为非法。改为无真实签名时省略该字段；上游给了
真实签名则原样转发。

## Summary
`signature: ""` on an Anthropic thinking block is a proxy-synthesized placeholder,
not a real Anthropic signature (our upstream never emits one). Some strict clients
reject the empty string as invalid. Omit the field when there's no real signature;
forward a real one verbatim when upstream provides it (forward-compat).

## Fix
- `src/handlers/messages.js`:
  - non-stream `openAIToAnthropic`: build the thinking block without `signature`
    unless `reasoning_signature` is present.
  - `AnthropicStreamTranslator`: emit `signature_delta` only when a real
    `delta.reasoning_signature` arrived (drop the empty-string fallback).

## Test plan
- [x] `test/messages.test.js`: signature/delta absent without a real signature
      (non-stream + streamed); real-signature round-trip preserved
- [x] `test/anthropic-input-validation.test.js`: no regressions
- [x] Full suite: `npm test` → **2761 pass / 0 fail**

Branch is on current `master` (`v3.5.0`), applies cleanly.
