### PR TITLE
fix(ci): migrate macOS x64 release runner to macos-26-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,14 +141,14 @@ jobs:
           path: dist-macos/windsurfapi-macos-arm64
           if-no-files-found: error
 
-  # macos-13 (Intel) runner pool is shrinking as GitHub migrates to ARM.
-  # x64 can queue for hours — it is NOT in the release `needs` so it never
+  # Use an explicit Intel label so the x64 build does not move to ARM.
+  # It is NOT in the release `needs`, so a failed or delayed x64 build never
   # blocks the release. If it finishes in time its artifact is picked up;
   # otherwise the release ships without the x64 binary.
   macos-exe-x64:
     name: macOS single-binary (x64 — non-blocking)
     needs: test
-    runs-on: macos-13
+    runs-on: macos-26-intel
     continue-on-error: true
     timeout-minutes: 45
     permissions:
@@ -341,7 +341,7 @@ jobs:
           name: windsurfapi-macos-arm64
           path: dist-macos
 
-      - name: Download macOS x64 binary (optional — macos-13 runner may be slow)
+      - name: Download macOS x64 binary (optional)
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:


### PR DESCRIPTION
## 改了什么 / What changed

- Replace the retired `macos-13` runner used by the macOS x64 release job with `macos-26-intel`.
- Update the related comments while preserving the existing non-blocking x64 release behavior.

## 为什么 / Why

GitHub shut down the macOS 13 runner image on December 4, 2025:
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

`macos-26-intel` is the current supported macOS 26 x64 runner label:
https://github.com/actions/runner-images#available-images

## 测试 / Testing

- Parsed `.github/workflows/release.yml` successfully with Ruby YAML.
- `git diff --check` passes.
- No application tests were run because this only changes the GitHub Actions runner image.

## Checklist

- [x] 代码风格和现有文件一致 / Code style matches existing files
- [x] 没有引入 npm 依赖 / No new npm dependencies
- [x] 不涉及 LS binary 协议 / LS binary protocol not affected
- [x] 不涉及 dashboard UI / Dashboard UI not affected