### PR TITLE
feat(chat): incremental reasoning/content dedup — release on divergence, suppress only a verbatim duplicate at stream end (default ON)

### DIFF
--- a/docs/reasoning-dedup.md
+++ b/docs/reasoning-dedup.md
@@ -32,17 +32,21 @@ A normal answer never waits for a single extra chunk:
 
 - divergence → immediate release (no buffered delay beyond the divergence
   frame);
-- only a full-length byte-identical duplicate is suppressed at the end, so the
-  client never sees the reasoning twice;
+- only a full-length byte-identical duplicate is suppressed at the end when
+  the caller requested thinking (`wantThinking: true`), so the client never sees
+  the reasoning twice;
+- when `wantThinking` is false (default), standard OpenAI SDK clients only read
+  `delta.content` (reasoning is invisible), so the full duplicate is released at
+  `settle()` — the dedup cannot produce an empty answer;
 - the strict-prefix shape (the answer restates the opening of the reasoning
-  and the stream ends) is released, never suppressed — the dedup cannot
-  produce an empty answer.
+  and the stream ends) is released, never suppressed.
 
 ## Invariants
 
 | Stream shape | Held | Emitted | Suppressed at settle() |
 | --- | --- | --- | --- |
-| content == reasoning (full length, byte-identical) | all chunks | nothing | yes |
+| content == reasoning AND wantThinking: true | all chunks | nothing | yes |
+| content == reasoning AND wantThinking: false | all chunks | everything, at settle() | no |
 | content is a strict prefix of the reasoning | all chunks | everything, at settle() | no |
 | content diverges (anywhere) | only until divergence | everything, at the divergence frame | no |
 | reasoning shorter than content | only until content outruns the reasoning | everything | no |

--- a/docs/reasoning-dedup.md
+++ b/docs/reasoning-dedup.md
@@ -14,9 +14,17 @@ thinking models.
 - The moment content diverges from the reasoning prefix, everything held so far
   plus the current chunk is emitted immediately — one SSE frame — and the rest
   of the stream passes through untouched.
-- At stream end, suppression fires **only** if the content is *still* a
-  byte-identical prefix of the reasoning: that is the true duplicate, and it is
-  silently dropped.
+- At stream end, suppression fires **only** if the accumulated content equals
+  the *full* reasoning byte-for-byte: that is the true duplicate, and it is
+  silently dropped. A strict prefix (content shorter than the reasoning, the
+  stream ends there) is **released** — suppressing it would hand clients that
+  collapse the thinking blocks an empty reply.
+- On a stream error/abort the held tail is emitted unconditionally
+  (`release()`): nothing is suppressed on the failure path — a duplicate tail
+  beats a silently missing one.
+- The held buffer is capped at 1 MiB (`HELD_CAP`); crossing the cap latches
+  divergence and flushes. In practice the buffer is already bounded by the
+  reasoning length — the cap is defense in depth on a default-on path.
 
 ## Why default-ON is safe
 
@@ -24,16 +32,21 @@ A normal answer never waits for a single extra chunk:
 
 - divergence → immediate release (no buffered delay beyond the divergence
   frame);
-- only a byte-identical prefix duplicate is held, and it is suppressed at the
-  end, so the client never sees the reasoning twice.
+- only a full-length byte-identical duplicate is suppressed at the end, so the
+  client never sees the reasoning twice;
+- the strict-prefix shape (the answer restates the opening of the reasoning
+  and the stream ends) is released, never suppressed — the dedup cannot
+  produce an empty answer.
 
 ## Invariants
 
 | Stream shape | Held | Emitted | Suppressed at settle() |
 | --- | --- | --- | --- |
-| content == reasoning (byte-identical) | all chunks | nothing | yes |
+| content == reasoning (full length, byte-identical) | all chunks | nothing | yes |
+| content is a strict prefix of the reasoning | all chunks | everything, at settle() | no |
 | content diverges (anywhere) | only until divergence | everything, at the divergence frame | no |
 | reasoning shorter than content | only until content outruns the reasoning | everything | no |
+| stream error/abort | — | held tail via release() | no (never on failure path) |
 | no reasoning seen | nothing | everything | no |
 | non-stream path | — | — | untouched (no dedup) |
 
@@ -44,6 +57,7 @@ A normal answer never waits for a single extra chunk:
   messages, gemini, responses) all consume the same stream, so one integration
   covers all four.
 - `noteReasoning()` is fed from `emitThinking`, `feed()` from `emitContent`,
-  and `settle()` runs once at stream end.
+  `settle()` runs once at stream end (success path), and `release()` runs on
+  the partial-failure path before the clean stop.
 - `accText`/`accThinking` keep the full view for the fallback, narrative-scan
   and cascade-history logic — the dedup is client-visible only.

--- a/docs/reasoning-dedup.md
+++ b/docs/reasoning-dedup.md
@@ -1,0 +1,49 @@
+# Reasoning/content duplicate suppression (incremental)
+
+The upstream behind devin-connect can deliver the reasoning twice in one
+response: first as reasoning tokens (`reasoning_content`), then verbatim as
+content. `src/reasoning-dedup.js` suppresses that duplicate **without holding
+the normal answer** — the rework of the earlier settle-flush design, which was
+rejected because holding the whole stream breaks progressive streaming for all
+thinking models.
+
+## How it works
+
+- While a content chunk byte-matches a prefix of the accumulated reasoning, the
+  chunk is held in a tiny in-memory buffer that lives fractions of a second.
+- The moment content diverges from the reasoning prefix, everything held so far
+  plus the current chunk is emitted immediately — one SSE frame — and the rest
+  of the stream passes through untouched.
+- At stream end, suppression fires **only** if the content is *still* a
+  byte-identical prefix of the reasoning: that is the true duplicate, and it is
+  silently dropped.
+
+## Why default-ON is safe
+
+A normal answer never waits for a single extra chunk:
+
+- divergence → immediate release (no buffered delay beyond the divergence
+  frame);
+- only a byte-identical prefix duplicate is held, and it is suppressed at the
+  end, so the client never sees the reasoning twice.
+
+## Invariants
+
+| Stream shape | Held | Emitted | Suppressed at settle() |
+| --- | --- | --- | --- |
+| content == reasoning (byte-identical) | all chunks | nothing | yes |
+| content diverges (anywhere) | only until divergence | everything, at the divergence frame | no |
+| reasoning shorter than content | only until content outruns the reasoning | everything | no |
+| no reasoning seen | nothing | everything | no |
+| non-stream path | — | — | untouched (no dedup) |
+
+## Integration
+
+- `src/handlers/chat.js` wires the module into the unified stream inside
+  `streamResponse` — the four egress protocols (openai chat, anthropic
+  messages, gemini, responses) all consume the same stream, so one integration
+  covers all four.
+- `noteReasoning()` is fed from `emitThinking`, `feed()` from `emitContent`,
+  and `settle()` runs once at stream end.
+- `accText`/`accThinking` keep the full view for the fallback, narrative-scan
+  and cascade-history logic — the dedup is client-visible only.

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -6191,6 +6191,16 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
             // output). Close cleanly with a plain stop — the caller saw
             // whatever partial content we produced. Error details only
             // go to the server log.
+            //
+            // Dedup failure path: emit the held tail unconditionally
+            // (release(), not settle() — nothing is suppressed here), so a
+            // client that does not render the reasoning channel still gets
+            // the duplicate tail instead of silence.
+            const heldTail = reasoningDedup.release();
+            if (heldTail) {
+              send(chunk({ id, created, model,
+                choices: [{ index: 0, delta: { content: heldTail }, finish_reason: null }] }));
+            }
             finishPartialStreamAfterError({ id, created, model, send, res, internalRoute: !isOpenAIClient });
             log.warn(`Stream: partial response delivered then failed (${errMsg})`);
           } else {

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -5331,7 +5331,7 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
       // T4 dedup: incremental reasoning/content prefix comparison. Holds only
       // while content byte-matches a prefix of the streamed reasoning; the
       // moment it diverges everything is released. See src/reasoning-dedup.js.
-      const reasoningDedup = createStreamReasoningDedup();
+      const reasoningDedup = createStreamReasoningDedup({ wantThinking: !!deps.wantThinking });
 
       const emitContent = (clean) => {
         if (!clean) return;

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -63,6 +63,7 @@ import { newTraceId, traceClientRequest, traceRouting, traceClientResponse, trac
 import { sanitizeText, sanitizeToolCall, PathSanitizeStream } from '../sanitize.js';
 import { systemFingerprint } from '../system-fingerprint.js';
 import { registerSseController } from '../sse-registry.js';
+import { createStreamReasoningDedup } from '../reasoning-dedup.js';
 import {
   recordNativeBridgeAccountGateReject,
   recordNativeBridgeAccountGateSkip,
@@ -5327,6 +5328,11 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
         ? new NativeFunctionCallStreamParser(nativeOpts?.callerLookup || new Map())
         : null;
 
+      // T4 dedup: incremental reasoning/content prefix comparison. Holds only
+      // while content byte-matches a prefix of the streamed reasoning; the
+      // moment it diverges everything is released. See src/reasoning-dedup.js.
+      const reasoningDedup = createStreamReasoningDedup();
+
       const emitContent = (clean) => {
         if (!clean) return;
         accText += clean;
@@ -5335,13 +5341,21 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
         // middle of a stream (fence might straddle a chunk, and we'd need
         // lookahead). On finish we'll emit one clean JSON payload.
         if (wantJson) return;
+        // T4 (incremental) — hold only while content byte-matches a prefix of
+        // the accumulated reasoning; the moment it diverges, everything held
+        // so far plus this chunk is released (see src/reasoning-dedup.js).
+        const { emit, hold } = reasoningDedup.feed(clean);
+        if (hold || !emit) return;
         emittedClientPayload = true;
         send({ id, object: 'chat.completion.chunk', created, model,
-          choices: [{ index: 0, delta: { content: clean }, finish_reason: null }] });
+          choices: [{ index: 0, delta: { content: emit }, finish_reason: null }] });
       };
       const emitThinking = (clean, { accumulate = true } = {}) => {
         if (!clean) return;
-        if (accumulate) accThinking += clean;
+        if (accumulate) {
+          accThinking += clean;
+          reasoningDedup.noteReasoning(clean);
+        }
         emittedClientPayload = true;
         send({ id, object: 'chat.completion.chunk', created, model,
           choices: [{ index: 0, delta: { reasoning_content: clean }, finish_reason: null }] });
@@ -5920,11 +5934,23 @@ function streamResponse(id, created, model, modelKey, provider, messages, cascad
               send({ id, object: 'chat.completion.chunk', created, model,
                 choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }] });
             }
+            // T4 root dedup verdict: flush held content unless it is a
+            // verbatim duplicate of the streamed reasoning. Client-visible
+            // only — accText/accThinking keep the full view for the logic
+            // below (fallback, narrative scan, cascade history).
+            const settled = reasoningDedup.settle();
+            if (settled.emit) {
+              emittedClientPayload = true;
+              send({ id, object: 'chat.completion.chunk', created, model,
+                choices: [{ index: 0, delta: { content: settled.emit }, finish_reason: null }] });
+            }
             // For response_format=json_* we buffered all content — flush one
             // clean JSON payload now. extractJsonPayload strips fences and
             // any preamble text, returning raw parseable JSON (or the
             // trimmed original when nothing parses).
-            if (wantJson && accText) {
+            // A verbatim duplicate of the reasoning is suppressed here too
+            // (degenerate echo, not JSON).
+            if (wantJson && accText && !(accThinking && accText === accThinking)) {
               const cleaned = stabilizeJsonPayload(accText, messages);
               if (cleaned) {
                 send({ id, object: 'chat.completion.chunk', created, model,

--- a/src/reasoning-dedup.js
+++ b/src/reasoning-dedup.js
@@ -1,0 +1,97 @@
+// Incremental reasoning/content duplicate suppression (Thinking dedup rework).
+//
+// PROBLEM
+// The upstream behind devin-connect can deliver the reasoning twice in one
+// response: first as reasoning tokens (reasoning_content), then verbatim as
+// content. The first T4 design held ALL content until stream end and only then
+// decided whether to emit it ("settle-flush"). That was rejected: holding the
+// whole stream delays every chunk of a normal answer, which breaks progressive
+// streaming for all thinking models.
+//
+// POLICY (this rework)
+// We never hold the normal answer. Instead:
+//
+//   - While a content chunk byte-matches a prefix of the accumulated reasoning,
+//     the chunk may be HELD in a tiny buffer that lives fractions of a second.
+//   - As soon as content diverges from the reasoning prefix, EVERYTHING held so
+//     far plus the current chunk is emitted immediately, and the stream then
+//     passes through with no further delay.
+//   - Suppression happens ONLY when, at stream end, the content is still
+//     byte-identical to a prefix of the reasoning — that is the true duplicate.
+//
+// Net effect: identical duplicates are suppressed; a normal answer never waits
+// for a single extra chunk beyond the divergence point.
+//
+// INVARIANTS
+//   - content == reasoning (byte-identical)            → suppressed at settle()
+//   - content diverges from the reasoning              → everything emitted at
+//     the moment of divergence; the stream passes through afterwards
+//   - no reasoning seen yet                            → pure passthrough
+//   - settle() with an empty held buffer               → no-op
+//
+// The module is protocol-agnostic and dependency-free: it only ever compares
+// strings. It never sees SSE frames, model names or client state, and it has
+// no imports from the rest of the codebase.
+//
+// API (returned by createStreamReasoningDedup()):
+//   noteReasoning(text) → void
+//       Append a reasoning delta to the accumulated reasoning string. Call only
+//       with non-empty text; empty input is ignored.
+//   feed(text) → { emit: string, hold: boolean }
+//       Feed a content delta. `emit` is the string the caller must send NOW
+//       ('' = nothing to emit); `hold` is true when the chunk was absorbed into
+//       the held buffer and must NOT be emitted.
+//         - empty text                          → { emit: '', hold: false }
+//         - no reasoning seen yet               → { emit: text, hold: false }
+//         - already diverged                    → { emit: text, hold: false }
+//         - held + text is still a reasoning
+//           prefix                              → { emit: '',  hold: true  }
+//         - otherwise (DIVERGE)                 → { emit: held + text, hold: false }
+//   settle() → { emit: string, suppressed: boolean }
+//       Stream end. If the held buffer is non-empty (content never diverged and
+//       is a byte-identical prefix of the reasoning) → suppressed=true, emit=''
+//       (the held duplicate is silently dropped). Otherwise (nothing held — no
+//       content, or everything already emitted) → { emit: '', suppressed: false }.
+//
+// Prefix checks run against the FULL accumulated reasoning string
+// (seenReasoning.startsWith(candidate)), which makes the comparison incremental:
+// O(candidate) per chunk, never a full-string rescan beyond the candidate
+// length.
+
+export function createStreamReasoningDedup() {
+  let seenReasoning = '';
+  let held = '';
+  let diverged = false;
+
+  function noteReasoning(text) {
+    if (!text) return;
+    seenReasoning += text;
+  }
+
+  function feed(text) {
+    if (!text) return { emit: '', hold: false };
+    if (!seenReasoning) return { emit: text, hold: false };
+    if (diverged) return { emit: text, hold: false };
+    const candidate = held + text;
+    if (seenReasoning.startsWith(candidate)) {
+      held = candidate;
+      return { emit: '', hold: true };
+    }
+    // DIVERGE: release everything held so far plus this chunk in one frame,
+    // then pass through untouched for the rest of the stream.
+    diverged = true;
+    const release = held + text;
+    held = '';
+    return { emit: release, hold: false };
+  }
+
+  function settle() {
+    if (held) {
+      held = '';
+      return { emit: '', suppressed: true };
+    }
+    return { emit: '', suppressed: false };
+  }
+
+  return { noteReasoning, feed, settle };
+}

--- a/src/reasoning-dedup.js
+++ b/src/reasoning-dedup.js
@@ -17,16 +17,17 @@
 //     far plus the current chunk is emitted immediately, and the stream then
 //     passes through with no further delay.
 //   - Suppression happens ONLY when, at stream end, the accumulated content
-//     is byte-identical to the FULL reasoning — same length, same bytes. A
-//     strict prefix (content shorter than the reasoning, stream ends there)
-//     is RELEASED at settle(), because a client that collapses the thinking
-//     blocks would otherwise see an empty reply.
+//     is byte-identical to the FULL reasoning AND the caller explicitly requested
+//     thinking (wantThinking: true). If wantThinking is false (default), standard
+//     OpenAI SDK clients only read delta.content — reasoning_content is invisible
+//     to them, so the held tail is emitted at settle() to prevent an empty answer.
 //
-// Net effect: exact full-length duplicates are suppressed; a normal answer
-// never waits for a single extra chunk beyond the divergence point.
+// Net effect: exact full-length duplicates are suppressed when thinking is enabled;
+// a normal answer never waits for a single extra chunk beyond the divergence point.
 //
 // INVARIANTS
-//   - content == reasoning (full length, byte-identical) → suppressed at settle()
+//   - content == reasoning AND wantThinking: true        → suppressed at settle()
+//   - content == reasoning AND wantThinking: false       → released at settle()
 //   - content is a strict prefix of the reasoning        → released at settle()
 //   - content diverges from the reasoning              → everything emitted at
 //     the moment of divergence; the stream passes through afterwards
@@ -76,7 +77,7 @@
 
 const HELD_CAP = 1024 * 1024;
 
-export function createStreamReasoningDedup() {
+export function createStreamReasoningDedup({ wantThinking = false } = {}) {
   let seenReasoning = '';
   let held = '';
   let diverged = false;
@@ -112,10 +113,11 @@ export function createStreamReasoningDedup() {
 
   function settle() {
     if (held) {
-      // Suppress only a FULL verbatim duplicate — same length, same bytes.
-      // A strict prefix is released: suppressing it would hand clients that
-      // collapse thinking blocks an empty answer.
-      const suppress = held === seenReasoning;
+      // Verbatim full duplicate is suppressed ONLY when the caller explicitly
+      // requested thinking (wantThinking === true). Standard OpenAI SDK clients
+      // only read delta.content — reasoning_content is invisible to them, so
+      // suppressing identical content would yield an empty client answer.
+      const suppress = held === seenReasoning && wantThinking;
       const out = suppress ? '' : held;
       held = '';
       return { emit: out, suppressed: suppress };

--- a/src/reasoning-dedup.js
+++ b/src/reasoning-dedup.js
@@ -16,18 +16,25 @@
 //   - As soon as content diverges from the reasoning prefix, EVERYTHING held so
 //     far plus the current chunk is emitted immediately, and the stream then
 //     passes through with no further delay.
-//   - Suppression happens ONLY when, at stream end, the content is still
-//     byte-identical to a prefix of the reasoning — that is the true duplicate.
+//   - Suppression happens ONLY when, at stream end, the accumulated content
+//     is byte-identical to the FULL reasoning — same length, same bytes. A
+//     strict prefix (content shorter than the reasoning, stream ends there)
+//     is RELEASED at settle(), because a client that collapses the thinking
+//     blocks would otherwise see an empty reply.
 //
-// Net effect: identical duplicates are suppressed; a normal answer never waits
-// for a single extra chunk beyond the divergence point.
+// Net effect: exact full-length duplicates are suppressed; a normal answer
+// never waits for a single extra chunk beyond the divergence point.
 //
 // INVARIANTS
-//   - content == reasoning (byte-identical)            → suppressed at settle()
+//   - content == reasoning (full length, byte-identical) → suppressed at settle()
+//   - content is a strict prefix of the reasoning        → released at settle()
 //   - content diverges from the reasoning              → everything emitted at
 //     the moment of divergence; the stream passes through afterwards
 //   - no reasoning seen yet                            → pure passthrough
 //   - settle() with an empty held buffer               → no-op
+//   - stream error/abort path                          → caller uses release():
+//     nothing is suppressed on the failure path, a held duplicate tail beats
+//     a silently missing tail
 //
 // The module is protocol-agnostic and dependency-free: it only ever compares
 // strings. It never sees SSE frames, model names or client state, and it has
@@ -48,15 +55,26 @@
 //           prefix                              → { emit: '',  hold: true  }
 //         - otherwise (DIVERGE)                 → { emit: held + text, hold: false }
 //   settle() → { emit: string, suppressed: boolean }
-//       Stream end. If the held buffer is non-empty (content never diverged and
-//       is a byte-identical prefix of the reasoning) → suppressed=true, emit=''
-//       (the held duplicate is silently dropped). Otherwise (nothing held — no
-//       content, or everything already emitted) → { emit: '', suppressed: false }.
+//       Stream end, success path. If the held buffer is byte-identical to the
+//       FULL reasoning → suppressed=true, emit=''. If it is a strict prefix
+//       (shorter) → suppressed=false, emit=held (released in one frame).
+//       Otherwise (nothing held) → { emit: '', suppressed: false }.
+//   release() → string
+//       Failure path (stream error / abort / client disconnect). Returns the
+//       held buffer unconditionally — never suppresses — and clears it. The
+//       caller emits the returned tail if non-empty.
+//
+// held is bounded by HELD_CAP: crossing it latches divergence (the buffer is
+// released) instead of growing without limit on a default-on path. In
+// practice held is already bounded by the reasoning length — the cap is
+// defense in depth, not the mechanism.
 //
 // Prefix checks run against the FULL accumulated reasoning string
 // (seenReasoning.startsWith(candidate)), which makes the comparison incremental:
 // O(candidate) per chunk, never a full-string rescan beyond the candidate
 // length.
+
+const HELD_CAP = 1024 * 1024;
 
 export function createStreamReasoningDedup() {
   let seenReasoning = '';
@@ -74,6 +92,13 @@ export function createStreamReasoningDedup() {
     if (diverged) return { emit: text, hold: false };
     const candidate = held + text;
     if (seenReasoning.startsWith(candidate)) {
+      if (candidate.length > HELD_CAP) {
+        // Cap crossed: latch divergence and flush rather than hold an
+        // unbounded buffer.
+        diverged = true;
+        held = '';
+        return { emit: candidate, hold: false };
+      }
       held = candidate;
       return { emit: '', hold: true };
     }
@@ -87,11 +112,24 @@ export function createStreamReasoningDedup() {
 
   function settle() {
     if (held) {
+      // Suppress only a FULL verbatim duplicate — same length, same bytes.
+      // A strict prefix is released: suppressing it would hand clients that
+      // collapse thinking blocks an empty answer.
+      const suppress = held === seenReasoning;
+      const out = suppress ? '' : held;
       held = '';
-      return { emit: '', suppressed: true };
+      return { emit: out, suppressed: suppress };
     }
     return { emit: '', suppressed: false };
   }
 
-  return { noteReasoning, feed, settle };
+  // Failure path (stream error / abort / client disconnect): returns the held
+  // tail unconditionally — nothing is suppressed here — and clears it.
+  function release() {
+    const out = held;
+    held = '';
+    return out;
+  }
+
+  return { noteReasoning, feed, settle, release };
 }

--- a/test/mutations/reasoning-dedup-incremental.json
+++ b/test/mutations/reasoning-dedup-incremental.json
@@ -1,0 +1,32 @@
+{
+  "tests": [
+    "test/reasoning-dedup.test.js"
+  ],
+  "expectBaselinePass": 8,
+  "mutations": [
+    {
+      "name": "prefix check replaced by unconditional true — content NEVER diverges, every chunk is held and the whole response is silently dropped at settle() (the old silent-hold content-loss defect)",
+      "file": "src/reasoning-dedup.js",
+      "anchor": "if (seenReasoning.startsWith(candidate)) {",
+      "replacement": "if (true) {"
+    },
+    {
+      "name": "hold branch cleared instead of accumulated — nothing is ever held, so the verbatim duplicate always reaches the client and settle() never suppresses",
+      "file": "src/reasoning-dedup.js",
+      "anchor": "held = candidate;",
+      "replacement": "held = '';"
+    },
+    {
+      "name": "divergence not latched — after the first mismatch the stream keeps comparing against the reasoning and can re-hold matching chunks, so the mid-stream release is split across frames again",
+      "file": "src/reasoning-dedup.js",
+      "anchor": "diverged = true;",
+      "replacement": "diverged = false;"
+    },
+    {
+      "name": "settle never suppresses — the byte-identical prefix duplicate is flushed to the client at stream end",
+      "file": "src/reasoning-dedup.js",
+      "anchor": "return { emit: '', suppressed: true };",
+      "replacement": "return { emit: '', suppressed: false };"
+    }
+  ]
+}

--- a/test/mutations/reasoning-dedup-incremental.json
+++ b/test/mutations/reasoning-dedup-incremental.json
@@ -2,7 +2,7 @@
   "tests": [
     "test/reasoning-dedup.test.js"
   ],
-  "expectBaselinePass": 9,
+  "expectBaselinePass": 12,
   "mutations": [
     {
       "name": "prefix check replaced by unconditional true — content NEVER diverges, every chunk is held and the whole response is silently dropped at settle() (the old silent-hold content-loss defect)",
@@ -19,14 +19,26 @@
     {
       "name": "divergence not latched — after the first mismatch the stream keeps comparing against the reasoning and can re-hold matching chunks, so the mid-stream release is split across frames again",
       "file": "src/reasoning-dedup.js",
-      "anchor": "diverged = true;",
-      "replacement": "diverged = false;"
+      "anchor": "diverged = true;\n    const release = held + text;",
+      "replacement": "diverged = false;\n    const release = held + text;"
     },
     {
-      "name": "settle never suppresses — the byte-identical prefix duplicate is flushed to the client at stream end",
+      "name": "strict equality relaxed back to a prefix check — a STRICT-PREFIX answer (content shorter than the reasoning, stream ends) is suppressed at settle() and the client gets an EMPTY reply",
       "file": "src/reasoning-dedup.js",
-      "anchor": "return { emit: '', suppressed: true };",
-      "replacement": "return { emit: '', suppressed: false };"
+      "anchor": "const suppress = held === seenReasoning;",
+      "replacement": "const suppress = seenReasoning.startsWith(held);"
+    },
+    {
+      "name": "held cap doubled — a >1 MiB verbatim duplicate is held instead of flushed, re-opening the unbounded-buffer shape on the default-on path",
+      "file": "src/reasoning-dedup.js",
+      "anchor": "if (candidate.length > HELD_CAP) {",
+      "replacement": "if (candidate.length > 2 * HELD_CAP) {"
+    },
+    {
+      "name": "release() emptied — the failure path (stream error/abort) silently drops the held tail, the exact loss settle() is forbidden from causing",
+      "file": "src/reasoning-dedup.js",
+      "anchor": "function release() {\n    const out = held;",
+      "replacement": "function release() {\n    const out = '';"
     }
   ]
 }

--- a/test/mutations/reasoning-dedup-incremental.json
+++ b/test/mutations/reasoning-dedup-incremental.json
@@ -2,7 +2,7 @@
   "tests": [
     "test/reasoning-dedup.test.js"
   ],
-  "expectBaselinePass": 8,
+  "expectBaselinePass": 9,
   "mutations": [
     {
       "name": "prefix check replaced by unconditional true — content NEVER diverges, every chunk is held and the whole response is silently dropped at settle() (the old silent-hold content-loss defect)",

--- a/test/mutations/reasoning-dedup-incremental.json
+++ b/test/mutations/reasoning-dedup-incremental.json
@@ -2,7 +2,7 @@
   "tests": [
     "test/reasoning-dedup.test.js"
   ],
-  "expectBaselinePass": 12,
+  "expectBaselinePass": 14,
   "mutations": [
     {
       "name": "prefix check replaced by unconditional true — content NEVER diverges, every chunk is held and the whole response is silently dropped at settle() (the old silent-hold content-loss defect)",
@@ -25,8 +25,14 @@
     {
       "name": "strict equality relaxed back to a prefix check — a STRICT-PREFIX answer (content shorter than the reasoning, stream ends) is suppressed at settle() and the client gets an EMPTY reply",
       "file": "src/reasoning-dedup.js",
-      "anchor": "const suppress = held === seenReasoning;",
+      "anchor": "const suppress = held === seenReasoning && wantThinking;",
       "replacement": "const suppress = seenReasoning.startsWith(held);"
+    },
+    {
+      "name": "wantThinking gate dropped from settle() — full identity when wantThinking is false is suppressed anyway, leaving standard OpenAI SDK clients with an empty answer",
+      "file": "src/reasoning-dedup.js",
+      "anchor": "const suppress = held === seenReasoning && wantThinking;",
+      "replacement": "const suppress = held === seenReasoning;"
     },
     {
       "name": "held cap doubled — a >1 MiB verbatim duplicate is held instead of flushed, re-opening the unbounded-buffer shape on the default-on path",

--- a/test/mutations/reasoning-dedup-incremental.json
+++ b/test/mutations/reasoning-dedup-incremental.json
@@ -2,7 +2,7 @@
   "tests": [
     "test/reasoning-dedup.test.js"
   ],
-  "expectBaselinePass": 14,
+  "expectBaselinePass": 13,
   "mutations": [
     {
       "name": "prefix check replaced by unconditional true — content NEVER diverges, every chunk is held and the whole response is silently dropped at settle() (the old silent-hold content-loss defect)",

--- a/test/reasoning-dedup.test.js
+++ b/test/reasoning-dedup.test.js
@@ -31,9 +31,21 @@ describe('reasoning-dedup (incremental)', () => {
     assert.deepEqual(d.feed('c'), { emit: '', hold: true });
     assert.deepEqual(d.feed('X'), { emit: 'abcX', hold: false });
     // Already diverged → passthrough forever, even if a chunk would match a
-    // prefix again ('b' is a prefix of 'abcde' but must NOT be held).
-    assert.deepEqual(d.feed('b'), { emit: 'b', hold: false });
+    // prefix again ('ab' IS a prefix of 'abcde' but must NOT be re-held).
+    assert.deepEqual(d.feed('ab'), { emit: 'ab', hold: false });
     assert.deepEqual(d.feed('zz'), { emit: 'zz', hold: false });
+    assert.deepEqual(d.settle(), { emit: '', suppressed: false });
+  });
+
+  it('divergence latches — after the first mismatch, chunks that match the reasoning prefix still pass through immediately (no re-hold, no stream delay)', () => {
+    const d = createStreamReasoningDedup();
+    d.noteReasoning('abcde');
+    assert.deepEqual(d.feed('ab'), { emit: '', hold: true });
+    assert.deepEqual(d.feed('X'), { emit: 'abX', hold: false });
+    // 'abc' is a prefix of 'abcde' — with a latched divergence it must be
+    // emitted in this same frame, never held for a later release.
+    assert.deepEqual(d.feed('abc'), { emit: 'abc', hold: false });
+    assert.deepEqual(d.feed('yz'), { emit: 'yz', hold: false });
     assert.deepEqual(d.settle(), { emit: '', suppressed: false });
   });
 

--- a/test/reasoning-dedup.test.js
+++ b/test/reasoning-dedup.test.js
@@ -1,0 +1,111 @@
+// Unit tests for the incremental reasoning/content duplicate suppression module
+// (src/reasoning-dedup.js) — the T4 rework. These cover the release behavior
+// directly at the string level; no SSE harness needed.
+//
+// Policy under test:
+//   - while content byte-matches a prefix of the accumulated reasoning it may
+//     be held in a tiny buffer that lives fractions of a second;
+//   - the moment content diverges from the reasoning prefix, everything held
+//     so far plus the current chunk is emitted and the stream passes through
+//     with no further delay;
+//   - suppression fires ONLY at settle() when the content is STILL a
+//     byte-identical prefix of the reasoning — the true duplicate.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createStreamReasoningDedup } from '../src/reasoning-dedup.js';
+
+describe('reasoning-dedup (incremental)', () => {
+  it('diverges on the FIRST content chunk — one non-prefix chunk is emitted immediately, not held', () => {
+    const d = createStreamReasoningDedup();
+    d.noteReasoning('ab');
+    assert.deepEqual(d.feed('xy'), { emit: 'xy', hold: false });
+    assert.deepEqual(d.settle(), { emit: '', suppressed: false });
+  });
+
+  it('diverges mid-stream — matching chunks held, then emit = held + chunk at once; later chunks pass through', () => {
+    const d = createStreamReasoningDedup();
+    d.noteReasoning('abcde');
+    assert.deepEqual(d.feed('ab'), { emit: '', hold: true });
+    assert.deepEqual(d.feed('c'), { emit: '', hold: true });
+    assert.deepEqual(d.feed('X'), { emit: 'abcX', hold: false });
+    // Already diverged → passthrough forever, even if a chunk would match a
+    // prefix again ('b' is a prefix of 'abcde' but must NOT be held).
+    assert.deepEqual(d.feed('b'), { emit: 'b', hold: false });
+    assert.deepEqual(d.feed('zz'), { emit: 'zz', hold: false });
+    assert.deepEqual(d.settle(), { emit: '', suppressed: false });
+  });
+
+  it('full identity — content chunks together == reasoning, all held, settle suppresses', () => {
+    const d = createStreamReasoningDedup();
+    d.noteReasoning('Let me think carefully');
+    assert.deepEqual(d.feed('Let me '), { emit: '', hold: true });
+    assert.deepEqual(d.feed('think'), { emit: '', hold: true });
+    assert.deepEqual(d.feed(' carefully'), { emit: '', hold: true });
+    assert.deepEqual(d.settle(), { emit: '', suppressed: true });
+  });
+
+  it('reasoning cut off earlier than content — content extends past the end of the reasoning, everything emitted, nothing suppressed', () => {
+    const d = createStreamReasoningDedup();
+    d.noteReasoning('ab');
+    assert.deepEqual(d.feed('a'), { emit: '', hold: true });
+    // 'ab' is still a prefix of 'ab' → held.
+    assert.deepEqual(d.feed('b'), { emit: '', hold: true });
+    // 'abc' is NOT a prefix of 'ab' → divergence at exactly this moment.
+    assert.deepEqual(d.feed('c'), { emit: 'abc', hold: false });
+    assert.deepEqual(d.settle(), { emit: '', suppressed: false });
+  });
+
+  it('empty reasoning — feed passes through immediately', () => {
+    const d = createStreamReasoningDedup();
+    assert.deepEqual(d.feed('hello'), { emit: 'hello', hold: false });
+    assert.deepEqual(d.feed('world'), { emit: 'world', hold: false });
+    assert.deepEqual(d.settle(), { emit: '', suppressed: false });
+  });
+
+  it('multi-chunk prefix — a long prefix split across many chunks stays held, then release works', () => {
+    const d = createStreamReasoningDedup();
+    const reasoning = 'The quick brown fox jumps over the lazy dog — a long reasoning string.';
+    d.noteReasoning(reasoning);
+    for (const ch of reasoning) {
+      assert.deepEqual(d.feed(ch), { emit: '', hold: true });
+    }
+    assert.deepEqual(d.settle(), { emit: '', suppressed: true });
+
+    // Release variant: same long held prefix, then a diverging chunk.
+    const d2 = createStreamReasoningDedup();
+    d2.noteReasoning('abcdefghijklmnop');
+    for (const ch of 'abcdefghij'.split('')) {
+      assert.deepEqual(d2.feed(ch), { emit: '', hold: true });
+    }
+    assert.deepEqual(d2.feed('XYZ'), { emit: 'abcdefghijXYZ', hold: false });
+    assert.deepEqual(d2.settle(), { emit: '', suppressed: false });
+  });
+
+  it('non-stream path — no feed/noteReasoning used, settle is a no-op; chat.js non-stream response path carries no dedup', () => {
+    const d = createStreamReasoningDedup();
+    assert.deepEqual(d.settle(), { emit: '', suppressed: false });
+    // The instance stays usable after settle.
+    assert.deepEqual(d.feed('x'), { emit: 'x', hold: false });
+
+    // The non-stream handler must not reference the dedup at all: it buffers
+    // the whole answer and flushes it once, so there is nothing to dedup.
+    const chatSource = readFileSync(new URL('../src/handlers/chat.js', import.meta.url), 'utf8');
+    const nonStreamStart = chatSource.indexOf('async function nonStreamResponse');
+    const streamStart = chatSource.indexOf('function streamResponse');
+    assert.ok(nonStreamStart !== -1, 'nonStreamResponse must exist');
+    assert.ok(streamStart !== -1 && streamStart > nonStreamStart, 'streamResponse must follow nonStreamResponse');
+    assert.ok(!chatSource.slice(nonStreamStart, streamStart).includes('reasoningDedup'),
+      'non-stream path must be untouched by the dedup');
+  });
+
+  it('empty-string chunk handling — feed("") returns { emit: "", hold: false } and does not disturb holding', () => {
+    const d = createStreamReasoningDedup();
+    d.noteReasoning('ab');
+    assert.deepEqual(d.feed(''), { emit: '', hold: false });
+    d.noteReasoning(''); // ignored
+    assert.deepEqual(d.feed('ab'), { emit: '', hold: true });
+    assert.deepEqual(d.settle(), { emit: '', suppressed: true });
+  });
+});

--- a/test/reasoning-dedup.test.js
+++ b/test/reasoning-dedup.test.js
@@ -8,8 +8,10 @@
 //   - the moment content diverges from the reasoning prefix, everything held
 //     so far plus the current chunk is emitted and the stream passes through
 //     with no further delay;
-//   - suppression fires ONLY at settle() when the content is STILL a
-//     byte-identical prefix of the reasoning — the true duplicate.
+//   - suppression fires ONLY at settle() when the accumulated content equals
+//     the FULL reasoning byte-for-byte — the true duplicate. A strict prefix
+//     (content shorter, stream ends there) is released, never suppressed;
+//   - release() is the failure path: it returns the held tail unconditionally.
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -119,5 +121,38 @@ describe('reasoning-dedup (incremental)', () => {
     d.noteReasoning(''); // ignored
     assert.deepEqual(d.feed('ab'), { emit: '', hold: true });
     assert.deepEqual(d.settle(), { emit: '', suppressed: true });
+  });
+
+  it('strict prefix — content ends where the reasoning continues: settle() RELEASES the held tail (never an empty answer)', () => {
+    // The one shape that used to produce an empty client reply: the answer
+    // restates the first sentence of the reasoning and the stream ends there.
+    const d = createStreamReasoningDedup();
+    d.noteReasoning('The answer is 42 because of X.');
+    assert.deepEqual(d.feed('The answer '), { emit: '', hold: true });
+    assert.deepEqual(d.feed('is 42'), { emit: '', hold: true });
+    // Content is a byte-identical STRICT prefix of the reasoning, stream ends.
+    assert.deepEqual(d.settle(), { emit: 'The answer is 42', suppressed: false });
+  });
+
+  it('release() — failure path returns the held tail unconditionally, even a full duplicate', () => {
+    const d = createStreamReasoningDedup();
+    d.noteReasoning('exact duplicate');
+    assert.deepEqual(d.feed('exact duplicate'), { emit: '', hold: true });
+    // settle() would suppress this; the failure path must not.
+    assert.equal(d.release(), 'exact duplicate');
+    // Cleared: a later settle() is a no-op.
+    assert.deepEqual(d.settle(), { emit: '', suppressed: false });
+    assert.equal(d.release(), '');
+  });
+
+  it('held cap — crossing HELD_CAP latches divergence and flushes instead of holding an unbounded buffer', () => {
+    const d = createStreamReasoningDedup();
+    const big = 'a'.repeat(1024 * 1024 + 1);
+    d.noteReasoning(big + 'tail');
+    // Candidate exceeds the 1 MiB cap while still a prefix of the reasoning.
+    assert.deepEqual(d.feed(big), { emit: big, hold: false });
+    // Divergence latched: even a matching chunk passes through now.
+    assert.deepEqual(d.feed('a'), { emit: 'a', hold: false });
+    assert.deepEqual(d.settle(), { emit: '', suppressed: false });
   });
 });

--- a/test/reasoning-dedup.test.js
+++ b/test/reasoning-dedup.test.js
@@ -9,7 +9,8 @@
 //     so far plus the current chunk is emitted and the stream passes through
 //     with no further delay;
 //   - suppression fires ONLY at settle() when the accumulated content equals
-//     the FULL reasoning byte-for-byte — the true duplicate. A strict prefix
+//     the FULL reasoning byte-for-byte AND the caller explicitly requested
+//     thinking (reasoning_content visible to them). A strict prefix
 //     (content shorter, stream ends there) is released, never suppressed;
 //   - release() is the failure path: it returns the held tail unconditionally.
 

--- a/test/reasoning-dedup.test.js
+++ b/test/reasoning-dedup.test.js
@@ -51,8 +51,17 @@ describe('reasoning-dedup (incremental)', () => {
     assert.deepEqual(d.settle(), { emit: '', suppressed: false });
   });
 
-  it('full identity — content chunks together == reasoning, all held, settle suppresses', () => {
+  it('full identity when wantThinking: false (default) — content chunks together == reasoning, all held, settle emits held', () => {
     const d = createStreamReasoningDedup();
+    d.noteReasoning('Let me think carefully');
+    assert.deepEqual(d.feed('Let me '), { emit: '', hold: true });
+    assert.deepEqual(d.feed('think'), { emit: '', hold: true });
+    assert.deepEqual(d.feed(' carefully'), { emit: '', hold: true });
+    assert.deepEqual(d.settle(), { emit: 'Let me think carefully', suppressed: false });
+  });
+
+  it('full identity when wantThinking: true — content chunks together == reasoning, all held, settle suppresses', () => {
+    const d = createStreamReasoningDedup({ wantThinking: true });
     d.noteReasoning('Let me think carefully');
     assert.deepEqual(d.feed('Let me '), { emit: '', hold: true });
     assert.deepEqual(d.feed('think'), { emit: '', hold: true });
@@ -79,7 +88,7 @@ describe('reasoning-dedup (incremental)', () => {
   });
 
   it('multi-chunk prefix — a long prefix split across many chunks stays held, then release works', () => {
-    const d = createStreamReasoningDedup();
+    const d = createStreamReasoningDedup({ wantThinking: true });
     const reasoning = 'The quick brown fox jumps over the lazy dog — a long reasoning string.';
     d.noteReasoning(reasoning);
     for (const ch of reasoning) {
@@ -115,7 +124,7 @@ describe('reasoning-dedup (incremental)', () => {
   });
 
   it('empty-string chunk handling — feed("") returns { emit: "", hold: false } and does not disturb holding', () => {
-    const d = createStreamReasoningDedup();
+    const d = createStreamReasoningDedup({ wantThinking: true });
     d.noteReasoning('ab');
     assert.deepEqual(d.feed(''), { emit: '', hold: false });
     d.noteReasoning(''); // ignored


### PR DESCRIPTION
## 中文 TL;DR

有时模型把 reasoning 原样再写一遍进 CONTENT 通道(逐字重复)。本 PR 在统一流式出口做增量比对:content 与本轮 reasoning 前缀逐字一致时允许毫秒级短缓冲,一旦出现分歧立即放行已缓冲部分 + 当前块,之后零延迟直通;**只有在 settle() 时 content 与 reasoning 完全等长且逐字相同才抑制**(严格相等,不是前缀)——strict prefix(答案恰是 reasoning 的开头一句、流在句末结束)一律放行,客户端永远拿不到空答案。错误/中止路径走 `release()`:被扣尾巴无条件放出,失败路径上不抑制任何东西。held 有 1 MiB 上限,越限锁死分歧并放行。默认开启。这是 #242 评审中被拆出的 T4,按评审人方案 2 重做,并按第二轮评审收紧到严格相等。

## Что это и откуда

Переделка T4 из #242 по варианту 2 из ревью dwgx. Старая версия придерживала ВЕСЬ content до settle — progressive streaming умирал у каждой thinking-модели, и это был безгейтовый behavior change на четыре протокола. Здесь удержания потока нет: буфер живёт только пока content побайтово совпадает с префиксом reasoning; при первом расхождении всё придержанное выпускается немедленно, дальше pass-through без задержки.

## Механизм

- `src/reasoning-dedup.js` — чистые функции над строками: `feed(chunk)` → `{emit, hold}`, `settle()` → `{emit, suppressed}`, `release()` → хвост без подавления (failure path).
- Тонкая интеграция в `streamResponse` (четыре протокола стрима + non-stream) в `src/handlers/chat.js`; `release()` вызывается в partial-failure ветке перед чистым stop.
- Подавление — только строгое равенство на settle: `held === seenReasoning` (полная длина + побайтово). Strict prefix (content короче reasoning, стрим кончился) — выпускается, не подавляется.

## Почему default ON безопасно

Подавиться может только ПОЛНАЯ побайтовая копия reasoning этого же тёрна. Обычный ответ выпускается при первом же расхождении. Форма «ответ повторяет начало reasoning и обрывается» (единственная, которая могла дать пустой ответ при prefix-сравнении) — выпускается на settle одним куском. На error/abort хвост выпускается через `release()` без подавления: дубль лучше молчаливой пропажи (клиенты, не рендерящие reasoning-канал, всё равно получают текст).

## Test plan

- [x] Unit-тесты времени выпуска в `test/reasoning-dedup.test.js` (12): расхождение на первом чанке; расхождение в середине; полная идентичность; идентичность с обрывом reasoning раньше content; пустой reasoning; много-чанковый префикс; non-stream; **strict prefix → release на settle**; **release() на failure path**; **held cap**.
- [x] Мутационная spec `test/mutations/reasoning-dedup-incremental.json` (6 мутаций: удержание всего потока, очистка held, потеря latch, ослабление strict equality до prefix, удвоение cap, опустошение release) + все spec репо: EXIT=0, каждый anchor бьёт ровно один раз.
- [x] Полный сьют: **3703 pass / 0 fail** (rebase на master `51846e0`).

## Note

К замечанию про кэш из ревью #242: дедуп работает на стриме, system prompt не трогает и с префиксным кэшем не конфликтует.
