### PR TITLE
fix(responses): emit input_tokens_details / output_tokens_details in Responses usage

### DIFF
--- a/src/handlers/responses.js
+++ b/src/handlers/responses.js
@@ -445,10 +445,28 @@ export function responsesToChat(body) {
 }
 
 function mapUsage(usage = {}) {
+  const inputTokens = usage.prompt_tokens || usage.input_tokens || 0;
+  const outputTokens = usage.completion_tokens || usage.output_tokens || 0;
+  const totalTokens = usage.total_tokens || inputTokens + outputTokens;
+  const promptDetails = usage.prompt_tokens_details || {};
+  const completionDetails = usage.completion_tokens_details || {};
+  const cachedTokens = promptDetails.cached_tokens || 0;
+  const reasoningTokens = completionDetails.reasoning_tokens || 0;
   return {
-    input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
-    output_tokens: usage.completion_tokens || usage.output_tokens || 0,
-    total_tokens: usage.total_tokens || (usage.prompt_tokens || usage.input_tokens || 0) + (usage.completion_tokens || usage.output_tokens || 0),
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: totalTokens,
+    input_tokens_details: {
+      text_tokens: promptDetails.text_tokens ?? Math.max(0, inputTokens - cachedTokens),
+      audio_tokens: promptDetails.audio_tokens || 0,
+      image_tokens: promptDetails.image_tokens || 0,
+      cached_tokens: cachedTokens,
+    },
+    output_tokens_details: {
+      text_tokens: completionDetails.text_tokens ?? Math.max(0, outputTokens - reasoningTokens),
+      audio_tokens: completionDetails.audio_tokens || 0,
+      reasoning_tokens: reasoningTokens,
+    },
   };
 }
 

--- a/test/responses.test.js
+++ b/test/responses.test.js
@@ -343,7 +343,54 @@ describe('chatToResponse', () => {
       role: 'assistant',
       content: [{ type: 'output_text', text: 'Hi', annotations: [] }],
     });
-    assert.deepEqual(response.usage, { input_tokens: 10, output_tokens: 2, total_tokens: 12 });
+    assert.deepEqual(response.usage, {
+      input_tokens: 10,
+      output_tokens: 2,
+      total_tokens: 12,
+      input_tokens_details: { text_tokens: 10, audio_tokens: 0, image_tokens: 0, cached_tokens: 0 },
+      output_tokens_details: { text_tokens: 2, audio_tokens: 0, reasoning_tokens: 0 },
+    });
+  });
+
+  it('derives text_tokens by subtracting cached/reasoning from the totals', () => {
+    const response = chatToResponse({
+      id: 'chatcmpl_2',
+      created: 123,
+      model: 'claude-sonnet-4.6',
+      choices: [{ index: 0, message: { role: 'assistant', content: 'Hi' }, finish_reason: 'stop' }],
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 40,
+        total_tokens: 140,
+        prompt_tokens_details: { cached_tokens: 30, image_tokens: 5 },
+        completion_tokens_details: { reasoning_tokens: 12 },
+      },
+    }, 'claude-sonnet-4.6', 'resp_test', 'msg_test');
+    // input text_tokens = 100 - 30 cached; output text_tokens = 40 - 12 reasoning.
+    assert.deepEqual(response.usage, {
+      input_tokens: 100,
+      output_tokens: 40,
+      total_tokens: 140,
+      input_tokens_details: { text_tokens: 70, audio_tokens: 0, image_tokens: 5, cached_tokens: 30 },
+      output_tokens_details: { text_tokens: 28, audio_tokens: 0, reasoning_tokens: 12 },
+    });
+  });
+
+  it('prefers an explicit upstream text_tokens over the derived subtraction', () => {
+    const response = chatToResponse({
+      id: 'chatcmpl_3',
+      created: 123,
+      model: 'claude-sonnet-4.6',
+      choices: [{ index: 0, message: { role: 'assistant', content: 'Hi' }, finish_reason: 'stop' }],
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 40,
+        prompt_tokens_details: { cached_tokens: 30, text_tokens: 65 },
+        completion_tokens_details: { reasoning_tokens: 12, text_tokens: 25 },
+      },
+    }, 'claude-sonnet-4.6', 'resp_test', 'msg_test');
+    assert.equal(response.usage.input_tokens_details.text_tokens, 65, 'explicit input text_tokens wins over 100-30');
+    assert.equal(response.usage.output_tokens_details.text_tokens, 25, 'explicit output text_tokens wins over 40-12');
   });
 
   it('maps chat tool_calls to function_call output items', () => {
@@ -659,7 +706,13 @@ describe('handleResponses streaming', () => {
     assert.equal(events[5].data.delta, 'lo');
     assert.equal(events[6].data.text, 'Hello');
     assert.equal(events.at(-1).data.response.status, 'completed');
-    assert.deepEqual(events.at(-1).data.response.usage, { input_tokens: 3, output_tokens: 2, total_tokens: 5 });
+    assert.deepEqual(events.at(-1).data.response.usage, {
+      input_tokens: 3,
+      output_tokens: 2,
+      total_tokens: 5,
+      input_tokens_details: { text_tokens: 3, audio_tokens: 0, image_tokens: 0, cached_tokens: 0 },
+      output_tokens_details: { text_tokens: 2, audio_tokens: 0, reasoning_tokens: 0 },
+    });
   });
 
   it('emits function_call events before the message and still completes on tool_calls finish', async () => {


### PR DESCRIPTION
## 中文 TL;DR
Responses usage 之前只有 input/output/total，缺 *_tokens_details。补齐
input_tokens_details / output_tokens_details（text 由 total 减 cached/reasoning 推导，
上游若给了显式 text_tokens 则优先）。

## Summary
Spec-completeness for the OpenAI Responses API `usage` object, which strict
consumers (Grok Build, codex-style clients) expect to carry the `*_tokens_details`
breakdown.

## Fix
- `src/handlers/responses.js` `mapUsage`: emit `input_tokens_details`
  (`text` / `audio` / `image` / `cached`) and `output_tokens_details`
  (`text` / `audio` / `reasoning`), deriving `text_tokens` by subtracting
  `cached` / `reasoning` from the totals and preferring an explicit upstream
  `text_tokens` when present.

## Test plan
- [x] `test/responses.test.js` +2: non-zero cached/reasoning subtraction, explicit
      `text_tokens` precedence; existing usage assertions updated to the richer shape
- [x] Full suite: `npm test` → **2763 pass / 0 fail**

Branch is on current `master` (`v3.5.0`), applies cleanly.
