### PR TITLE
feat(orcarouter): add OrcaRouter as a first-class OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -421,6 +421,14 @@ ASTRAFLOW_API_KEY=
 # China endpoint  (env: ASTRAFLOW_CN_API_KEY) — base URL: https://api.modelverse.cn/v1
 ASTRAFLOW_CN_API_KEY=
 
+# ========== OrcaRouter (OpenAI-compatible AI gateway — https://www.orcarouter.ai) ==========
+# Routes `orcarouter/*` models straight to https://api.orcarouter.ai/v1 with this
+# key. OrcaRouter aggregates Anthropic / OpenAI / Google / DeepSeek / more behind
+# one endpoint, with adaptive routing, automatic failover, zero-markup inference,
+# observability, guardrails and agent-tool governance. Get a key at
+# https://www.orcarouter.ai.
+ORCAROUTER_API_KEY=
+
 # ========== Advanced ==========
 CODEIUM_API_URL=https://server.self-serve.windsurf.com
 # 不传 model 时用哪个。默认(不设此项)是 claude-sonnet-4.6。

--- a/README.en.md
+++ b/README.en.md
@@ -339,6 +339,7 @@ In your client's settings for **Custom OpenAI Compatible**:
 | `WINDSURFAPI_NATIVE_TOOL_BRIDGE_MODELS` / `PROVIDERS` / `ROUTES` / `CALLERS` / `ACCOUNTS` / `API_KEYS` | empty | Optional native-bridge gray gates. Empty means unrestricted; when set, the request must match. `ACCOUNTS` accepts upstream account id/email. `API_KEYS` matches caller API keys without passing plaintext tokens into chat logic. |
 | `WINDSURFAPI_NATIVE_TOOL_BRIDGE_OFF` | empty | Set to `1` to force native bridge off. |
 | `WINDSURFAPI_SPECIAL_AGENT_BACKEND` | empty | Optional lab-only special-agent backend. Set `devin-cli` to test `swe-1.6`, `swe-1.6-fast`, `adaptive`, and `arena-*` through Devin CLI instead of direct Cascade. This is not a normal catalog-model fix. |
+| `ORCAROUTER_API_KEY` | empty | Enables the OrcaRouter third-party gateway provider. When set, `orcarouter/*` models (e.g. `orcarouter/fusion-mini`) are forwarded verbatim to `https://api.orcarouter.ai/v1` and do not consume Windsurf account-pool quota. See the "Supported Models" section. |
 | `DEVIN_CLI_PATH` | `devin` | Devin CLI executable path. Docker/macOS deployments must install or mount it themselves. |
 | `DEVIN_CLI_MODE` | `print` | `print` uses conservative `devin -p`; `acp` is an experimental ACP stdio backend using upstream Windsurf account-pool apiKeys. |
 | `DEVIN_MAX_PROCS` | `1` | Maximum concurrent Devin CLI processes. |
@@ -449,6 +450,18 @@ swe-1.5 / 1.5-fast / 1.6 / 1.6-fast / 1.7 / 1.7-lightning · arena-fast · arena
 > **Free-account entitlements** typically include `gemini-2.5-flash`, `glm-4.7` / `glm-5` / `5.1`, `kimi-k2` / `k2.5` / `k2-6`, `qwen-3` and similar open-source models; Claude family, GPT family, and Opus / thinking variants require Pro. Each account's exact list shows up in the dashboard.
 >
 > **Tool-calling reliability (measured v2.0.82+):** Claude family is the most reliable (their training covered prompt-level tool protocols); GLM-4.7 / Kimi-K2.5 work for most cases via NLU fallback + optional retry-with-correction; GLM-5.1 is unreliable on the cascade backend (it often returns empty responses, no narration to recover from); GPT family is also limited because the cascade upstream doesn't carry `tools[]` schema. For Claude Code / Cline / Codex doing local tool calls, prefer `claude-haiku-4.5` or `claude-sonnet-4.6`.
+
+<details>
+<summary><b>OrcaRouter (OpenAI-compatible AI gateway) — third-party provider</b></summary>
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway. Like OpenRouter, it exposes a provider/model namespace across many models on one endpoint — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind that same endpoint. Adding it as a first-class provider here means setting `ORCAROUTER_API_KEY` and calling any `orcarouter/*` model (e.g. `orcarouter/fusion-mini`, `orcarouter/fusion`); requests are forwarded verbatim to `https://api.orcarouter.ai/v1` and do not consume Windsurf account-pool quota. Gateway-level, zero-trust security for AI agents runs on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+- Config: set `ORCAROUTER_API_KEY=sk-orca-...` in `.env`.
+- Model prefix: `orcarouter/<upstream-model-id>` — any id forwards (`GET /v1/models` lists the curated `orcarouter/free` / `fusion` / `fusion-flash` / `fusion-mini` / `auto`).
+- Both streaming and non-streaming OpenAI-compatible responses are relayed.
+- Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
+
+</details>
 
 ### Language-Following for CJK Users
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ curl -X DELETE http://localhost:3003/v1/responses/resp_xxx -H "Authorization: Be
 | `WINDSURFAPI_NATIVE_TOOL_BRIDGE_MODELS` / `PROVIDERS` / `ROUTES` / `CALLERS` / `ACCOUNTS` / `API_KEYS` | 空 | native bridge 灰度门。为空表示不限；设置后必须匹配才启用。`ACCOUNTS` 可填账号 id/email，`API_KEYS` 匹配调用方 API key 但不会把明文 key 传进 chat 逻辑 |
 | `WINDSURFAPI_NATIVE_TOOL_BRIDGE_OFF` | 空 | 设为 `1` 强制关闭 native tool bridge，优先级高于上面的开关 |
 | `WINDSURFAPI_SPECIAL_AGENT_BACKEND` | 空 | 可选 lab-only special-agent 后端。设为 `devin-cli` 后，`swe-1.6` / `swe-1.6-fast` / `adaptive` / `arena-*` 不再走 direct Cascade，而是走 Devin CLI PoC；这不是普通 catalog 模型修复 |
+| `ORCAROUTER_API_KEY` | 空 | 启用 OrcaRouter 第三方网关 provider。设置后 `orcarouter/*` 模型（`orcarouter/fusion-mini` 等）直接转发到 `https://api.orcarouter.ai/v1`，不消耗 Windsurf 账号池；见"支持的模型"一节 |
 | `DEVIN_CLI_PATH` | `devin` | Devin CLI 可执行文件路径；Docker/macOS 都需要自己安装或挂载，不是基础镜像硬依赖 |
 | `DEVIN_CLI_MODE` | `print` | `print` 为 `devin -p` 保守模式；`acp` 为实验 ACP stdio 后端，使用账号池上游 Windsurf apiKey 认证，默认不全量启用 |
 | `DEVIN_MAX_PROCS` | `1` | Devin CLI 最大并发进程数，避免 special-agent 路径把内存打爆 |
@@ -528,6 +529,18 @@ swe-1.5 / 1.5-fast / 1.6 / 1.6-fast / 1.7 / 1.7-lightning · arena-fast · arena
 </details>
 
 > `swe-1.6` / `swe-1.6-fast` / `adaptive` / `arena-*` 属于 special-agent 路径。direct Cascade 会报 unknown model UID / route 不通；默认不会假装可用。需要测试时显式开启 `WINDSURFAPI_SPECIAL_AGENT_BACKEND=devin-cli`，并安装/挂载 Devin CLI。当前 PoC 是 `devin -p` print 模式，默认拒绝 caller-local tools/media；ACP 工具桥接另做。
+
+<details>
+<summary><b>OrcaRouter（OpenAI 兼容 AI 网关）— 第三方 provider</b></summary>
+
+[OrcaRouter](https://www.orcarouter.ai) 是一个 OpenAI 兼容的 AI 网关，像 OpenRouter 一样在一个端点上聚合 Anthropic / OpenAI / Google / DeepSeek 等多家模型，同时叠加自适应路由、自动故障转移、零加价推理、可观测性、护栏与 agent 工具治理。把它作为一等 provider 接进 WindsurfAPI：设置 `ORCAROUTER_API_KEY` 后，`orcarouter/*` 模型（如 `orcarouter/fusion-mini`、`orcarouter/fusion`）直接转发到 `https://api.orcarouter.ai/v1`，不消耗 Windsurf 账号池配额。网关级、零信任的 AI agent 安全（默认拒绝地筛查每一条 prompt/response、治理每一次工具调用）也在同一个端点生效，无需改应用代码。
+
+- 配置：`.env` 里填 `ORCAROUTER_API_KEY=sk-orca-...`。
+- 模型前缀：`orcarouter/<上游模型 id>`，任意 id 均可转发（`GET /v1/models` 会列出预置的 `orcarouter/free` / `fusion` / `fusion-flash` / `fusion-mini` / `auto`）。
+- 流式与非流式都透传 OpenAI 兼容响应。
+- Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
+
+</details>
 
 > **免费账号 entitled 模型**主要是 `gemini-2.5-flash`、`glm-4.7`、`glm-5` / `5.1`、`kimi-k2` / `k2.5` / `k2-6`、`qwen-3` 等开源系列；Claude / GPT 全系 + Opus 系列要 Pro。具体每个账号的 entitled 清单看 dashboard。
 >

--- a/src/config.js
+++ b/src/config.js
@@ -176,6 +176,11 @@ export const config = {
   astraflowApiKeyCn: process.env.ASTRAFLOW_CN_API_KEY || '',
   astraflowApiUrl: 'https://api-us-ca.umodelverse.ai/v1',
   astraflowApiUrlCn: 'https://api.modelverse.cn/v1',
+  // OrcaRouter — OpenAI-compatible AI gateway (https://www.orcarouter.ai).
+  // Routes orcarouter/* models straight to https://api.orcarouter.ai/v1.
+  // Set ORCAROUTER_API_KEY to enable them (see src/orcarouter.js).
+  orcarouterApiKey: process.env.ORCAROUTER_API_KEY || '',
+  orcarouterApiUrl: 'https://api.orcarouter.ai/v1',
   // Fallback model when a request omits `model`. MUST be a name that resolves to
   // a live DEVIN_CONNECT catalog selector (mapped:true) — the old
   // 'claude-4.5-sonnet-thinking' is a legacy word-order alias that resolveModel

--- a/src/handlers/cascade-metadata-egress.js
+++ b/src/handlers/cascade-metadata-egress.js
@@ -149,6 +149,7 @@ const PROVIDER_DISPLAY_NAMES = {
   minimax: 'MiniMax',
   moonshot: 'Moonshot',
   openai: 'OpenAI',
+  orcarouter: 'OrcaRouter',
   windsurf: 'Windsurf',
   xai: 'xAI',
   zhipu: 'Zhipu',

--- a/src/handlers/chat.js
+++ b/src/handlers/chat.js
@@ -32,6 +32,39 @@ function clineCompatArgs(raw, active) {
   if (fixed !== (raw || '{}')) recordArgRepair();
   return fixed;
 }
+
+// OrcaRouter forward: relay the upstream JSON/SSE response to the caller.
+// The upstream body is buffered whole by forwardChatCompletions, so the stream
+// path just writes it back verbatim (frames are already `data: …\n\n`-separated).
+// Error responses (4xx/5xx) are relayed with their OpenAI-shaped body so the
+// client sees the gateway's real `type`/`code` instead of a generic 502.
+function forwardOrcaRouterChat(body, { apiKey, signal = null } = {}) {
+  return forwardChatCompletions(body, { apiKey, signal })
+    .then(({ status, body: buf }) => {
+      const raw = buf.toString('utf8');
+      if (body.stream) {
+        return {
+          status,
+          stream: true,
+          headers: {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-store',
+            'Connection': 'keep-alive',
+            'X-Accel-Buffering': 'no',
+          },
+          async handler(res) {
+            if (!res.writableEnded) res.write(raw);
+            if (!res.writableEnded) res.end();
+          },
+        };
+      }
+      try {
+        return { status, body: JSON.parse(raw) };
+      } catch {
+        return { status, body: { error: { message: raw.slice(0, 300), type: 'upstream_error', code: 'orcarouter_non_json' } } };
+      }
+    });
+}
 import { checkMessageRateLimit } from '../windsurf-api.js';
 import { getEffectiveProxy } from '../dashboard/proxy-config.js';
 import {
@@ -54,6 +87,7 @@ import {
 } from '../special-agent.js';
 import { acpVisionEnabled } from '../devin-acp.js';
 import { selectBackend, usesCascadeFlow } from '../backend-router.js';
+import { isOrcaRouterModel, orcaRouterApiKey, forwardChatCompletions } from '../orcarouter.js';
 import { toChatCompletion as _toChatCompletion, streamChatCompletion as _streamChatCompletion } from '../devin-connect-openai.js';
 import { resolveConnectSelector } from '../devin-connect-models.js';
 import { isRetryable as isConnectRetryable, getToolDefTags, parseToolCallTagMap } from '../devin-connect.js';
@@ -4029,6 +4063,45 @@ async function _handleChatCompletionsInner(body, context = {}) {
       log.info(`Chat[${reqId}]: DEVIN_CONNECT failover hop ${hops + 1} → next pooled account`);
       bumpConnect('failover_hops');
       acct = next;
+    }
+  }
+
+  // OrcaRouter short-circuit: a model whose catalog entry carries
+  // provider/backend 'orcarouter' — or any raw `orcarouter/` prefixed id — is
+  // served by the operator's own ORCAROUTER_API_KEY, not the Windsurf account
+  // pool. Forward the request verbatim to https://api.orcarouter.ai/v1 and
+  // relay the OpenAI-compatible response (JSON or SSE) straight back. This
+  // lives AFTER access control so operator allow/blocklists still apply, but
+  // BEFORE the Windsurf backends so no account or LS is ever touched.
+  const isOrcaRouterRequest = isOrcaRouterModel(modelInfo)
+    || String(routingModelKey || '').toLowerCase().startsWith('orcarouter/');
+  if (isOrcaRouterRequest) {
+    const orcaKey = orcaRouterApiKey();
+    if (!orcaKey) {
+      return {
+        status: 503,
+        body: { error: {
+          message: 'OrcaRouter is not configured. Set ORCAROUTER_API_KEY to use orcarouter/* models.',
+          type: 'api_error',
+          code: 'orcarouter_not_configured',
+        } },
+      };
+    }
+    log.info(`Chat[${reqId}]: routing ${safeLogValue(routingModelKey)} through OrcaRouter gateway`);
+    try {
+      return await forwardOrcaRouterChat(body, { apiKey: orcaKey, signal: context.signal });
+    } catch (err) {
+      // Transport-level failures (network, timeout, abort). Relay as a clean
+      // 502 so the caller can retry, instead of surfacing as a bare 500.
+      log.warn(`Chat[${reqId}]: OrcaRouter upstream error: ${err?.message || err}`);
+      return {
+        status: 502,
+        body: { error: {
+          message: `OrcaRouter upstream error: ${err?.message || 'unknown error'}`,
+          type: 'upstream_error',
+          code: 'orcarouter_upstream_error',
+        } },
+      };
     }
   }
 

--- a/src/models.js
+++ b/src/models.js
@@ -219,6 +219,23 @@ export const MODELS = {
   'astraflow/llama-3.3-70b':        { name: 'astraflow/llama-3.3-70b',        provider: 'astraflow', enumValue: 0, modelUid: 'llama-3.3-70b-instruct',    credit: 0.5 , deprecated: true },
   'astraflow/gemini-2.0-flash':     { name: 'astraflow/gemini-2.0-flash',     provider: 'astraflow', enumValue: 0, modelUid: 'gemini-2.0-flash',          credit: 0.5 , deprecated: true },
 
+  // ── OrcaRouter (AI gateway) ────────────────────────────────
+  // OrcaRouter is an OpenAI-compatible AI gateway (https://www.orcarouter.ai)
+  // that aggregates models from Anthropic, OpenAI, Google, DeepSeek and more
+  // behind one endpoint, adding adaptive routing, automatic failover and
+  // zero-markup inference. These entries use provider:'orcarouter' and set
+  // enumValue:0 so chat.js short-circuits the Windsurf backends and forwards
+  // the request verbatim to https://api.orcarouter.ai/v1 (src/orcarouter.js)
+  // with the operator's ORCAROUTER_API_KEY. A handful of curated ids are
+  // catalogued below; any id from GET /v1/models is also accepted as a raw
+  // orcarouter/ prefixed model name, so the gateway's full catalog stays
+  // reachable without a static entry here.
+  'orcarouter/free':                { name: 'orcarouter/free',                provider: 'orcarouter', enumValue: 0, modelUid: 'orcarouter/free',                credit: 0 , backend: 'orcarouter' },
+  'orcarouter/fusion':              { name: 'orcarouter/fusion',              provider: 'orcarouter', enumValue: 0, modelUid: 'orcarouter/fusion',              credit: 1 , backend: 'orcarouter' },
+  'orcarouter/fusion-flash':        { name: 'orcarouter/fusion-flash',        provider: 'orcarouter', enumValue: 0, modelUid: 'orcarouter/fusion-flash',        credit: 1 , backend: 'orcarouter' },
+  'orcarouter/fusion-mini':         { name: 'orcarouter/fusion-mini',         provider: 'orcarouter', enumValue: 0, modelUid: 'orcarouter/fusion-mini',         credit: 0.5, backend: 'orcarouter' },
+  'orcarouter/auto':                { name: 'orcarouter/auto',                provider: 'orcarouter', enumValue: 0, modelUid: 'orcarouter/auto',                credit: 1 , backend: 'orcarouter' },
+
   // ── Gemini ──────────────────────────────────────────────
   'gemini-2.5-pro':                 { name: 'gemini-2.5-pro',                 provider: 'google', enumValue: 246, modelUid: 'MODEL_GOOGLE_GEMINI_2_5_PRO', credit: 1 },
   'gemini-2.5-flash':               { name: 'gemini-2.5-flash',               provider: 'google', enumValue: 312, modelUid: 'MODEL_GOOGLE_GEMINI_2_5_FLASH', credit: 0.5 },
@@ -835,6 +852,10 @@ function isModelAllowedByCatalogUids(key, catalogUids) {
   const model = MODELS[key];
   if (!model) return false;
   if (model.backend === 'special_agent') return true;
+  // Third-party gateway models (orcarouter/*) are served by the operator's own
+  // upstream key, never by the Windsurf account pool — so the Windsurf cloud
+  // catalog must not filter them out of /v1/models.
+  if (model.backend === 'orcarouter') return true;
   const uid = normalizeCloudCatalogUid(model.modelUid);
   return uid !== '' && catalogUids.has(uid);
 }

--- a/src/orcarouter.js
+++ b/src/orcarouter.js
@@ -1,0 +1,94 @@
+/**
+ * OrcaRouter — OpenAI-compatible AI gateway provider (https://www.orcarouter.ai).
+ *
+ * Unlike the Windsurf/Devin backends (Cascade, Devin CLI, Devin Connect), an
+ * OrcaRouter request is not translated into the Windsurf gRPC protocol. It is
+ * forwarded verbatim to https://api.orcarouter.ai/v1 with the operator's own
+ * ORCAROUTER_API_KEY, and the OpenAI-compatible response (JSON or SSE) is
+ * streamed straight back to the caller.
+ *
+ * Routing decision lives in chat.js: a resolved model whose catalog entry has
+ * provider:'orcarouter' short-circuits the Windsurf backends entirely. See
+ * src/models.js for the registered `orcarouter/*` model ids.
+ */
+
+import https from 'https';
+
+const ORCAROUTER_BASE_URL = 'https://api.orcarouter.ai/v1';
+const ORCAROUTER_CHAT_PATH = '/chat/completions';
+
+// Transport seam: defaults to https.request. Swappable in tests so the request
+// path can be exercised without a real socket. Mirrors the __setCatalogRequestImpl
+// seam in devin-connect-catalog.js.
+let requestImpl = https.request;
+export function __setOrcaRouterRequestImpl(fn) { requestImpl = fn || https.request; }
+
+/** Whether the resolved model info routes through the OrcaRouter gateway. */
+export function isOrcaRouterModel(modelInfo) {
+  return modelInfo?.provider === 'orcarouter';
+}
+
+/** Operator-configured OrcaRouter API key (ORCAROUTER_API_KEY). Empty if unset. */
+export function orcaRouterApiKey(env = process.env) {
+  return String(env.ORCAROUTER_API_KEY || '').trim();
+}
+
+/**
+ * Forward one /v1/chat/completions request to OrcaRouter.
+ *
+ * Resolves with the upstream HTTP status and raw response body for BOTH success
+ * and error responses, so the caller can relay OpenAI-shaped error bodies
+ * verbatim. Streamed SSE comes back as an opaque Buffer — the caller decides how
+ * to relay it. Rejects only on transport errors (network, timeout, abort).
+ *
+ * @param {object} body       parsed JSON request body (model, messages, …)
+ * @param {object} [opts]
+ * @param {string} [opts.apiKey]  ORCAROUTER_API_KEY value
+ * @param {AbortSignal} [opts.signal]
+ * @returns {Promise<{status:number, body:Buffer}>}
+ */
+export function forwardChatCompletions(body, { apiKey = null, signal = null } = {}) {
+  const key = apiKey || orcaRouterApiKey();
+  if (!key) {
+    return Promise.reject(new Error('ORCAROUTER_API_KEY is not set. Configure it to use orcarouter/* models.'));
+  }
+
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const url = new URL(ORCAROUTER_BASE_URL + ORCAROUTER_CHAT_PATH);
+    const reqOpts = {
+      method: 'POST',
+      hostname: url.hostname,
+      path: url.pathname + url.search,
+      headers: {
+        'Authorization': `Bearer ${key}`,
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        'Accept': body.stream ? 'text/event-stream' : 'application/json',
+        'User-Agent': 'windsurf-api',
+      },
+    };
+
+    const req = requestImpl(reqOpts, (res) => {
+      const chunks = [];
+      res.on('data', (d) => chunks.push(d));
+      res.on('end', () => {
+        const buf = Buffer.concat(chunks);
+        // Resolve with the upstream status and body for BOTH success and error
+        // responses so the caller can relay 4xx/5xx bodies verbatim (OpenAI
+        // error shapes carry useful `type`/`code` fields).
+        resolve({ status: res.statusCode, body: buf });
+      });
+      res.on('error', reject);
+    });
+
+    req.on('error', reject);
+    req.setTimeout(240_000, () => req.destroy(new Error('OrcaRouter upstream timeout')));
+    if (signal) {
+      if (signal.aborted) req.destroy(new Error('aborted'));
+      signal.addEventListener('abort', () => req.destroy(new Error('aborted')), { once: true });
+    }
+    req.write(payload);
+    req.end();
+  });
+}

--- a/test/cloud-catalog-filter.test.js
+++ b/test/cloud-catalog-filter.test.js
@@ -65,14 +65,21 @@ function syncAllowed(keys = [ALLOWED_KEY], accountId = ACCOUNT_A) {
 }
 
 function cascadeKeys(keys) {
-  return keys.filter((key) => MODELS[key]?.backend !== 'special_agent');
+  // Exclude backends the Cascade cloud catalog does not govern: special-agent
+  // models and third-party gateway models (orcarouter/*) are served by their
+  // own upstreams, so the account-pool catalog neither controls nor should
+  // hide them.
+  return keys.filter((key) => {
+    const backend = MODELS[key]?.backend;
+    return backend !== 'special_agent' && backend !== 'orcarouter';
+  });
 }
 
 function fullStaticCloudConfigs() {
   const seen = new Set();
   const configs = [];
   for (const model of Object.values(MODELS)) {
-    if (model?.deprecated || model?.backend === 'special_agent' || typeof model?.modelUid !== 'string') continue;
+    if (model?.deprecated || model?.backend === 'special_agent' || model?.backend === 'orcarouter' || typeof model?.modelUid !== 'string') continue;
     const normalized = model.modelUid.trim().toLowerCase();
     if (!normalized || seen.has(normalized)) continue;
     seen.add(normalized);
@@ -256,7 +263,11 @@ describe('upstream account cloud catalog filtering', () => {
 
     const models = handleModels({}).data;
     assert.deepEqual(cascadeKeys(models.map((model) => model._windsurf_id)), [key]);
-    assert.equal(models[0].owned_by, 'anthropic');
+    // The discovered model is the only Cascade-catalog entry; index into the
+    // filtered view rather than the raw list (which may lead with third-party
+    // gateway models like orcarouter/* that precede it in MODELS order).
+    const catalogModel = models.find((m) => m._windsurf_id === key);
+    assert.equal(catalogModel.owned_by, 'anthropic');
   });
 
   it('unions model listings while enforcing each account catalog during routing', () => {

--- a/test/orcarouter.test.js
+++ b/test/orcarouter.test.js
@@ -1,0 +1,206 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'events';
+import {
+  isOrcaRouterModel,
+  orcaRouterApiKey,
+  forwardChatCompletions,
+  __setOrcaRouterRequestImpl,
+} from '../src/orcarouter.js';
+import { handleChatCompletions } from '../src/handlers/chat.js';
+import { addAccountByKey, removeAccount } from '../src/auth.js';
+
+// ── fake https.request transport ──────────────────────────────
+// Returns a request-like EventEmitter; invokes the response callback with a
+// fake res (also an EventEmitter). The last-written body is captured for
+// assertions.
+let capturedOptions = null;
+let capturedPayload = null;
+let respond = null; // ({ status, body }) triggers the response path
+let failRequest = null; // (err) emits a request-level transport error
+
+function fakeRequest(opts, onRes) {
+  capturedOptions = opts;
+  const req = new EventEmitter();
+  req.setTimeout = () => req;
+  req.write = (d) => { capturedPayload = String(d); };
+  req.end = () => {};
+  req.destroy = (err) => { if (err) req.emit('error', err); };
+  failRequest = (err) => req.emit('error', err);
+  // Store how to fire the response so each test can drive it.
+  respond = ({ status, body }) => {
+    const res = new EventEmitter();
+    res.statusCode = status;
+    process.nextTick(() => {
+      onRes(res);
+      const buf = Buffer.isBuffer(body) ? body : Buffer.from(body);
+      if (buf.length) res.emit('data', buf);
+      res.emit('end');
+    });
+  };
+  return req;
+}
+
+const createdAccountIds = [];
+
+afterEach(() => {
+  __setOrcaRouterRequestImpl(null);
+  capturedOptions = null;
+  capturedPayload = null;
+  respond = null;
+  failRequest = null;
+  while (createdAccountIds.length) removeAccount(createdAccountIds.pop());
+  delete process.env.ORCAROUTER_API_KEY;
+});
+
+describe('orcarouter module', () => {
+  it('isOrcaRouterModel only matches provider orcarouter', () => {
+    assert.equal(isOrcaRouterModel({ provider: 'orcarouter' }), true);
+    assert.equal(isOrcaRouterModel({ provider: 'openai' }), false);
+    assert.equal(isOrcaRouterModel(null), false);
+    assert.equal(isOrcaRouterModel(undefined), false);
+  });
+
+  it('orcaRouterApiKey reads ORCAROUTER_API_KEY and trims', () => {
+    assert.equal(orcaRouterApiKey({ ORCAROUTER_API_KEY: '  sk-orca-abc  ' }), 'sk-orca-abc');
+    assert.equal(orcaRouterApiKey({}), '');
+    assert.equal(orcaRouterApiKey({ ORCAROUTER_API_KEY: '' }), '');
+  });
+
+  it('forwardChatCompletions rejects when no API key configured', async () => {
+    await assert.rejects(
+      forwardChatCompletions({ model: 'orcarouter/fusion', messages: [] }),
+      /ORCAROUTER_API_KEY is not set/
+    );
+  });
+
+  it('builds the request to api.orcarouter.ai with Bearer auth and JSON body', async () => {
+    __setOrcaRouterRequestImpl(fakeRequest);
+    const p = forwardChatCompletions(
+      { model: 'orcarouter/fusion', messages: [{ role: 'user', content: 'hi' }] },
+      { apiKey: 'sk-orca-test' },
+    );
+    await new Promise((r) => setImmediate(r));
+    assert.equal(capturedOptions.method, 'POST');
+    assert.equal(capturedOptions.hostname, 'api.orcarouter.ai');
+    assert.equal(capturedOptions.path, '/v1/chat/completions');
+    assert.equal(capturedOptions.headers['Authorization'], 'Bearer sk-orca-test');
+    assert.equal(capturedOptions.headers['Content-Type'], 'application/json');
+    const parsed = JSON.parse(capturedPayload);
+    assert.equal(parsed.model, 'orcarouter/fusion');
+  });
+
+  it('resolves with upstream status and body (including error responses)', async () => {
+    __setOrcaRouterRequestImpl(fakeRequest);
+    const p = forwardChatCompletions({ model: 'orcarouter/fusion', messages: [] }, { apiKey: 'sk-orca-test' });
+    await new Promise((r) => setImmediate(r));
+    respond({ status: 200, body: JSON.stringify({ id: 'x', choices: [] }) });
+    const { status, body } = await p;
+    assert.equal(status, 200);
+    assert.equal(JSON.parse(body.toString('utf8')).id, 'x');
+
+    // error path — relayed, not rejected
+    __setOrcaRouterRequestImpl(fakeRequest);
+    const p2 = forwardChatCompletions({ model: 'orcarouter/fusion', messages: [] }, { apiKey: 'sk-orca-test' });
+    await new Promise((r) => setImmediate(r));
+    respond({ status: 401, body: JSON.stringify({ error: { type: 'invalid_request_error', message: 'bad key' } }) });
+    const r2 = await p2;
+    assert.equal(r2.status, 401);
+    assert.equal(JSON.parse(r2.body.toString('utf8')).error.message, 'bad key');
+  });
+
+  it('resolves with an SSE body when stream=true', async () => {
+    __setOrcaRouterRequestImpl(fakeRequest);
+    const p = forwardChatCompletions({ model: 'orcarouter/fusion', stream: true, messages: [] }, { apiKey: 'sk-orca-test' });
+    await new Promise((r) => setImmediate(r));
+    const sseBody = 'data: {"choices":[{"delta":{"content":"a"}}]}\n\ndata: [DONE]\n\n';
+    respond({ status: 200, body: sseBody });
+    const { status, body } = await p;
+    assert.equal(status, 200);
+    assert.equal(body.toString('utf8'), sseBody);
+  });
+});
+
+describe('chat handler orcarouter routing', () => {
+  it('rejects orcarouter/* requests with a clear 503 when no API key is set', async () => {
+    const account = addAccountByKey(`orca-${Date.now()}-nokey`, 'orca');
+    createdAccountIds.push(account.id);
+
+    const result = await handleChatCompletions({
+      model: 'orcarouter/fusion',
+      messages: [{ role: 'user', content: 'hi' }],
+      __callerKey: 'api:test:orcanokey',
+    });
+    assert.equal(result.status, 503);
+    assert.equal(result.body.error.code, 'orcarouter_not_configured');
+    assert.match(result.body.error.message, /ORCAROUTER_API_KEY/);
+  });
+
+  it('forwards non-stream orcarouter/* requests to the gateway and relays the JSON body', async () => {
+    __setOrcaRouterRequestImpl(fakeRequest);
+    process.env.ORCAROUTER_API_KEY = 'sk-orca-live-test';
+    const account = addAccountByKey(`orca-${Date.now()}-ok`, 'orca');
+    createdAccountIds.push(account.id);
+
+    const p = handleChatCompletions({
+      model: 'orcarouter/fusion',
+      messages: [{ role: 'user', content: 'Say hi' }],
+      __callerKey: 'api:test:orcaok',
+    });
+    await new Promise((r) => setImmediate(r));
+    // chat.js's forwardOrcaRouterChat awaits forwardChatCompletions; drive the
+    // fake response after the request is built.
+    respond({
+      status: 200,
+      body: JSON.stringify({
+        id: 'chatcmpl-orca',
+        model: 'orcarouter/fusion',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'Hi!' }, finish_reason: 'stop' }],
+      }),
+    });
+    const result = await p;
+    assert.equal(result.status, 200);
+    assert.equal(result.body.choices[0].message.content, 'Hi!');
+    // The forwarded body carries the original model name.
+    const sent = JSON.parse(capturedPayload);
+    assert.equal(sent.model, 'orcarouter/fusion');
+  });
+
+  it('forwards raw orcarouter/<dynamic-id> models even without a static catalog entry', async () => {
+    __setOrcaRouterRequestImpl(fakeRequest);
+    process.env.ORCAROUTER_API_KEY = 'sk-orca-live-test';
+    const account = addAccountByKey(`orca-${Date.now()}-dyn`, 'orca');
+    createdAccountIds.push(account.id);
+
+    const p = handleChatCompletions({
+      model: 'orcarouter/deepseek/deepseek-chat',
+      messages: [{ role: 'user', content: 'hi' }],
+      __callerKey: 'api:test:orcadyan',
+    });
+    await new Promise((r) => setImmediate(r));
+    respond({ status: 200, body: JSON.stringify({ id: 'x', model: 'orcarouter/deepseek/deepseek-chat', choices: [{ index: 0, message: { role: 'assistant', content: 'yo' }, finish_reason: 'stop' }] }) });
+    const result = await p;
+    assert.equal(result.status, 200);
+    assert.equal(result.body.choices[0].message.content, 'yo');
+  });
+
+  it('maps transport failures to a clean 502 upstream_error', async () => {
+    __setOrcaRouterRequestImpl(fakeRequest);
+    process.env.ORCAROUTER_API_KEY = 'sk-orca-live-test';
+    const account = addAccountByKey(`orca-${Date.now()}-err`, 'orca');
+    createdAccountIds.push(account.id);
+
+    const p = handleChatCompletions({
+      model: 'orcarouter/fusion',
+      messages: [{ role: 'user', content: 'hi' }],
+      __callerKey: 'api:test:orcaerr',
+    });
+    await new Promise((r) => setImmediate(r));
+    failRequest(new Error('ECONNRESET'));
+    const result = await p;
+    assert.equal(result.status, 502);
+    assert.equal(result.body.error.type, 'upstream_error');
+    assert.equal(result.body.error.code, 'orcarouter_upstream_error');
+    assert.match(result.body.error.message, /ECONNRESET/);
+  });
+});


### PR DESCRIPTION
## What & why

WindsurfAPI turns Windsurf/Devin's models into OpenAI/Anthropic/Gemini-compatible API endpoints, and it already accepts third-party OpenAI-compatible providers (Astraflow landed via #184 as a catalog + config entry). This PR adds **[OrcaRouter](https://www.orcarouter.ai)** the same way — but with a working forwarder, not just catalog entries.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`src/orcarouter.js`** (new): zero-dependency forwarder. Posts `/v1/chat/completions` verbatim to `https://api.orcarouter.ai/v1` with `ORCAROUTER_API_KEY` and relays the OpenAI-compatible JSON or SSE response back. Mirrors the `__setCatalogRequestImpl` transport seam from `devin-connect-catalog.js`.
- **`src/handlers/chat.js`**: short-circuits `orcarouter/*` models after access control and before the Windsurf backends (no account-pool or LS contact); transport failures map to a clean `502 upstream_error`.
- **`src/models.js`**: registers `orcarouter/free`, `fusion`, `fusion-flash`, `fusion-mini`, `auto` with `provider/backend: 'orcarouter'`; the cloud-catalog filter never hides them (they consume the operator's gateway key, not Windsurf quota). Any raw `orcarouter/<id>` forwards too, so the gateway's full `GET /v1/models` catalog is reachable without a static entry.
- **`src/config.js` / `.env.example`**: `ORCAROUTER_API_KEY` + base URL; **`src/handlers/cascade-metadata-egress.js`**: OrcaRouter display name.
- **Docs**: README.md / README.en.md third-party provider section under "Supported Models" plus an env-var row.

## Testing

- `test/orcarouter.test.js` (new): 10 tests — transport mock covers request construction (auth header, path, body), success/error/SSE relay, the 503 when no key is set, dynamic `orcarouter/<id>` routing, and 502 on transport failure. All green.
- `test/cloud-catalog-filter.test.js`: gates `orcarouter` out of the Cascade-catalog view like `special_agent` models.
- Full `npm test`: 4314 tests, 4299 pass, 15 pre-existing env-sensitive failures (mutate-verify-harness 12, restart 2, update-script-release-target 1) that fail identically on `master` without this change.
- **L3 live test** against the real gateway using the operator key: non-streaming `orcarouter/fusion-mini` → 200 with a real completion; streaming → 200 with SSE frames relayed and `[DONE]`; confirmed through the full `handleChatCompletions` path.

## Checklist

- [x] Code style matches existing files (2-space, single quotes, semicolons, ESM)
- [x] Zero npm dependencies
- [x] No protocol/field-number changes (no LS proto touched)
- [x] No AI attribution trailer in the commit message

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
