### PR TITLE
fix(chat): DEVIN_CONNECT 路径补上 sticky 绑定 — 缓存亲和此前完全失效

### DIFF
--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -1807,6 +1807,33 @@ function acquireConnectFailover(triedKeys, signal, callerKey, selector = null) {
   return getApiKey(triedKeys, null, callerKey, selector);
 }
 
+// Prompt-cache affinity for the DEVIN_CONNECT path.
+//
+// setStickyBinding is otherwise only reached from the two Cascade success paths,
+// where it exists so a resumed cascade_id keeps its account. The connect path
+// never wrote a binding, so on a DEVIN_CONNECT deployment STICKY_SESSION_ENABLED=1
+// was a no-op: getApiKey's lookup ran on every turn and always missed, and the
+// candidate sort (which ends on `lastUsed` ascending) then handed each turn of a
+// conversation to a DIFFERENT account on purpose.
+//
+// Upstream prompt caches are per-account. Replaying an identical payload on a
+// second account is a fresh cache WRITE, not a read — measured on a paid Teams
+// account, three accounts in a row each reported metadata #7 tag 4 (write) for
+// the same body, while a repeat on the FIRST account reported tag 5 (read).
+// Because a write costs roughly an order of magnitude more than a read, rotating
+// mid-conversation re-pays for the whole accumulated context every turn.
+//
+// The connect path always acquires with modelKey=null (acquireConnectAccount and
+// acquireConnectFailover both pass null), so the binding MUST be written with
+// null too: bindingKey() is `callerKey\0(modelKey || '*')` and a mismatch here
+// would silently never resolve on lookup.
+export function bindConnectSticky(callerKey, acct) {
+  if (!callerKey || !acct?.id || !isStickyEnabled()) return;
+  try {
+    setStickyBinding(callerKey, null, acct.id, currentApiKeyForId(acct.id, acct.apiKey));
+  } catch { /* affinity is best-effort — never fail a served request over it */ }
+}
+
 // How many times a single DEVIN_CONNECT request may hop to a fresh pooled
 // account after a dead-token failure. 0 disables failover (same-account
 // re-login still applies). Default 2 so a request survives a couple of stale
@@ -2866,6 +2893,13 @@ async function _handleChatCompletionsInner(body, context = {}) {
               if (acct) triedKeys.push(acct.apiKey);
               const r = await attemptStream(acct);
               if (r.kind === 'ok') {
+                // Pin this conversation to the account that just served it, so the
+                // next turn reads the prompt cache back instead of re-writing it.
+                // Complementary to the pair-chain commit below: that keeps the
+                // upstream session_id stable, this keeps the ACCOUNT stable — the
+                // prompt cache lives on the account, so without both the next turn
+                // still lands elsewhere and re-writes the whole context.
+                bindConnectSticky(callerKey, acct);
                 // Session continuity: commit the completed request→response pair
                 // from the streamed result so the next turn resolves to this same
                 // session_id via pair-chain overlap. Gate-checked + best-effort
@@ -3001,6 +3035,8 @@ async function _handleChatCompletionsInner(body, context = {}) {
       if (acct) triedKeys.push(acct.apiKey);
       const r = await attempt(acct);
       if (r.kind === 'ok') {
+        // Same cache-affinity pin as the streaming path above.
+        bindConnectSticky(callerKey, acct);
         // Feed the dashboard token-usage breakdown from the DEVIN_CONNECT path
         // too. Without this the non-stream connect responses never reached
         // recordTokenUsage (only the cascade paths did), so the "Token 用量分布"

--- a/test/connect-sticky-affinity.test.js
+++ b/test/connect-sticky-affinity.test.js
@@ -1,0 +1,77 @@
+// DEVIN_CONNECT prompt-cache affinity.
+//
+// setStickyBinding was only reached from the two Cascade success paths, so on a
+// connect-only deployment STICKY_SESSION_ENABLED=1 bound nothing: getApiKey's
+// lookup missed on every turn and the candidate sort (which ends on `lastUsed`
+// ascending) then moved each turn of a conversation to a different account.
+// Upstream prompt caches are per-account, so that re-wrote the whole accumulated
+// context every turn instead of reading it back.
+//
+// The invariant this suite pins: the connect path acquires with modelKey=null
+// (acquireConnectAccount / acquireConnectFailover both pass null), so the
+// binding must be WRITTEN with null as well — bindingKey() is
+// `callerKey\0(modelKey || '*')`, and a mismatch is silent (it degrades to the
+// exact no-op this fix removes).
+//
+// ⚠️ sticky-session.js reads STICKY_SESSION_ENABLED into a module-load const, so
+// the env has to be set before the first import. node:test gives each file its
+// own process, so setting it at the top of this file is enough.
+
+process.env.STICKY_SESSION_ENABLED = '1';
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const sticky = await import('../src/account/sticky-session.js');
+const { bindConnectSticky } = await import('../src/handlers/chat.js');
+
+const CALLER = 'api:deadbeefdeadbeefdeadbeefdeadbeef:user:abc123';
+
+describe('connect sticky affinity — key shape must match the connect-path lookup', () => {
+  beforeEach(() => sticky.resetAllBindings());
+
+  it('binds under the null-modelKey slot the connect path looks up', () => {
+    bindConnectSticky(CALLER, { id: 'acct-1', apiKey: 'sk-live-1' });
+    // acquireConnectAccount / acquireConnectFailover both call getApiKey with
+    // modelKey=null, so this is the only lookup that matters for the connect path.
+    const bound = sticky.getStickyBinding(CALLER, null);
+    assert.ok(bound, 'connect-path lookup (modelKey=null) must resolve');
+    assert.equal(bound.accountId, 'acct-1');
+    assert.equal(bound.apiKey, 'sk-live-1');
+  });
+
+  it('a model-scoped binding would NOT satisfy the connect lookup (regression guard)', () => {
+    // Writing with a concrete modelKey is the mistake this fix has to avoid:
+    // bindingKey() would be `caller\0gpt-...` while the lookup asks for
+    // `caller\0*`, so every turn silently misses and rotation resumes.
+    sticky.setStickyBinding(CALLER, 'gpt-5-6-sol-max', 'acct-2', 'sk-live-2');
+    assert.equal(sticky.getStickyBinding(CALLER, null), null,
+      'model-scoped write must not be visible to the null lookup');
+  });
+
+  it('rebinds to the account that most recently served the caller', () => {
+    bindConnectSticky(CALLER, { id: 'acct-1', apiKey: 'sk-live-1' });
+    bindConnectSticky(CALLER, { id: 'acct-9', apiKey: 'sk-live-9' });
+    assert.equal(sticky.getStickyBinding(CALLER, null).accountId, 'acct-9',
+      'after a failover hop the new account owns the cache and must be pinned');
+  });
+});
+
+describe('connect sticky affinity — inert on every incomplete input', () => {
+  beforeEach(() => sticky.resetAllBindings());
+
+  it('no callerKey, no account, or no account id writes nothing', () => {
+    bindConnectSticky('', { id: 'acct-1', apiKey: 'sk-1' });
+    bindConnectSticky(CALLER, null);
+    bindConnectSticky(CALLER, undefined);
+    bindConnectSticky(CALLER, { apiKey: 'sk-1' }); // env-token fallback: no pooled id
+    // getStickyStats().creates is cumulative for the module's lifetime, so assert
+    // on the binding table itself rather than the counter.
+    assert.equal(sticky.getStickyBinding(CALLER, null), null, 'nothing may be bound');
+  });
+
+  it('never throws — affinity is best-effort and must not fail a served request', () => {
+    assert.doesNotThrow(() => bindConnectSticky(CALLER, { id: 'acct-1' }));
+    assert.doesNotThrow(() => bindConnectSticky(CALLER, { id: 'acct-1', apiKey: null }));
+  });
+});


### PR DESCRIPTION
## 问题

`setStickyBinding` 目前只在两处被调用，都在 Cascade 成功路径上（`chat.js` 里 `poolCtx` 与 `cascadeResult` 两个分支），注释也写明了意图是让 `cascade_id` 在下一轮仍然有效。

**DEVIN_CONNECT 路径从不写入绑定。** 所以在 connect 部署上设 `STICKY_SESSION_ENABLED=1` 实际是空转：

```
[sticky] CHECK  ... enabled=true
[sticky] ENTER  ...
[sticky] MISS   ...
```

开启后连续 23 次请求，23 次 CHECK / 23 次 MISS / 0 次 SET。查询一直在跑，但没有任何代码写入过绑定。

而 `getApiKey` 的候选排序以 `lastUsed` 升序收尾（最久未使用优先），所以在没有绑定的情况下，系统会**主动**把同一会话的每一轮派给不同账号。

## 为什么这很贵

上游 prompt cache 按账号隔离。用付费账号实测（`gpt-5-6-sol-max`，同一段 payload，直接钉死 token 调用以排除池子干扰）：

| 步骤 | metadata #7 | 判读 |
|---|---|---|
| 账号 A 首发 | `{2:3, 3:5, 4:1991, 6:66}` | tag4 = cache **write** |
| 账号 B 同内容 | `{2:3, 3:5, 4:1991, 6:66}` | 仍是 **write**，read 为 0 |
| 账号 A 再发 | `{2:3, 3:5, 5:1991, 6:66}` | tag5 = cache **read** |
| 账号 C 同内容 | `{2:3, 3:5, 4:1991, 6:66}` | 又是 **write** |

换账号后整段上下文必须重新全量写入。写入与读取的配额单价实测相差约一个量级，所以每轮换号 = 每轮重付整个累积上下文的成本。

对增长型对话（Codex / Claude Code 的工具循环）影响最大，因为上下文每轮都在变长。

## 修复后

同一段长对话（每轮新增约 8K token，走 `/v1/chat/completions`，带稳定的 `user` 字段）：

```
轮次 |   write  |   read
   1 |     8138 |        0     首轮建缓存
   2 |     8130 |     8138
  10 |     8130 |    73178
  22 |     8130 |   170738     write 恒为本轮增量
  23 |   186998 |        0     绑定账号额度耗尽 → 换号，全量重写
  24 |     8130 |   186998     新账号上重新建立后继续复用
```

修复前每一轮都是第 23 行那种全量重写。日志也从 0 命中变成 41/44 命中。

第 23 轮说明回退路径工作正常：绑定账号不可用时清除绑定、正常选号、重新绑定，不会拒绝服务（`stickyNoFallback=false` 时）。

## 一个容易踩的细节

连接路径取号时 `modelKey` 恒为 `null`：

```js
acquireConnectAccount  → waitForAccount(tried, signal, QUEUE_MAX_WAIT_MS, null, callerKey, selector)
acquireConnectFailover → getApiKey(triedKeys, null, callerKey, selector)
```

而 `bindingKey()` 是 `callerKey + '\0' + (modelKey || '*')`。所以绑定**必须也以 `null` 写入**，否则查询永远落在 `callerKey\0*` 而绑定落在 `callerKey\0<model>`，静默不命中 —— 退化成修复前一模一样的空转。测试里对这个失败模式加了回归守卫。

## 与 #226 pair-chain 的关系

两者互补，都需要：

- pair-chain（`commitConnectSession`）让**上游 session_id** 在多轮之间稳定。
- 本 PR 让**账号**在多轮之间稳定。

prompt cache 存在账号上，所以只有 session_id 稳定是不够的：下一轮仍会被 `lastUsed` 升序派到别的账号，缓存照样落空、整段上下文重写。反过来只有账号稳定也拿不到 session 续接的收益。

流式路径里这次把绑定放在 `commitConnectSession` 之前（同一个 `r.kind === 'ok'` 分支内），两者都是尽力而为、互不影响。

## 改动

- `src/handlers/chat.js`：新增 `bindConnectSticky(callerKey, acct)`，在流式与非流式两条 connect 成功路径各调用一次。尽力而为：入参残缺或 sticky 未开时惰性返回，内部 try/catch 保证绝不因绑定失败影响已服务的请求。
- `test/connect-sticky-affinity.test.js`：键形状契约、模型域写入的回归守卫、残缺入参惰性、不抛异常。

行为在 `STICKY_SESSION_ENABLED` 未开时**完全不变**（`isStickyEnabled()` 直接返回）。

`npm test` → **2751 passed / 0 failed**。
