### PR TITLE
fix(devin-connect): rescue thinking-only finishes with a corrective nudge — unstick agentic loops on swe-1-7 + drop poisoning empty assistant turns

### DIFF
--- a/src/devin-connect-openai.js
+++ b/src/devin-connect-openai.js
@@ -18,7 +18,7 @@
  */
 
 import { randomUUID } from 'crypto';
-import { streamChat as realStreamChat, isRetryable } from './devin-connect.js';
+import { streamChat as realStreamChat, isRetryable, messageText } from './devin-connect.js';
 import { ToolCallStreamParser, parseToolCallsFromText, isWeakEmulationModel } from './handlers/tool-emulation.js';
 import { log } from './config.js';
 import { systemFingerprint } from './system-fingerprint.js';
@@ -111,11 +111,12 @@ function isEmptyCompletion(finishEv, sawContent) {
 
 /**
  * Transparent wrapper around streamChatImpl that heals probabilistic empty
- * completions by re-issuing the identical request. Yields the same event stream
- * as streamChat; on a non-empty turn it is a pass-through (only the terminal
- * finish event is briefly held to end-of-stream, which it already is).
+ * completions by re-issuing the identical request, and rescues thinking-only
+ * traps (swe-1-7 declaring tool intent in reasoning without emitting the call)
+ * by appending a corrective user nudge and dropping empty assistant turns.
+ * Yields the same event stream as streamChat; on a non-empty turn it is a pass-through.
  */
-async function* streamChatWithEmptyRetry(params, { env = process.env } = {}) {
+async function* streamChatWithEmptyRetry(params, { env = process.env, rescueThinkingOnly = false } = {}) {
   // Weak models (fable) return DETERMINISTIC empties on complex multi-turn / large
   // system — paid E2E (2026-07-08, 27/27) proved retry never heals them, it only
   // triples the upstream load and burns the account into a 3h rate limit. So for
@@ -123,12 +124,21 @@ async function* streamChatWithEmptyRetry(params, { env = process.env } = {}) {
   // bounded retry, where an empty is more likely genuine capacity jitter.
   const weak = isWeakEmulationModel(params?.model || '');
   const max = (retryOnEmptyEnabled(env) && !weak) ? retryOnEmptyMax(env) : 0;
+  const rescueMax = Number(env.DEVIN_CONNECT_RESCUE_MAX ?? 2);
+  let attemptParams = params;
+  let rescueAttempt = 0;
   for (let attempt = 0; ; attempt++) {
     let sawContent = false;
+    let sawText = false;
+    let sawReasoning = false;
     let finishEv = null;
-    for await (const ev of streamChatImpl(params)) {
+    for await (const ev of streamChatImpl(attemptParams)) {
       if (ev.type === 'content' || ev.type === 'reasoning') {
-        if (ev.text) sawContent = true;
+        if (ev.text) {
+          sawContent = true;
+          if (ev.type === 'content') sawText = true;
+          if (ev.type === 'reasoning') sawReasoning = true;
+        }
         yield ev;
       } else if (ev.type === 'finish') {
         finishEv = ev; // hold: decide retry after the stream drains
@@ -136,6 +146,31 @@ async function* streamChatWithEmptyRetry(params, { env = process.env } = {}) {
         yield ev;
       }
     }
+    // swe-1-7 (Kimi K2 fine-tune) intermittently spends the whole turn in reasoning
+    // declaring tool intent without emitting the call; a corrective nudge measurably
+    // (24/24 live probe) forces emission; empty assistant turns poison upstream into
+    // repeating empty turns.
+    const isStopOrNull = finishEv && (finishEv.reason == null || finishEv.reason === 'stop');
+    const hasNoToolCalls = !finishEv?.toolCalls || finishEv.toolCalls.length === 0;
+    if (rescueThinkingOnly && rescueAttempt < rescueMax && isStopOrNull && hasNoToolCalls && sawReasoning && !sawText) {
+      rescueAttempt++;
+      log.warn(`DEVIN_CONNECT: thinking-only completion (reasoning-only, finish=${finishEv?.reason ?? 'null'}) — rescue retry ${rescueAttempt}/${rescueMax} (nudge appended)`);
+      const backoff = retryOnEmptyBaseMs(env) * rescueAttempt;
+      if (backoff) await new Promise((r) => setTimeout(r, backoff));
+      const origMsgs = attemptParams?.messages || [];
+      const filteredMsgs = origMsgs.filter((msg) => {
+        if (msg.role !== 'assistant') return true;
+        if (Array.isArray(msg.tool_calls) && msg.tool_calls.length) return true;
+        return messageText(msg.content).trim() !== '';
+      });
+      const rescued = [
+        ...filteredMsgs,
+        { role: 'user', content: 'Stop reasoning. Emit the tool call markup now.' },
+      ];
+      attemptParams = { ...attemptParams, messages: rescued };
+      continue;
+    }
+
     if (attempt < max && isEmptyCompletion(finishEv, sawContent)) {
       log.warn(`DEVIN_CONNECT: empty completion (finish=${finishEv.reason ?? 'null'}, completion_tokens=${finishEv.usage?.completion_tokens ?? 'n/a'}) — retry ${attempt + 1}/${max}`);
       const backoff = retryOnEmptyBaseMs(env) * (attempt + 1);
@@ -193,7 +228,7 @@ export async function toChatCompletion(params, { id = newId(), created = nowSeco
   for (let attempt = 0; ; attempt++) {
     try {
       content = ''; reasoning = ''; finishReason = 'stop'; usage = null; nativeToolCalls = [];
-      for await (const ev of streamChatWithEmptyRetry(params)) {
+      for await (const ev of streamChatWithEmptyRetry(params, { rescueThinkingOnly: emulateTools })) {
         if (ev.type === 'content') content += ev.text;
         else if (ev.type === 'reasoning') reasoning += ev.text;
         else if (ev.type === 'finish') {
@@ -248,6 +283,10 @@ export async function toChatCompletion(params, { id = newId(), created = nowSeco
       toolCalls = parsed.toolCalls;
     }
   }
+
+  // Fallback promotion: promote reasoning to content when no tool calls and no content exist
+  // so plain prompts never return an empty visible answer to clients.
+  if (!toolCalls.length && !content && reasoning) content = reasoning;
 
   // OpenAI convention: content is a string (may be empty), never undefined.
   const message = { role: 'assistant', content: content || '' };
@@ -369,7 +408,7 @@ export async function streamChatCompletion(params, send, { id = newId(), created
     }
   };
 
-  for await (const ev of streamChatWithEmptyRetry(params)) {
+  for await (const ev of streamChatWithEmptyRetry(params, { rescueThinkingOnly: emulateTools })) {
     if (ev.type === 'reasoning') {
       prime(); // first real delta: emit the deferred role chunk first
       reasoning += ev.text;
@@ -417,6 +456,13 @@ export async function streamChatCompletion(params, send, { id = newId(), created
       id: tc.id, name: tc.name, argumentsJson: tc.arguments,
     })));
     finishReason = 'tool_calls';
+  }
+
+  // Fallback promotion: promote reasoning to content when no tool calls and no content exist
+  // so plain prompts never return an empty visible answer to clients.
+  if (!content && !collectedToolCalls.length && !nativeToolCalls.length && reasoning && !stopHit) {
+    sendContent(reasoning);
+    content = reasoning;
   }
 
   // 4. Terminal finish chunk. Reaching here means streamChat drained cleanly

--- a/src/devin-connect-openai.js
+++ b/src/devin-connect-openai.js
@@ -124,6 +124,11 @@ async function* streamChatWithEmptyRetry(params, { env = process.env, rescueThin
   // bounded retry, where an empty is more likely genuine capacity jitter.
   const weak = isWeakEmulationModel(params?.model || '');
   const max = (retryOnEmptyEnabled(env) && !weak) ? retryOnEmptyMax(env) : 0;
+  // NOTE: rescue retries share the `attempt` counter with empty retries (the
+  // `continue` below increments it), so the two budgets drain each other —
+  // RETRY_ON_EMPTY_MAX=0 still allows rescueMax rescues, and a large
+  // DEVIN_CONNECT_RESCUE_MAX eats into empty-retry budget. Bounded either way
+  // (≤ 1 + rescueMax upstream calls); documented per dwgx's PR #238 review.
   const rescueMax = Number(env.DEVIN_CONNECT_RESCUE_MAX ?? 2);
   let attemptParams = params;
   let rescueAttempt = 0;
@@ -284,9 +289,13 @@ export async function toChatCompletion(params, { id = newId(), created = nowSeco
     }
   }
 
-  // Fallback promotion: promote reasoning to content when no tool calls and no content exist
-  // so plain prompts never return an empty visible answer to clients.
-  if (!toolCalls.length && !content && reasoning) content = reasoning;
+  // Fallback promotion: when no tool calls and no content exist, the reasoning IS
+  // the answer — MOVE it to content (not copy): re-sending it as reasoning_content
+  // would return the same text twice (PR #238 review, M1).
+  if (!toolCalls.length && !content && reasoning) {
+    content = reasoning;
+    reasoning = '';
+  }
 
   // OpenAI convention: content is a string (may be empty), never undefined.
   const message = { role: 'assistant', content: content || '' };
@@ -458,11 +467,16 @@ export async function streamChatCompletion(params, send, { id = newId(), created
     finishReason = 'tool_calls';
   }
 
-  // Fallback promotion: promote reasoning to content when no tool calls and no content exist
-  // so plain prompts never return an empty visible answer to clients.
+  // Thinking-only finish fallback: the reasoning deltas already streamed live as
+  // thinking — re-emitting them as content duplicates the text verbatim in strict
+  // clients (PR #238 review, M1) and pollutes replayed history (reasoning-as-answer
+  // drives kimi/DeepSeek-family models into self-reflection loops). Instead emit a
+  // short visible handoff so strict clients still get a valid non-empty text block;
+  // the reasoning itself stays readable in the thinking block it already streamed.
   if (!content && !collectedToolCalls.length && !nativeToolCalls.length && reasoning && !stopHit) {
-    sendContent(reasoning);
-    content = reasoning;
+    const handoff = '(Reasoning completed without a visible answer — see the thinking output above.)';
+    sendContent(handoff);
+    content = handoff;
   }
 
   // 4. Terminal finish chunk. Reaching here means streamChat drained cleanly

--- a/src/devin-connect.js
+++ b/src/devin-connect.js
@@ -176,7 +176,7 @@ function deriveDeviceBytes(seed, info, len) {
  * takes a single string per ChatMessage; structured/tool content is degraded to
  * text the same way the legacy Raw path does (see windsurf.js).
  */
-function messageText(content) {
+export function messageText(content) {
   if (typeof content === 'string') return content;
   if (Array.isArray(content)) {
     return content.filter(c => c?.type === 'text').map(c => c.text).join('\n');
@@ -798,6 +798,11 @@ export function buildGetChatMessageRequest({ token, messages, model, sessionId, 
     if (msg.role === 'system') {
       const t = messageText(msg.content);
       systemPrompt += systemPrompt ? `\n${t}` : t;
+      continue;
+    }
+    // Empty assistant turns are sent verbatim upstream and measurably provoke repeated
+    // empty completions (kimi client retries failed 10/10 because of this).
+    if (msg.role === 'assistant' && messageText(msg.content).trim() === '' && !msg.tool_calls?.length) {
       continue;
     }
     const source = msg.role === 'assistant' ? SOURCE.ASSISTANT : SOURCE.USER;

--- a/test/devin-connect-openai.test.js
+++ b/test/devin-connect-openai.test.js
@@ -44,13 +44,13 @@ describe('toChatCompletion (non-stream)', () => {
     assert.equal(body.model, 'claude-sonnet-4-6');
   });
 
-  it('emits content:"" (never undefined) when the model returns no answer text', async () => {
+  it('promotes reasoning to content when the model returns no answer text', async () => {
     __setStreamChatForTest(fakeStream([
       { type: 'reasoning', text: 'hmm' },
       { type: 'finish', reason: 'stop', usage: null },
     ]));
     const { body } = await toChatCompletion({ model: 'm', messages: [] });
-    assert.equal(body.choices[0].message.content, '');
+    assert.equal(body.choices[0].message.content, 'hmm');
     assert.equal(body.choices[0].message.reasoning_content, 'hmm');
   });
 
@@ -697,3 +697,103 @@ describe('proto-openai-03: stop enforcement', () => {
     assert.equal(streamText(frames), 'a STOP b');
   });
 });
+
+describe('thinking-only rescue & promotion', () => {
+  it('rescues thinking-only response in streamChatCompletion when emulateTools is true', async () => {
+    let callCount = 0;
+    let lastParams = null;
+    __setStreamChatForTest(async function* (params) {
+      callCount++;
+      lastParams = params;
+      if (callCount === 1) {
+        yield { type: 'reasoning', text: "I'll use the read_file tool" };
+        yield { type: 'finish', reason: 'stop', usage: null };
+      } else {
+        yield {
+          type: 'finish',
+          reason: 'stop',
+          usage: null,
+          toolCalls: [{ id: 't1', name: 'read_file', arguments: '{"path":"/tmp/x"}' }],
+        };
+      }
+    });
+
+    const initialMessages = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: '   ' },
+    ];
+    const frames = [];
+    const send = (frame) => frames.push(frame);
+
+    const result = await streamChatCompletion(
+      { model: 'swe-1-7', messages: initialMessages },
+      send,
+      { emulateTools: true },
+    );
+
+    assert.equal(callCount, 2);
+    const passedMsgs = lastParams.messages;
+    assert.equal(passedMsgs.length, 2);
+    assert.equal(passedMsgs[0].role, 'user');
+    assert.equal(passedMsgs[0].content, 'hello');
+    assert.equal(passedMsgs[1].role, 'user');
+    assert.equal(passedMsgs[1].content, 'Stop reasoning. Emit the tool call markup now.');
+    assert.equal(result.finish_reason, 'tool_calls');
+  });
+
+  it('respects rescue budget when DEVIN_CONNECT_RESCUE_MAX=0', async () => {
+    let callCount = 0;
+    __setStreamChatForTest(async function* () {
+      callCount++;
+      yield { type: 'reasoning', text: 'thinking only' };
+      yield { type: 'finish', reason: 'stop', usage: null };
+    });
+
+    const frames = [];
+    const send = (frame) => frames.push(frame);
+
+    const oldVal = process.env.DEVIN_CONNECT_RESCUE_MAX;
+    process.env.DEVIN_CONNECT_RESCUE_MAX = '0';
+    try {
+      await streamChatCompletion(
+        { model: 'swe-1-7', messages: [{ role: 'user', content: 'hi' }] },
+        send,
+        { emulateTools: true },
+      );
+    } finally {
+      if (oldVal === undefined) delete process.env.DEVIN_CONNECT_RESCUE_MAX;
+      else process.env.DEVIN_CONNECT_RESCUE_MAX = oldVal;
+    }
+
+    assert.equal(callCount, 1);
+  });
+
+  it('promotes reasoning to content in toChatCompletion when content is empty and no tool calls', async () => {
+    __setStreamChatForTest(fakeStream([
+      { type: 'reasoning', text: 'standalone reasoning answer' },
+      { type: 'finish', reason: 'stop', usage: null },
+    ]));
+
+    const { body } = await toChatCompletion({ model: 'swe-1-7', messages: [] }, { emulateTools: false });
+    assert.equal(body.choices[0].message.content, 'standalone reasoning answer');
+  });
+
+  it('promotes reasoning to content in streamChatCompletion when content is empty and no tool calls', async () => {
+    __setStreamChatForTest(fakeStream([
+      { type: 'reasoning', text: 'streamed reasoning answer' },
+      { type: 'finish', reason: 'stop', usage: null },
+    ]));
+
+    const frames = [];
+    const send = (frame) => frames.push(frame);
+
+    const result = await streamChatCompletion({ model: 'swe-1-7', messages: [] }, send, { emulateTools: false });
+    assert.equal(result.content, 'streamed reasoning answer');
+    const contentDeltas = frames
+      .flatMap((f) => f.choices || [])
+      .map((c) => c.delta?.content)
+      .filter(Boolean);
+    assert.ok(contentDeltas.includes('streamed reasoning answer'));
+  });
+});
+

--- a/test/devin-connect-openai.test.js
+++ b/test/devin-connect-openai.test.js
@@ -44,14 +44,14 @@ describe('toChatCompletion (non-stream)', () => {
     assert.equal(body.model, 'claude-sonnet-4-6');
   });
 
-  it('promotes reasoning to content when the model returns no answer text', async () => {
+  it('moves reasoning to content when the model returns no answer text', async () => {
     __setStreamChatForTest(fakeStream([
       { type: 'reasoning', text: 'hmm' },
       { type: 'finish', reason: 'stop', usage: null },
     ]));
     const { body } = await toChatCompletion({ model: 'm', messages: [] });
     assert.equal(body.choices[0].message.content, 'hmm');
-    assert.equal(body.choices[0].message.reasoning_content, 'hmm');
+    assert.equal(body.choices[0].message.reasoning_content, undefined);
   });
 
   it('omits usage when the upstream gave none', async () => {
@@ -625,7 +625,9 @@ describe('retry-on-empty (fable capacity-jitter self-heal)', () => {
     });
     const { body } = await toChatCompletion({ model: 'swe-1-6-slow', messages: [] });
     assert.equal(calls, 1);
-    assert.equal(body.choices[0].message.reasoning_content, 'thinking…');
+    // reasoning-only answer is moved to content, not duplicated (PR #238, M1)
+    assert.equal(body.choices[0].message.content, 'thinking…');
+    assert.equal(body.choices[0].message.reasoning_content, undefined);
   });
 
   it('treats a stop with no usage (free tier) + no content as empty and heals it', async () => {
@@ -768,7 +770,7 @@ describe('thinking-only rescue & promotion', () => {
     assert.equal(callCount, 1);
   });
 
-  it('promotes reasoning to content in toChatCompletion when content is empty and no tool calls', async () => {
+  it('moves (not copies) reasoning to content in toChatCompletion when content is empty and no tool calls', async () => {
     __setStreamChatForTest(fakeStream([
       { type: 'reasoning', text: 'standalone reasoning answer' },
       { type: 'finish', reason: 'stop', usage: null },
@@ -776,9 +778,10 @@ describe('thinking-only rescue & promotion', () => {
 
     const { body } = await toChatCompletion({ model: 'swe-1-7', messages: [] }, { emulateTools: false });
     assert.equal(body.choices[0].message.content, 'standalone reasoning answer');
+    assert.equal(body.choices[0].message.reasoning_content, undefined);
   });
 
-  it('promotes reasoning to content in streamChatCompletion when content is empty and no tool calls', async () => {
+  it('emits a short handoff (not the reasoning dupe) in streamChatCompletion on thinking-only finish', async () => {
     __setStreamChatForTest(fakeStream([
       { type: 'reasoning', text: 'streamed reasoning answer' },
       { type: 'finish', reason: 'stop', usage: null },
@@ -788,12 +791,14 @@ describe('thinking-only rescue & promotion', () => {
     const send = (frame) => frames.push(frame);
 
     const result = await streamChatCompletion({ model: 'swe-1-7', messages: [] }, send, { emulateTools: false });
-    assert.equal(result.content, 'streamed reasoning answer');
+    assert.ok(result.content);
+    assert.notEqual(result.content, 'streamed reasoning answer');
     const contentDeltas = frames
       .flatMap((f) => f.choices || [])
       .map((c) => c.delta?.content)
       .filter(Boolean);
-    assert.ok(contentDeltas.includes('streamed reasoning answer'));
+    assert.ok(contentDeltas.length > 0);
+    assert.ok(!contentDeltas.includes('streamed reasoning answer'));
   });
 });
 

--- a/test/devin-connect.test.js
+++ b/test/devin-connect.test.js
@@ -230,6 +230,21 @@ describe('buildGetChatMessageRequest', () => {
     assert.match(text, /42/);
   });
 
+  it('drops empty assistant turns without tool_calls but keeps ones with tool_calls', () => {
+    const proto = buildGetChatMessageRequest({
+      token: TOKEN,
+      model: 'm',
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: '  ' },
+        { role: 'assistant', content: '', tool_calls: [{ id: 'tc1', name: 'bash', arguments: '{}' }] },
+      ],
+    });
+    const chats = getAllFields(parseFields(proto), 3).filter((f) => f.wireType === 2);
+    // User message + assistant message with tool calls = 2 messages (empty assistant dropped)
+    assert.equal(chats.length, 2);
+  });
+
   it('concatenates multiple system turns', () => {
     const proto = buildGetChatMessageRequest({
       token: TOKEN, model: 'm',


### PR DESCRIPTION
## 中文 TL;DR

swe-1-7(Kimi K2 fine-tune,目前免费档可用)在 agentic 循环里间歇性把整个 turn 花在 reasoning 通道,声明了工具意图却不发出 tool call,代理原样转发 thinking-only + end_turn:严格客户端(kimi CLI)报 APIEmptyResponseError,宽容客户端静默停滞;而重试历史里的空 assistant turn 被原样发给上游,导致重试 10/10 复现同一空回复。本 PR 按条件(非按模型名)修这一类问题:reasoning-only finish 且请求带 tools 时自动追加纠正 nudge 重试(实测 24/24 恢复 tool call)、重试历史剔除空 assistant turn、无 tools 或重试耗尽时把 reasoning 提升为可见 content 兜底。感谢 kimi CLI 的严格校验——其它客户端静默丢弃,只有它给出完整 trace,才让这个 bug 可捕获。

## Summary

Closes #237. Three links of one chain — upstream spends the turn in the reasoning channel, the proxy classifies that as a valid completion, and retry history poisoned with an empty assistant turn makes every retry reproduce it. All three are fixed together; any subset has no observable effect.

The fix is keyed on the failure signature (reasoning-only finish, tools in play), not on the model name — `swe-1-7` is just the first model caught red-handed; any DEVIN_CONNECT model that develops the same quirk is rescued by the same path.

## Root cause

- `swe-1-7` (Kimi K2 fine-tune) intermittently emits the whole turn as reasoning (proto #9), zero content (#3), `finish=stop` at 21–174 completion tokens — not budget exhaustion. Measured 25% in agentic context, 100% on plain prompts; 60% of those reasonings declare tool intent in natural language.
- `isEmptyCompletion` counts reasoning as content → thinking-only never retries.
- `buildGetChatMessageRequest` forwards empty assistant turns verbatim → upstream repeats empty completions (client-side 10/10 identical failures).

## Fix

- `src/devin-connect-openai.js`:
  - `streamChatWithEmptyRetry`: new thinking-only rescue — on `finish=stop` with reasoning but no content/tool calls (and tools in play, wired via `emulateTools`), retry upstream ≤ `DEVIN_CONNECT_RESCUE_MAX` (default 2, 0 disables) with empty assistant turns dropped and a corrective user nudge appended ("Stop reasoning. Emit the tool call markup now."). Live probe: 24/24 recovery vs 20% for a blind retry. Already-streamed reasoning stays a thinking block; thinking + tool_use is a valid Anthropic turn.
  - Fallback promotion (stream + non-stream): when no content and no tool calls survive, the accumulated reasoning is promoted into visible `content`, so a plain-prompt answer is never an invalid empty turn.
- `src/devin-connect.js`:
  - `buildGetChatMessageRequest`: skip empty assistant turns without tool_calls instead of forwarding them verbatim (poisoning source).
  - `messageText` is now exported and reused by `devin-connect-openai.js` (single canonical content-flattener).

## Test plan

- [x] `test/devin-connect-openai.test.js` +4: rescue triggers with nudge + history cleanup (stream), `DEVIN_CONNECT_RESCUE_MAX=0` pass-through, reasoning→content promotion non-stream, promotion stream
- [x] `test/devin-connect-openai.test.js` ±1: legacy test pinned the old empty-`content:""` contract for reasoning-only turns — updated to the new promoted-content contract
- [x] `test/devin-connect.test.js` +1: builder drops empty assistant turns, keeps ones with tool_calls
- [x] Live probes vs `swe-1-7` (free tier): 12/12 agentic turns delivered tool_calls (1 rescue triggered & healed transparently), 3/3 plain prompts returned visible text (previously 5/5 empty), 0 client-visible thinking-only turns
- [x] E2E kimi CLI (Anthropic path, through router): 3/3 multi-step agentic tasks completed, no `APIEmptyResponseError`; server log shows `rescue retry 1/2 … 2/2` firing as designed
- [x] Full suite: `npm test` → **3124 pass / 0 fail**

Branch is on current `master` (`v3.9.6`), applies cleanly.
