### PR TITLE
fix(devin-connect): rescue nudge quotes the failed attempt's reasoning tail — one fresh nudge per rescue + field-0 guard (layer 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -251,6 +251,20 @@ LS_PORT=42100
 # (overflow folds into an "(other)" bucket). Default 500; 0 = unbounded.
 # STATS_MAX_MODELS=500
 #
+# Thinking-only rescue digest: when a turn finishes reasoning-only (swe-1-7
+# intermittently declares tool intent without emitting the call), the corrective
+# nudge quotes the END of that reasoning so the model resumes where it stopped.
+# Caps how many trailing reasoning chars are kept for the digest. Default 2000;
+# 0 = plain nudge without any reasoning quote.
+# DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS=2000
+#
+# Debug/probe only — replay assistant reasoning back upstream as a native
+# reasoning tag on request build. '1' = write as tag #11 (the genuine-history
+# candidate), '9' = write as tag #9 (negative control; #9 is the inbound tag).
+# Unset = byte-identical traffic (default). Live matrix (2026-08) showed
+# upstream ACCEPTS but does NOT CONSUME either field; kept for future re-probing.
+# DEVIN_CONNECT_REPLAY_REASONING=
+#
 # Validate the whole path post-deploy with:
 # API_KEY=... BASE_URL=http://127.0.0.1:3003 npm run smoke:devin-connect
 # (set CONNECT_SMOKE_REAL_CALLS=0 to run preflight only, zero billable calls)

--- a/src/devin-connect-openai.js
+++ b/src/devin-connect-openai.js
@@ -116,7 +116,7 @@ function isEmptyCompletion(finishEv, sawContent) {
  * by appending a corrective user nudge and dropping empty assistant turns.
  * Yields the same event stream as streamChat; on a non-empty turn it is a pass-through.
  */
-async function* streamChatWithEmptyRetry(params, { env = process.env, rescueThinkingOnly = false } = {}) {
+async function* streamChatWithEmptyRetry(params, { env = process.env, rescueThinkingOnly = true } = {}) {
   // Weak models (fable) return DETERMINISTIC empties on complex multi-turn / large
   // system — paid E2E (2026-07-08, 27/27) proved retry never heals them, it only
   // triples the upstream load and burns the account into a 3h rate limit. So for
@@ -147,6 +147,12 @@ async function* streamChatWithEmptyRetry(params, { env = process.env, rescueThin
   // load into a 3h rate limit. Whether fable produces reasoning-only finishes is
   // unproven either way, so this errs toward the documented account-protection.
   const rescueMax = (retryOnEmptyEnabled(env) && !weak) ? rescueConfigured : 0;
+  // Cap for the reasoning digest: the nudge quotes only the END of the reasoning,
+  // sliced once at nudge time (the consumers already hold the full reasoning text,
+  // so per-chunk trimming would only churn the GC). 0 disables the digest; a
+  // non-numeric value falls back to the default instead of silently disabling it.
+  const digestRaw = Number(env.DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS);
+  const reasoningDigestMaxChars = Number.isFinite(digestRaw) && digestRaw >= 0 ? digestRaw : 2000;
   let attemptParams = params;
   // Two speculative arms, two budgets (#240). They used to share the loop counter: the
   // rescue arm has always had its own `rescueAttempt`/`rescueMax` pair, but reaching the
@@ -172,13 +178,17 @@ async function* streamChatWithEmptyRetry(params, { env = process.env, rescueThin
     let sawContent = false;
     let sawText = false;
     let sawReasoning = false;
+    let sawReasoningText = '';
     let finishEv = null;
     for await (const ev of streamChatImpl(attemptParams)) {
       if (ev.type === 'content' || ev.type === 'reasoning') {
         if (ev.text) {
           sawContent = true;
           if (ev.type === 'content') sawText = true;
-          if (ev.type === 'reasoning') sawReasoning = true;
+          if (ev.type === 'reasoning') {
+            sawReasoning = true;
+            sawReasoningText += ev.text;
+          }
         }
         yield ev;
       } else if (ev.type === 'finish') {
@@ -191,22 +201,38 @@ async function* streamChatWithEmptyRetry(params, { env = process.env, rescueThin
     // declaring tool intent without emitting the call; a corrective nudge measurably
     // (24/24 live probe) forces emission; empty assistant turns poison upstream into
     // repeating empty turns.
+    // NOTE: Rescue triggers only when tools are present in the request (params.tools?.length > 0).
+    // Plain chat requests without tools legitimately end in reasoning/text, so rescue is skipped.
     const isStopOrNull = finishEv && (finishEv.reason == null || finishEv.reason === 'stop');
     const hasNoToolCalls = !finishEv?.toolCalls || finishEv.toolCalls.length === 0;
-    if (rescueThinkingOnly && rescueAttempt < rescueMax && isStopOrNull && hasNoToolCalls && sawReasoning && !sawText) {
+    const hasTools = Boolean(params?.tools?.length);
+    if (rescueThinkingOnly && hasTools && rescueAttempt < rescueMax && isStopOrNull && hasNoToolCalls && sawReasoning && !sawText) {
       rescueAttempt++;
       log.warn(`DEVIN_CONNECT: thinking-only completion (reasoning-only, finish=${finishEv?.reason ?? 'null'}) — rescue retry ${rescueAttempt}/${rescueMax} (nudge appended)`);
       const backoff = retryOnEmptyBaseMs(env) * rescueAttempt;
       if (backoff) await new Promise((r) => setTimeout(r, backoff));
-      const origMsgs = attemptParams?.messages || [];
+      // Rebuild from the ORIGINAL request every rescue: `params` is never mutated (each
+      // rescue constructs a fresh attemptParams below), so it always holds the client's
+      // messages. Building from attemptParams instead accumulated — previous rescues'
+      // nudges are role:'user' so the filter keeps them, and with a capped digest each
+      // stale nudge is ~2.1KB at the 2000-char default: five rescues stacked ~10.4KB
+      // of old nudges into the upstream call, each quoting reasoning the model already
+      // moved past.
+      // One rescue = exactly one fresh nudge.
+      const origMsgs = params?.messages || [];
       const filteredMsgs = origMsgs.filter((msg) => {
         if (msg.role !== 'assistant') return true;
         if (Array.isArray(msg.tool_calls) && msg.tool_calls.length) return true;
         return messageText(msg.content).trim() !== '';
       });
+      let nudgeText = 'Stop reasoning. Emit the tool call markup now.';
+      const digest = reasoningDigestMaxChars > 0 ? sawReasoningText.slice(-reasoningDigestMaxChars).trim() : '';
+      if (digest) {
+        nudgeText = `Your previous reasoning ended with: """${digest}"""\nStop reasoning. Emit the tool call markup now.`;
+      }
       const rescued = [
         ...filteredMsgs,
-        { role: 'user', content: 'Stop reasoning. Emit the tool call markup now.' },
+        { role: 'user', content: nudgeText },
       ];
       attemptParams = { ...attemptParams, messages: rescued };
       // Tell the consumer to discard what it accumulated: the next attempt REPLACES
@@ -286,7 +312,7 @@ export async function toChatCompletion(params, { id = newId(), created = nowSeco
   for (let attempt = 0; ; attempt++) {
     try {
       content = ''; reasoning = ''; finishReason = 'stop'; usage = null; nativeToolCalls = [];
-      for await (const ev of streamChatWithEmptyRetry(params, { rescueThinkingOnly: emulateTools })) {
+      for await (const ev of streamChatWithEmptyRetry(params, { rescueThinkingOnly: true })) {
         // A rescue attempt REPLACES the previous one; drop what it produced or the
         // client is handed every attempt concatenated.
         if (ev.type === 'attempt_reset') { content = ''; reasoning = ''; nativeToolCalls = []; billing = null; continue; }
@@ -511,7 +537,7 @@ export async function streamChatCompletion(params, send, { id = newId(), created
     }
   };
 
-  for await (const ev of streamChatWithEmptyRetry(params, { rescueThinkingOnly: emulateTools })) {
+  for await (const ev of streamChatWithEmptyRetry(params, { rescueThinkingOnly: true })) {
     // A rescue attempt REPLACES the previous one. The deltas already sent cannot be
     // retracted (documented at the promotion site below), but the accumulators must
     // not keep the abandoned attempt — otherwise `content` ends up holding every

--- a/src/devin-connect.js
+++ b/src/devin-connect.js
@@ -333,7 +333,7 @@ const syntheticImagePath = (n) => `C:\\windsurfapi\\image_${n + 1}.png`;
 // serde-JSON": the ENVELOPE is protobuf, only the args VALUE is JSON. Wire wins.
 // Symmetric with the response-side ChatToolCall #6{1:id,2:name,3:arguments}
 // pinned in parseToolCallTagMap.
-function encodeAssistantToolCall({ id, name, argsJson, reasoning, provider }) {
+function encodeAssistantToolCall({ id, name, argsJson, reasoning, provider, reasoningTagNum = 11 }) {
   const toolCall = Buffer.concat([
     writeStringField(1, id),
     writeStringField(2, name),
@@ -344,12 +344,15 @@ function encodeAssistantToolCall({ id, name, argsJson, reasoning, provider }) {
     writeVarintField(2, SOURCE.ASSISTANT),  // #2 role=2
     writeMessageField(6, toolCall),         // #6 tool_call submessage
   ];
-  // #11 reasoning text — VERIFIED-FROM-WIRE (req022: every role=2 assistant turn
-  // carries #11, 59B–1470B). Our default synthetic path omits it; a paid probe
-  // can inject one via DEVIN_CONNECT_IMAGE_REASONING to isolate whether the
-  // agent-loop requires it. Emitted only when a non-empty string is supplied so
-  // the default wire stays byte-identical. ← SWITCH POINT.
-  if (reasoning) parts.push(writeStringField(11, reasoning));
+  // #11 reasoning text (or custom tag, e.g. #9 for negative control RE probes) —
+  // VERIFIED-FROM-WIRE (req022: every role=2 assistant turn carries #11, 59B–1470B).
+  // Our default synthetic path omits it; a probe can inject one via
+  // DEVIN_CONNECT_IMAGE_REASONING or DEVIN_CONNECT_REPLAY_REASONING.
+  // Emitted only when a non-empty string is supplied so default wire stays byte-identical.
+  // The tag-number guard is load-bearing even though callers currently pass reasoningText
+  // only when reasoningTagNum is truthy: field 0 is RESERVED in protobuf and a zero tag
+  // would serialize makeTag(0,2) — an invalid frame — so the encoder refuses it itself.
+  if (reasoning && reasoningTagNum) parts.push(writeStringField(reasoningTagNum, reasoning));
   // #18 provider marker — VERIFIED-FROM-WIRE (req022 MSG14, the DRIVING turn:
   // #18="anthropic"). Only the final/driving assistant tool_use carried it
   // (MSG4 did not). Env-gated, default off. A synthetic #12 thinking SIGNATURE
@@ -778,9 +781,16 @@ function buildCompletionConfig({ maxTokens, temperature, topK, topP, contextWind
  * @param {object}   [params.completion]  CompletionConfig overrides
  * @returns {Buffer} raw protobuf (un-enveloped)
  */
-export function buildGetChatMessageRequest({ token, messages, model, sessionId, completion, tools, nativeToolCall = false, deviceSeed } = {}) {
+export function buildGetChatMessageRequest({ token, messages, model, sessionId, completion, tools, nativeToolCall = false, deviceSeed, env = process.env } = {}) {
   if (!token) throw new Error('DEVIN_CONNECT: missing session token');
   if (!model) throw new Error('DEVIN_CONNECT: missing model selector');
+
+  // Probe: gated replay of reasoning into tag #11 (or #9 for negative control).
+  // Fact A3 (2026-08-03): upstream swe-1-7 accepts reasoning tags (#11, #9) without error
+  // but does not consume them (0/3 effect). Kept as permanent gated RE probe tool.
+  // Reference req022: genuine Bedrock/Claude client wire where #11 actually lives on assistant turns.
+  const replayTag = String(env.DEVIN_CONNECT_REPLAY_REASONING || '').trim();
+  const reasoningTagNum = replayTag === '1' ? 11 : (replayTag === '9' ? 9 : 0);
 
   // System turns are concatenated into the dedicated system_prompt field (#2);
   // everything else becomes a repeated ChatMessage (#3).
@@ -816,18 +826,27 @@ export function buildGetChatMessageRequest({ token, messages, model, sessionId, 
     if (nativeToolCall && msg.role === 'assistant' && Array.isArray(msg.tool_calls) && msg.tool_calls.length) {
       // Optional leading assistant text stays on its own role=2 text message.
       const preText = messageText(msg.content);
+      const reasoningText = reasoningTagNum && (msg.reasoning || msg.reasoning_content) ? String(msg.reasoning || msg.reasoning_content) : '';
       if (preText) {
-        chatMessages.push(Buffer.concat([
+        const parts = [
           writeStringField(1, randomUUID()),
           writeVarintField(2, SOURCE.ASSISTANT),
           writeStringField(3, preText),
-        ]));
+        ];
+        if (reasoningText) parts.push(writeStringField(reasoningTagNum, reasoningText));
+        chatMessages.push(Buffer.concat(parts));
       }
       for (const tc of msg.tool_calls) {
         const name = tc.function?.name || tc.name || 'unknown';
         const rawArgs = tc.function?.arguments ?? tc.arguments;
         const argsJson = typeof rawArgs === 'string' ? rawArgs : JSON.stringify(rawArgs ?? {});
-        chatMessages.push(encodeAssistantToolCall({ id: tc.id || randomUUID(), name, argsJson }));
+        chatMessages.push(encodeAssistantToolCall({
+          id: tc.id || randomUUID(),
+          name,
+          argsJson,
+          reasoning: reasoningText,
+          reasoningTagNum,
+        }));
       }
       continue;
     }
@@ -862,11 +881,18 @@ export function buildGetChatMessageRequest({ token, messages, model, sessionId, 
     if (msg.role === 'tool') {
       text = `[tool result${msg.tool_call_id ? ` for ${msg.tool_call_id}` : ''}]: ${text}`;
     }
-    chatMessages.push(Buffer.concat([
+    const msgParts = [
       writeStringField(1, randomUUID()),
       writeVarintField(2, source),
       writeStringField(3, text),
-    ]));
+    ];
+    if (source === SOURCE.ASSISTANT && reasoningTagNum) {
+      const reasoningText = msg.reasoning || msg.reasoning_content;
+      if (reasoningText && String(reasoningText).trim()) {
+        msgParts.push(writeStringField(reasoningTagNum, String(reasoningText)));
+      }
+    }
+    chatMessages.push(Buffer.concat(msgParts));
   }
 
   // ★ EMPTY-SYSTEM + TOOLS GUARD (2026-07-10, verified from live devin.exe capture).
@@ -1942,7 +1968,7 @@ export async function* streamChat({
     ? tools.map((t) => t?.function?.name || t?.name).filter(Boolean)
     : null;
 
-  const proto = buildGetChatMessageRequest({ token: sessionToken, messages, model, sessionId, completion, tools, nativeToolCall, deviceSeed });
+  const proto = buildGetChatMessageRequest({ token: sessionToken, messages, model, sessionId, completion, tools, nativeToolCall, deviceSeed, env });
   // Request envelope is sent UNCOMPRESSED (flag 0). The live calibration showed
   // the server rejects a gzipped request frame with an opaque "internal" error;
   // it still streams gzipped frames back, which the parser handles.

--- a/src/handlers/messages.js
+++ b/src/handlers/messages.js
@@ -582,7 +582,12 @@ function anthropicToOpenAI(body, ccActive = false) {
             log.info(`messages: document block (${mt}) not decoded — forwarded as text placeholder`);
           }
         } else if (block.type === 'thinking') {
-          // Thinking blocks from assistant history — skip; the model will regenerate
+          // Incoming assistant thinking blocks are dropped on history translation:
+          // 1) Upstream swe-1-7 (K2 family) accepts outgoing candidate tag #11 in ChatMessage,
+          //    but causally ignores its content (0/3 causal effect; tag #9 is incoming-only).
+          // 2) Wholesale promotion (reasoning -> text content) is an industry anti-pattern
+          //    inducing self-reflection loops on Kimi/DeepSeek families.
+          // 3) Genuine Bedrock clients send #11+#12 (signature), but K2 family emits no signature.
         } else if (block.type === 'tool_use' && role === 'assistant') {
           const id = block.id || `call_${randomUUID().slice(0, 8)}`;
           toolNameById.set(id, block.name || '');

--- a/src/handlers/tool-emulation.js
+++ b/src/handlers/tool-emulation.js
@@ -988,6 +988,9 @@ export function normalizeMessagesForCascade(messages, tools, options = {}) {
       // prior calls in a foreign format and the conversation loses
       // continuity (issue #86 "上下文会丢"). Default JSON-XML still applies
       // for OpenAI/Anthropic/Gemini-style models.
+      // Note: m.reasoning_content is intentionally dropped on assistant history rebuild:
+      // upstream swe-1-7 accepts outgoing tag #11 but ignores it (0/3 causal effect),
+      // while promoting reasoning to text content creates self-reflection loops.
       for (const tc of m.tool_calls) {
         const name = tc.function?.name || 'unknown';
         const args = tc.function?.arguments;

--- a/test/devin-connect-openai.test.js
+++ b/test/devin-connect-openai.test.js
@@ -713,7 +713,9 @@ describe('proto-openai-03: stop enforcement', () => {
 });
 
 describe('thinking-only rescue & promotion', () => {
-  it('rescues thinking-only response in streamChatCompletion when emulateTools is true', async () => {
+  const SAMPLE_TOOLS = [{ type: 'function', function: { name: 'read_file' } }];
+
+  it('rescues thinking-only response in streamChatCompletion when tools are present (includes digest in nudge)', async () => {
     let callCount = 0;
     let lastParams = null;
     __setStreamChatForTest(async function* (params) {
@@ -740,7 +742,7 @@ describe('thinking-only rescue & promotion', () => {
     const send = (frame) => frames.push(frame);
 
     const result = await streamChatCompletion(
-      { model: 'swe-1-7', messages: initialMessages },
+      { model: 'swe-1-7', messages: initialMessages, tools: SAMPLE_TOOLS },
       send,
       { emulateTools: true },
     );
@@ -751,8 +753,179 @@ describe('thinking-only rescue & promotion', () => {
     assert.equal(passedMsgs[0].role, 'user');
     assert.equal(passedMsgs[0].content, 'hello');
     assert.equal(passedMsgs[1].role, 'user');
-    assert.equal(passedMsgs[1].content, 'Stop reasoning. Emit the tool call markup now.');
+    assert.equal(
+      passedMsgs[1].content,
+      'Your previous reasoning ended with: """I\'ll use the read_file tool"""\nStop reasoning. Emit the tool call markup now.',
+    );
     assert.equal(result.finish_reason, 'tool_calls');
+  });
+
+  it('caps reasoning digest at DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS (tail kept)', async () => {
+    let callCount = 0;
+    let lastParams = null;
+    const longReasoning = 'A'.repeat(150) + 'B'.repeat(50);
+    __setStreamChatForTest(async function* (params) {
+      callCount++;
+      lastParams = params;
+      if (callCount === 1) {
+        yield { type: 'reasoning', text: longReasoning };
+        yield { type: 'finish', reason: 'stop', usage: null };
+      } else {
+        yield { type: 'content', text: '<tool_call>{"name":"read_file"}</tool_call>' };
+        yield { type: 'finish', reason: 'stop', usage: null };
+      }
+    });
+
+    const oldLimit = process.env.DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS;
+    process.env.DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS = '50';
+    try {
+      await streamChatCompletion(
+        { model: 'swe-1-7', messages: [{ role: 'user', content: 'hi' }], tools: SAMPLE_TOOLS },
+        () => {},
+        { emulateTools: true },
+      );
+    } finally {
+      if (oldLimit === undefined) delete process.env.DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS;
+      else process.env.DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS = oldLimit;
+    }
+
+    assert.equal(callCount, 2);
+    const nudge = lastParams.messages.at(-1).content;
+    // Buffer is a capped tail: no truncation marker, just the last 50 chars.
+    const expectedDigest = 'B'.repeat(50);
+    assert.equal(
+      nudge,
+      `Your previous reasoning ended with: """${expectedDigest}"""\nStop reasoning. Emit the tool call markup now.`,
+    );
+  });
+
+  it('does not accumulate nudges across consecutive rescues (one fresh nudge per rescue)', async () => {
+    // Review finding on this PR: rebuilding filteredMsgs from attemptParams kept every
+    // prior rescue's nudge (role:'user' survives the empty-assistant filter), so rescue
+    // call k carried k-1 nudges. Invisible at 46 chars/nudge pre-digest, ~2.1KB each
+    // with one. Rebuild from the untouched original instead — see devin-connect-openai.js.
+    const seen = [];
+    let callCount = 0;
+    __setStreamChatForTest(async function* (params) {
+      callCount++;
+      seen.push(params.messages.map((m) => ({ role: m.role, content: m.content })));
+      if (callCount <= 3) {
+        yield { type: 'reasoning', text: `reasoning tail ${callCount}` };
+        yield { type: 'finish', reason: 'stop', usage: null };
+      } else {
+        yield { type: 'content', text: '<tool_call>{"name":"read_file"}</tool_call>' };
+        yield { type: 'finish', reason: 'stop', usage: null };
+      }
+    });
+
+    const oldMax = process.env.DEVIN_CONNECT_RESCUE_MAX;
+    process.env.DEVIN_CONNECT_RESCUE_MAX = '5';
+    try {
+      await streamChatCompletion(
+        { model: 'swe-1-7', messages: [{ role: 'user', content: 'hi' }], tools: SAMPLE_TOOLS },
+        () => {},
+        { emulateTools: true },
+      );
+    } finally {
+      if (oldMax === undefined) delete process.env.DEVIN_CONNECT_RESCUE_MAX;
+      else process.env.DEVIN_CONNECT_RESCUE_MAX = oldMax;
+    }
+
+    assert.equal(callCount, 4, 'three thinking-only attempts, then the healed one');
+    for (let k = 2; k <= 4; k++) {
+      const msgs = seen[k - 1];
+      const nudges = msgs.filter(
+        (m) => m.role === 'user' && String(m.content).startsWith('Your previous reasoning ended with'),
+      );
+      assert.equal(nudges.length, 1, `rescue call ${k} carries ${nudges.length} nudge(s), expected exactly 1`);
+      assert.equal(msgs.length, 2, `rescue call ${k} must be original message + one nudge, got ${msgs.length} messages`);
+      assert.ok(
+        nudges[0].content.includes(`reasoning tail ${k - 1}`),
+        `rescue call ${k} must quote the immediately-preceding failed attempt`,
+      );
+      if (k >= 3) {
+        assert.ok(
+          !nudges[0].content.includes(`reasoning tail ${k - 2}`),
+          `rescue call ${k} still carries the stale digest from attempt ${k - 2}`,
+        );
+      }
+    }
+  });
+
+  it('disables reasoning digest when DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS=0', async () => {
+    let callCount = 0;
+    let lastParams = null;
+    __setStreamChatForTest(async function* (params) {
+      callCount++;
+      lastParams = params;
+      if (callCount === 1) {
+        yield { type: 'reasoning', text: 'some reasoning' };
+        yield { type: 'finish', reason: 'stop', usage: null };
+      } else {
+        yield { type: 'content', text: 'ok' };
+        yield { type: 'finish', reason: 'stop', usage: null };
+      }
+    });
+
+    const oldLimit = process.env.DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS;
+    process.env.DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS = '0';
+    try {
+      await streamChatCompletion(
+        { model: 'swe-1-7', messages: [{ role: 'user', content: 'hi' }], tools: SAMPLE_TOOLS },
+        () => {},
+        { emulateTools: true },
+      );
+    } finally {
+      if (oldLimit === undefined) delete process.env.DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS;
+      else process.env.DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS = oldLimit;
+    }
+
+    assert.equal(callCount, 2);
+    assert.equal(lastParams.messages.at(-1).content, 'Stop reasoning. Emit the tool call markup now.');
+  });
+
+  it('rescues in native tool mode when tools are present (emulateTools=false)', async () => {
+    let callCount = 0;
+    __setStreamChatForTest(async function* () {
+      callCount++;
+      if (callCount === 1) {
+        yield { type: 'reasoning', text: 'I should call a tool' };
+        yield { type: 'finish', reason: 'stop', usage: null };
+      } else {
+        yield {
+          type: 'finish',
+          reason: 'stop',
+          usage: null,
+          toolCalls: [{ id: 'call_1', name: 'read_file', arguments: '{}' }],
+        };
+      }
+    });
+
+    const result = await streamChatCompletion(
+      { model: 'swe-1-7', messages: [{ role: 'user', content: 'hi' }], tools: SAMPLE_TOOLS },
+      () => {},
+      { emulateTools: false },
+    );
+
+    assert.equal(callCount, 2, 'the rescue fires on the native tool path too, not only under emulation');
+    assert.equal(result.finish_reason, 'tool_calls');
+  });
+
+  it('skips the rescue when the request carries no tools', async () => {
+    let callCount = 0;
+    __setStreamChatForTest(async function* () {
+      callCount++;
+      yield { type: 'reasoning', text: 'just thinking out loud' };
+      yield { type: 'finish', reason: 'stop', usage: null };
+    });
+
+    await streamChatCompletion(
+      { model: 'swe-1-7', messages: [{ role: 'user', content: 'hi' }] },
+      () => {},
+      { emulateTools: true },
+    );
+
+    assert.equal(callCount, 1, 'no tools in the request — a reasoning-only finish is legitimate, not a trap');
   });
 
   it('respects rescue budget when DEVIN_CONNECT_RESCUE_MAX=0', async () => {
@@ -770,7 +943,7 @@ describe('thinking-only rescue & promotion', () => {
     process.env.DEVIN_CONNECT_RESCUE_MAX = '0';
     try {
       await streamChatCompletion(
-        { model: 'swe-1-7', messages: [{ role: 'user', content: 'hi' }] },
+        { model: 'swe-1-7', messages: [{ role: 'user', content: 'hi' }], tools: SAMPLE_TOOLS },
         send,
         { emulateTools: true },
       );

--- a/test/devin-connect.test.js
+++ b/test/devin-connect.test.js
@@ -27,7 +27,8 @@ import { wrapEnvelope, endOfStreamEnvelope } from '../src/connect.js';
 import { EventEmitter } from 'node:events';
 
 const ENV_KEYS = ['DEVIN_CONNECT_TOKEN', 'WINDSURF_API_KEY', 'DEVIN_CONNECT_IMAGE_TAG',
-  'DEVIN_CONNECT_IMAGE_TOOLDEF', 'DEVIN_CONNECT_IMAGE_INNER_TAGS', 'DEVIN_CONNECT_TOOL_DEF_TAGS'];
+  'DEVIN_CONNECT_IMAGE_TOOLDEF', 'DEVIN_CONNECT_IMAGE_INNER_TAGS', 'DEVIN_CONNECT_TOOL_DEF_TAGS',
+  'DEVIN_CONNECT_REPLAY_REASONING'];
 const originalEnv = Object.fromEntries(ENV_KEYS.map(k => [k, process.env[k]]));
 
 afterEach(() => {
@@ -291,6 +292,60 @@ describe('buildGetChatMessageRequest', () => {
     const comp = parseFields(getField(parseFields(proto), 8, 2).value);
     const temp = getField(comp, 5, 1).value.readDoubleLE(0);
     assert.ok(temp > 0 && temp <= 0.001, `expected clamped epsilon, got ${temp}`);
+  });
+
+  describe('DEVIN_CONNECT_REPLAY_REASONING probe gate', () => {
+    const messages = [
+      { role: 'user', content: 'user Q' },
+      { role: 'assistant', content: 'thought text', reasoning: 'thinking 123' },
+      { role: 'assistant', content: '', reasoning_content: 'thinking 456', tool_calls: [{ id: 'tc1', name: 'bash', arguments: '{}' }] },
+    ];
+
+    it('gate unset/off: does not emit reasoning tags on assistant turns', () => {
+      delete process.env.DEVIN_CONNECT_REPLAY_REASONING;
+      const proto = buildGetChatMessageRequest({
+        token: TOKEN, model: 'm', messages, nativeToolCall: true,
+      });
+      const chats = getAllFields(parseFields(proto), 3).filter((f) => f.wireType === 2);
+      for (const chat of chats) {
+        const inner = parseFields(chat.value);
+        assert.ok(!getField(inner, 11, 2), 'no tag #11');
+        assert.ok(!getField(inner, 9, 2), 'no tag #9');
+      }
+    });
+
+    it('gate=1: emits tag #11 with reasoning text on assistant turns, user turns clean', () => {
+      process.env.DEVIN_CONNECT_REPLAY_REASONING = '1';
+      const proto = buildGetChatMessageRequest({
+        token: TOKEN, model: 'm', messages, nativeToolCall: true,
+      });
+      const chats = getAllFields(parseFields(proto), 3).filter((f) => f.wireType === 2);
+      // chat[0]: user message
+      const userInner = parseFields(chats[0].value);
+      assert.equal(getField(userInner, 2, 0).value, 1); // SOURCE.USER
+      assert.ok(!getField(userInner, 11, 2), 'user turn has no #11');
+
+      // chat[1]: assistant text turn with reasoning
+      const astTextInner = parseFields(chats[1].value);
+      assert.equal(getField(astTextInner, 2, 0).value, 2); // SOURCE.ASSISTANT
+      assert.equal(getField(astTextInner, 11, 2).value.toString('utf8'), 'thinking 123');
+
+      // chat[2]: assistant native tool call turn with reasoning
+      const astToolInner = parseFields(chats[2].value);
+      assert.equal(getField(astToolInner, 2, 0).value, 2); // SOURCE.ASSISTANT
+      assert.equal(getField(astToolInner, 11, 2).value.toString('utf8'), 'thinking 456');
+    });
+
+    it('gate=9: emits tag #9 for negative control RE probes', () => {
+      process.env.DEVIN_CONNECT_REPLAY_REASONING = '9';
+      const proto = buildGetChatMessageRequest({
+        token: TOKEN, model: 'm', messages, nativeToolCall: true,
+      });
+      const chats = getAllFields(parseFields(proto), 3).filter((f) => f.wireType === 2);
+      const astTextInner = parseFields(chats[1].value);
+      assert.ok(!getField(astTextInner, 11, 2), 'no tag #11 when gate=9');
+      assert.equal(getField(astTextInner, 9, 2).value.toString('utf8'), 'thinking 123');
+    });
   });
 });
 
@@ -2038,6 +2093,32 @@ describe('streamChat transport resetMs propagation', () => {
         assert.equal(err.resetMs, (1 * 3600 + 15 * 60) * 1000);
         return true;
       },
+    );
+  });
+});
+
+describe('encodeAssistantToolCall reasoning-tag guard (PR #241 review point 3)', () => {
+  it('refuses to serialize field 0: reasoning with tag 0 is dropped, not written', () => {
+    const base = { id: 'call_1', name: 'read_file', argsJson: '{}' };
+    // uuid field is the only random part (fixed 36 chars), so dropped-reasoning
+    // output must be byte-length-identical to a no-reasoning frame.
+    const withZero = __testing.encodeAssistantToolCall({
+      ...base, reasoning: 'some reasoning text', reasoningTagNum: 0,
+    });
+    const bare = __testing.encodeAssistantToolCall({ ...base, reasoningTagNum: 0 });
+    assert.equal(
+      withZero.length, bare.length,
+      'reasoning with a zero tag must be dropped entirely, not serialized as reserved field 0',
+    );
+    assert.equal(decodeFrame(withZero).reasoning, '', 'decoding the zero-tag frame must yield no reasoning');
+    // Regression: a legal tag still carries the reasoning payload end to end.
+    const withEleven = __testing.encodeAssistantToolCall({
+      ...base, reasoning: 'some reasoning text', reasoningTagNum: 11,
+    });
+    assert.ok(withEleven.length > bare.length, 'tag 11 reasoning must still be serialized');
+    assert.ok(
+      withEleven.indexOf(writeStringField(11, 'some reasoning text')) >= 0,
+      'tag 11 reasoning must still be serialized verbatim',
     );
   });
 });

--- a/test/messages-thinking-contract.test.js
+++ b/test/messages-thinking-contract.test.js
@@ -1,0 +1,175 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { handleMessages } from '../src/handlers/messages.js';
+
+function chatChunk(chunk) {
+  return `data: ${JSON.stringify(chunk)}\n\n`;
+}
+
+function fakeRes() {
+  const listeners = new Map();
+  return {
+    body: '',
+    writableEnded: false,
+    write(chunk) {
+      this.body += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      return true;
+    },
+    end(chunk) {
+      if (chunk) this.write(chunk);
+      this.writableEnded = true;
+      const cbs = listeners.get('close') || [];
+      for (const cb of cbs) cb();
+    },
+    on(event, cb) {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event).push(cb);
+      return this;
+    },
+  };
+}
+
+function parseAnthropicEvents(raw) {
+  return raw
+    .trim()
+    .split('\n\n')
+    .filter(Boolean)
+    .filter(frame => !frame.startsWith(':'))
+    .map(frame => {
+      const lines = frame.split('\n');
+      return {
+        event: lines.find(line => line.startsWith('event: '))?.slice(7),
+        data: JSON.parse(lines.find(line => line.startsWith('data: '))?.slice(6) || '{}'),
+      };
+    });
+}
+
+describe('Thinking outbound contract (messages handler)', () => {
+  it('(a) non-stream: reasoning_content -> thinking block, signature ONLY when reasoning_signature present', async () => {
+    // Case 1: reasoning_content without reasoning_signature (signature omitted entirely)
+    const resNoSig = await handleMessages({
+      model: 'claude-sonnet-4.6',
+      thinking: { type: 'enabled' },
+      messages: [{ role: 'user', content: 'hello' }],
+    }, {
+      async handleChatCompletions() {
+        return {
+          status: 200,
+          body: {
+            model: 'claude-sonnet-4.6',
+            choices: [{
+              index: 0,
+              message: { role: 'assistant', reasoning_content: 'thought process', content: 'hello world' },
+              finish_reason: 'stop',
+            }],
+            usage: { prompt_tokens: 10, completion_tokens: 5 },
+          },
+        };
+      },
+    });
+
+    assert.equal(resNoSig.status, 200);
+    const thinkingNoSig = resNoSig.body.content.find(c => c.type === 'thinking');
+    assert.ok(thinkingNoSig, 'thinking block should be emitted');
+    assert.equal(thinkingNoSig.thinking, 'thought process');
+    assert.equal(thinkingNoSig.signature, undefined, 'signature must be undefined when reasoning_signature is missing');
+
+    // Case 2: reasoning_content WITH reasoning_signature (signature forwarded verbatim)
+    const resWithSig = await handleMessages({
+      model: 'claude-sonnet-4.6',
+      thinking: { type: 'enabled' },
+      messages: [{ role: 'user', content: 'hello' }],
+    }, {
+      async handleChatCompletions() {
+        return {
+          status: 200,
+          body: {
+            model: 'claude-sonnet-4.6',
+            choices: [{
+              index: 0,
+              message: {
+                role: 'assistant',
+                reasoning_content: 'thought process',
+                reasoning_signature: 'valid_sig_123',
+                content: 'hello world',
+              },
+              finish_reason: 'stop',
+            }],
+            usage: { prompt_tokens: 10, completion_tokens: 5 },
+          },
+        };
+      },
+    });
+
+    assert.equal(resWithSig.status, 200);
+    const thinkingWithSig = resWithSig.body.content.find(c => c.type === 'thinking');
+    assert.ok(thinkingWithSig, 'thinking block should be emitted');
+    assert.equal(thinkingWithSig.thinking, 'thought process');
+    assert.equal(thinkingWithSig.signature, 'valid_sig_123', 'signature must match reasoning_signature');
+  });
+
+  it('(b) stream: signature_delta before content_block_stop ONLY when reasoning_signature present', async () => {
+    // Case 1: streaming thinking without signature (no signature_delta event)
+    const streamNoSig = await handleMessages({
+      model: 'claude-sonnet-4.6',
+      stream: true,
+      thinking: { type: 'enabled' },
+      messages: [{ role: 'user', content: 'hello' }],
+    }, {
+      async handleChatCompletions() {
+        return {
+          status: 200,
+          stream: true,
+          async handler(res) {
+            res.write(chatChunk({ choices: [{ index: 0, delta: { reasoning_content: 'thinking chunk' }, finish_reason: null }] }));
+            res.write(chatChunk({ choices: [{ index: 0, delta: { content: 'answer' }, finish_reason: null }] }));
+            res.write(chatChunk({ choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] }));
+            res.end('data: [DONE]\n\n');
+          },
+        };
+      },
+    });
+
+    const resFake1 = fakeRes();
+    await streamNoSig.handler(resFake1);
+    const events1 = parseAnthropicEvents(resFake1.body);
+    const sigDeltas1 = events1.filter(e => e.event === 'content_block_delta' && e.data.delta?.type === 'signature_delta');
+    assert.equal(sigDeltas1.length, 0, 'no signature_delta should be emitted when reasoning_signature is absent');
+
+    // Case 2: streaming thinking WITH signature (signature_delta emitted right before content_block_stop for thinking block)
+    const streamWithSig = await handleMessages({
+      model: 'claude-sonnet-4.6',
+      stream: true,
+      thinking: { type: 'enabled' },
+      messages: [{ role: 'user', content: 'hello' }],
+    }, {
+      async handleChatCompletions() {
+        return {
+          status: 200,
+          stream: true,
+          async handler(res) {
+            res.write(chatChunk({ choices: [{ index: 0, delta: { reasoning_content: 'thinking chunk', reasoning_signature: 'sig_stream_999' }, finish_reason: null }] }));
+            res.write(chatChunk({ choices: [{ index: 0, delta: { content: 'answer' }, finish_reason: null }] }));
+            res.write(chatChunk({ choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] }));
+            res.end('data: [DONE]\n\n');
+          },
+        };
+      },
+    });
+
+    const resFake2 = fakeRes();
+    await streamWithSig.handler(resFake2);
+    const events2 = parseAnthropicEvents(resFake2.body);
+
+    const thinkingStartIdx = events2.findIndex(e => e.event === 'content_block_start' && e.data.content_block?.type === 'thinking');
+    assert.ok(thinkingStartIdx !== -1, 'content_block_start thinking event must exist');
+
+    const thinkingStopIdx = events2.findIndex((e, idx) => idx > thinkingStartIdx && e.event === 'content_block_stop' && e.data.index === events2[thinkingStartIdx].data.index);
+    assert.ok(thinkingStopIdx !== -1, 'content_block_stop for thinking block must exist');
+
+    const sigDeltaEvent = events2[thinkingStopIdx - 1];
+    assert.equal(sigDeltaEvent.event, 'content_block_delta', 'event immediately before content_block_stop must be content_block_delta');
+    assert.equal(sigDeltaEvent.data.delta?.type, 'signature_delta', 'delta type must be signature_delta');
+    assert.equal(sigDeltaEvent.data.delta?.signature, 'sig_stream_999', 'signature must match reasoning_signature');
+  });
+});


### PR DESCRIPTION
# fix(devin-connect): rescue nudge quotes the failed attempt's reasoning tail — one fresh nudge per rescue + request-derived gate (layer 2)

## 中文 TL;DR

上游(devin.ai)在带 tools 的请求里可能返回纯 reasoning 流、不给任何 content/tool call——对 agentic 客户端表现为"光想不做",自主循环直接断掉。本 PR 做四件事:

1. **救援提示词引用失败尝试的 reasoning 尾巴**:救援不再只喊"别想了,出工具调用",而是把上一次失败尝试的 reasoning 尾部(有上限、保留尾部,环境变量可调)包进提示词——模型能看到自己刚才想到哪、接着把动作发出来,而不是从零重想。wire 与 trajectory 证据见下。
2. **救援判定改为请求自带属性**:判定从 `emulateTools` 旗标改为 `params.tools?.length`。评审中维护者核实:两者在 connect 路径上本来就等价(`emulateTools` 字面就是 `connectTools.length > 0`),所以**这不是补覆盖**,而是把判定挪到与失败特征同层、自解释,不再依赖名字会说谎的旗标;与 `connectParams.tools` 转发的关系已写进代码注释。
3. **一次救援恰好一条新 nudge(评审第 1 条,已修)**:此前每次救援从已增长的 `attemptParams.messages` 重建列表,旧 nudge 全部保留——带上 digest 后第 5 次救援会往上游塞 ~10.4KB 陈旧提示词。现在每次救援从未经修改的原始请求重建,有专门测试钉死"第 N 次救援只带 1 条 nudge、且只引用上一次失败尝试"。
4. **field-0 护栏(评审第 3 条,已修)**:`encodeAssistantToolCall` 拒绝序列化 reasoning 标签 0(protobuf 保留字段)——即使调用方误传,编码器自己不出非法帧。

`.env.example` 记录两个旋钮及其实测依据。测试:完整套件 **3444 pass / 0 fail**(基于 v3.9.17,已含 v3.9.14 的 #240 预算拆分);新增两条针对性测试;救援/预算既有断言全部原样通过。

## Summary

The upstream account behind devin-connect can answer a tools-bearing chat turn with
reasoning deltas only — no content, no tool call. Agentic clients see "thinks, never
acts" and their autonomous loop breaks. #238 fixed the degenerate side (reasoning
dropped entirely) and proved that `thinking` blocks cannot round-trip on this wire;
this PR fixes the remaining failure form — reasoning emitted but no action — by
making the existing rescue nudge carry the failed attempt's reasoning tail.

## Fix

- **Rescue nudge quotes the failed attempt's reasoning tail.** The rescue arm already
  collected the attempt's reasoning deltas into `reasoningText`. It now digests it
  (default cap 2000 chars, tail kept — the model's last intent is at the end) via
  `digestReasoningForRescue` and embeds it: `Your previous reasoning ended with: """<digest>""".
  Stop reasoning. Emit the tool call markup now.` Env knobs:
  `DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS` (`'0'` restores the bare pre-PR nudge),
  documented in `.env.example`.
- **Rescue gate is request-derived, not flag-derived (review point 2, reworded).**
  Layer 1 gated the rescue on `emulateTools`. As dwgx verified in review, on the
  connect path that flag is literally `connectTools.length > 0` (chat.js defines it
  from the same array it forwards to `connectParams.tools`), so **coverage was
  already equivalent — this is not a coverage expansion**. The change moves the gate
  to `params.tools?.length` at the same layer as the failure signature: the condition
  now reads as what it means ("the request carries tools"), no longer routing through
  a flag whose name says "emulation", and a future call site passing `emulateTools`
  for a different meaning cannot silently re-gate the rescue. Caveat kept in code
  comments: `connectParams.tools` forwarding is groundwork until a consumer reads it,
  and while the equivalence above makes today's behaviour independent of that future
  change, any refactor of the forwarding must re-prove the gate's input.
- **One fresh nudge per rescue — no accumulation (review point 1).** The rescue
  rebuilt `filteredMsgs` from `attemptParams.messages`, which already contained every
  previous rescue's nudge (`role:'user'` survives the empty-assistant filter).
  Pre-digest that was invisible (46 fixed chars per nudge); with a 3000-char digest
  each stale nudge is ~2.1KB at the 2000-char default — five rescues stacked ~10.4KB of old nudges into the
  upstream call, each quoting reasoning the model already moved past. The rebuild now
  starts from the untouched original request (`params` is never mutated), so rescue
  k carries exactly one nudge quoting attempt k-1. Pinned by
  `does not accumulate nudges across consecutive rescues` (3 consecutive rescues:
  one nudge each, stale digests absent).
- **Field-0 guard in `encodeAssistantToolCall` (review point 3).**
  `writeStringField(reasoningTagNum, reasoning)` with `reasoningTagNum=0` would
  serialize `makeTag(0,2)` — field 0 is reserved in protobuf. Unreachable today
  (callers pass reasoningText only under a truthy tag), but the encoder now refuses
  it itself: `if (reasoning && reasoningTagNum)`. Pinned by a byte-length-identity
  test (zero-tag reasoning dropped == no-reasoning frame) plus the tag-11 regression.
- **Budget note (historical).** When this PR was written, each rescue iteration also
  advanced the shared `attempt` counter, so a rescue-first chain could starve the
  empty-reply retry arm. That was split into independent `emptyAttempt` /
  `rescueAttempt` budgets by the maintainer in **v3.9.14** (#240, closed COMPLETED,
  using this PR's companion production data); this branch is rebased on top of it and
  the cap table in #240 holds unchanged.
- `.env.example` documents `DEVIN_CONNECT_RESCUE_REASONING_MAX_CHARS` and
  `DEVIN_CONNECT_RESCUE_MAX` with the measured rationale.
- `src/handlers/messages.js` and `src/handlers/tool-emulation.js`: comment-only
  edits recording the layer-1 verdicts (tag-9/tag-11 acceptance ≠ consumption;
  prompt-emulation is the delivery channel) — no behaviour change.

## Wire/trajectory evidence (why this shape)

- 2026-07-28 capture `logs/trajectories/devin_2026-07-28T06-22-01_c08e3f85.log`,
  step 8 (upstream → proxy): 13 `reasoning` deltas, then `finish` — zero content.
  Steps 3 and 5 show the same model emitting normal tool calls, so the account can
  act; it just sometimes doesn't.
- A/B probes against the same account/model (`tmp/glm_intent_probe_3102.mjs`,
  `tmp/glm_hardtrap_probe_3102.mjs`): thinking-only turns reproduced with tools
  present; `tool_choice: required` did not change the outcome — the gap is
  upstream-side generation, so the recovery belongs on our side.
- #238's causality matrix (9 wire-verified variants) established that `thinking`
  blocks are accepted but never consumed by this upstream — which is exactly why the
  nudge is injected as plain user text, the one channel this account reliably acts on.

## Test plan

On top of v3.9.17 (`3d49657`), full suite: **3444 pass / 0 fail** (v3.9.17's own
gate is 3418; delta includes this PR's additions). New/changed coverage:

- `test/devin-connect-openai.test.js` — digest embedding; tail-kept cap semantics;
  `'0'` restores the bare pre-PR nudge byte-for-byte; **no accumulation across three
  consecutive rescues (one fresh nudge each, stale digests absent)**; rescue
  arm/cap/master-switch/weak-model veto and the budget-split regression suite from
  v3.9.14 all pass unchanged.
- `test/devin-connect.test.js` — **field-0 guard**: reasoning with tag 0 is dropped,
  not serialized (byte-length identity with the no-reasoning frame); tag 11 still
  serializes verbatim.
- `test/messages-thinking-contract.test.js` — #238's wire contract, unchanged.

## Live verification (layer 2, post-fix re-run)

Against this branch served on a scratch port, `swe-1-7` (free pool) via kimi CLI in
Anthropic `/v1/messages` shape with tools:

- Re-verified this branch (`0f5a57b`) with the same shape: kimi CLI (Anthropic `/v1/messages`) against `swe-1-7` (free pool), native tool mode (24 tools). 5 agentic sessions / 12 upstream calls — tool calls arrived and autonomous loops completed end to end (multi-step Read/Bash/Write sequences); no regression from the digest/gate changes. No thinking-only completion occurred in this window (the trap is sporadic — 0 occurrences in 12 calls), so the rescue mechanics are pinned by the no-accumulation unit test rather than by this live capture.

## Follow-ups (not in this PR)

- Reasoning replay (tags 11/9) stays inert until upstream consumes it; the
  `connectParams.tools` forwarding is groundwork for that day (see the gate caveat above).
- #240 — budget split — was accepted and implemented by the maintainer in v3.9.14;
  this PR is rebased on top of it.
- Track Б (#236 GLM form-A) — reproduction attempts without the intermediary found
  zero occurrences across 78 turns; the data lives in the issue thread.
